### PR TITLE
Add ignore command to migrate cli

### DIFF
--- a/knex.js
+++ b/knex.js
@@ -99,7 +99,7 @@ var Knex = function(config) {
   // Attach each of the `Migrate` "interface" methods directly onto to `knex.migrate` namespace, e.g.:
   // knex.migrate.latest().then(...
   // knex.migrate.currentVersion(...
-  _.each(['make', 'latest', 'rollback', 'currentVersion'], function(method) {
+  _.each(['make', 'latest', 'rollback', 'currentVersion', 'ignore'], function(method) {
     knex.migrate[method] = function() {
       var Migrate   = require('./lib/migrate');
       var migration = new Migrate(knex);

--- a/lib/cli/migrate.js
+++ b/lib/cli/migrate.js
@@ -74,6 +74,21 @@ module.exports = function(commands) {
     .then(success);
   };
 
+  commands['migrate:currentVersion'].help = 'displays migrations current version';
+
+  commands['migrate:ignore'] = function(argv) {
+    checkConfig(argv).then(function(config) {
+      return knex.migrate.ignore(config);
+    })
+    .then(function(version) {
+      console.log('Current Version: '.green + version.blue);
+    })
+    .catch(failure)
+    .then(success);
+  };
+
+  commands['migrate:ignore'].help = 'flag migrations as done';
+
 };
 
 var checkConfig = function(argv) {

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -90,13 +90,24 @@ Migrate.prototype = {
       .bind();
   },
 
+  // Migrates to the latest configuration.
+  ignore: function(config) {
+    return this.init(config)
+      .then(this.migrationData)
+      .tap(validateMigrationList)
+      .spread(function(all, completed) {
+        return this.runBatch(_.difference(all, completed), 'ignore');
+      })
+      .bind();
+  },
+
   // Run a batch of current migrations, in sequence.
   runBatch: function(migrations, direction) {
     return Promise.map(migrations, validateMigrationStructure(this))
     .bind(this)
     .then(function(migrations) {
       return this.latestBatchNumber().then(function(batchNo) {
-        if (direction === 'up') batchNo++;
+        if (['up', 'ignore'].indexOf(direction) >= 0) batchNo++;
         return batchNo;
       }).then(this.waterfallBatch(migrations, direction));
     });
@@ -208,16 +219,18 @@ Migrate.prototype = {
     var current   = Promise.fulfilled().bind({failed: false, failedOn: 0});
     var log       = [];
     return function(batchNo) {
-      _.each(migrations, function(migration, i) {
+      _.each(migrations, function(migration) {
         var name  = migration[0];
         migration = migration[1];
 
         // We're going to run each of the migrations in the current "up"
         current = current.then(function() {
-          return migration[direction](knex, Promise);
+          return 'ignore' === direction ?
+                 Promise.resolve() :
+                 migration[direction](knex, Promise);
         }).then(function() {
           log.push(name);
-          if (direction === 'up') {
+          if (['up', 'ignore'].indexOf(direction) >= 0) {
             return knex(tableName).insert({
               name: name,
               batch: batchNo,


### PR DESCRIPTION
Just a naive implementation of what we need. We have a tool which synchronizes schema files (and initialization data) in database. Thus, when we synchronize, we need to tell that all migration scripts detected are irrelevants.