### PR TITLE
Added option to enable or disable quoting (quote)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -12,6 +12,9 @@ var EventEmitter = require('events').EventEmitter;
 // object attaches fresh constructors for each component
 // of the library.
 function Client(config) {
+  if (config && config.quote !== false) {
+    config.quote = true;
+  }
   this.initFormatter();
   this.initRaw();
   this.initTransaction();

--- a/lib/dialects/mysql/formatter.js
+++ b/lib/dialects/mysql/formatter.js
@@ -22,23 +22,49 @@ Formatter_MySQL.prototype.operators = [
   'rlike', 'regexp', 'not regexp'
 ];
 
+// based on http://docs.oracle.com/cd/B10501_01/win.920/a97249/ch3.htm
+Formatter_MySQL.prototype.reservedWords = [
+  'abort', 'accept', 'access', 'add', 'all', 'alter', 'and', 'any', 'array',
+  'arraylen', 'as', 'asc', 'assert', 'assign', 'at', 'audit', 'authorization',
+  'avg', 'base_table', 'begin', 'between', 'binary_integer', 'body', 'boolean',
+  'by', 'case', 'char', 'char_base', 'check', 'close', 'cluster', 'clusters',
+  'colauth', 'column', 'comment', 'commit', 'compress', 'connect', 'constant',
+  'crash', 'create', 'current', 'currval', 'cursor', 'data_base', 'database',
+  'date', 'dba', 'debugoff', 'debugon', 'decimal', 'declare', 'default',
+  'definition', 'delay', 'delete', 'desc', 'digits', 'dispose', 'distinct',
+  'do', 'drop', 'else', 'elsif', 'end', 'entry', 'exception', 'exception_init',
+  'exclusive', 'exists', 'exit', 'false', 'fetch', 'file', 'float', 'for',
+  'form', 'from', 'function', 'generic', 'goto', 'grant', 'group', 'having',
+  'identified', 'if', 'immediate', 'in', 'increment', 'index', 'indexes',
+  'indicator', 'initial', 'insert', 'integer', 'interface', 'intersect', 'into',
+  'is', 'level', 'like', 'limited', 'lock', 'long', 'loop', 'max', 'maxextents',
+  'min', 'minus', 'mlslabel', 'mod', 'mode', 'modify', 'natural', 'naturaln',
+  'network', 'new', 'nextval', 'noaudit', 'nocompress', 'not', 'nowait', 'null',
+  'number', 'number_base', 'of', 'offline', 'on', 'online', 'open', 'option',
+  'or', 'order', 'others', 'out', 'package', 'partition', 'pctfree',
+  'pls_integer', 'positive', 'positiven', 'pragma', 'prior', 'private',
+  'privileges', 'procedure', 'public', 'raise', 'range', 'raw', 'real',
+  'record', 'ref', 'release', 'remr', 'rename', 'resource', 'return', 'reverse',
+  'revoke', 'rollback', 'row', 'rowid', 'rowlabel', 'rownum', 'rows', 'rowtype',
+  'run', 'savepoint', 'schema', 'select', 'seperate', 'session', 'set', 'share',
+  'signtype', 'size', 'smallint', 'space', 'sql', 'sqlcode', 'sqlerrm', 'start',
+  'statement', 'stddev', 'subtype', 'successful', 'sum', 'synonym', 'sysdate',
+  'tabauth', 'table', 'tables', 'task', 'terminate', 'then', 'to', 'trigger',
+  'true', 'type', 'uid', 'union', 'unique', 'update', 'use', 'user', 'validate',
+  'values', 'varchar', 'varchar2', 'variance', 'view', 'views', 'when',
+  'whenever', 'where', 'while', 'with', 'work', 'write', 'xor'
+];
+
 // Wraps a value (column, tableName) with the correct ticks.
 Formatter_MySQL.prototype.wrapValue = function(value) {
-  return (value !== '*' ? '`' + value + '`' : '*');
+  return (value === '*' || (
+    !this.isQuoting() &&
+    /^([a-z_])+([a-z0-9_]*)$/.test(value) &&
+    this.reservedWords.indexOf(value) === -1
+  )) ? value : '`' + value + '`';
 };
 
-// Memoize the calls to "wrap" for a little extra perf.
-var wrapperMemo = (function(){
-  var memo = Object.create(null);
-  return function(key) {
-    if (memo[key] === void 0) {
-      memo[key] = this._wrapString(key);
-    }
-    return memo[key];
-  };
-}());
-
-Formatter_MySQL.prototype._wrap = wrapperMemo;
+Formatter_MySQL.prototype._wrap = Formatter.prototype._wrapString;
 
 // Assign the formatter to the the client.
 client.Formatter = Formatter_MySQL;

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -16,6 +16,7 @@ var mysql;
 function Client_MySQL(config) {
   Client.apply(this, arguments);
   if (config.debug) this.isDebugging = true;
+  this.forceQuoting = !!config.quote;
   if (config.connection) {
     this.initDriver();
     this.initRunner();

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -26,8 +26,8 @@ inherits(QueryBuilder_MySQL, QueryBuilder);
 // Set the "Formatter" to use for the queries,
 // ensuring that all parameterized values (even across sub-queries)
 // are properly built into the same query.
-function QueryCompiler_MySQL() {
-  this.formatter = new client.Formatter();
+function QueryCompiler_MySQL(builder) {
+  this.formatter = new client.Formatter(builder);
   QueryCompiler.apply(this, arguments);
 }
 inherits(QueryCompiler_MySQL, QueryCompiler);

--- a/lib/dialects/oracle/formatter.js
+++ b/lib/dialects/oracle/formatter.js
@@ -16,17 +16,40 @@ function Formatter_Oracle() {
 inherits(Formatter_Oracle, Formatter);
 
 Formatter_Oracle.prototype.operators = [
-  '=', '<', '>', '<=', '>=', '<>', '!=',
-  'like', 'not like', 'between', 'ilike',
-  '&', '|', '^', '<<', '>>',
-  'rlike', 'regexp', 'not regexp'
+  '=', '!=', '^=', '<>', 'ÿ=',
+  '>', '>=', '<', '<=',
+  'like', 'not like', 'between', 'not between',
+  '&', '|', '^', '<<', '>>'
+];
+
+// based on http://docs.oracle.com/cd/B28359_01/appdev.111/b31231/appb.htm#CJHIIICD
+Formatter_Oracle.prototype.reservedWords = [
+  'access', 'add', 'all', 'alter', 'and', 'any', 'arraylen', 'as', 'asc',
+  'audit', 'between', 'by', 'char', 'check', 'cluster', 'column', 'comment',
+  'compress', 'connect', 'create', 'current', 'date', 'decimal', 'default',
+  'delete', 'desc', 'distinct', 'drop', 'else', 'exclusive', 'exists', 'file',
+  'float', 'for', 'from', 'grant', 'group', 'having', 'identified', 'immediate',
+  'in', 'increment', 'index', 'initial', 'insert', 'integer', 'intersect',
+  'into', 'is', 'level', 'like', 'lock', 'long', 'maxextents', 'minus', 'mode',
+  'modify', 'noaudit', 'nocompress', 'not', 'notfound', 'nowait', 'null',
+  'number', 'of', 'offline', 'on', 'online', 'option', 'or', 'order', 'pctfree',
+  'prior', 'privileges', 'public', 'raw', 'rename', 'resource', 'revoke', 'row',
+  'rowid', 'rowlabel', 'rownum', 'rows', 'select', 'session', 'set', 'share',
+  'size', 'smallint', 'sqlbuf', 'start', 'successful', 'synonym', 'sysdate',
+  'table', 'then', 'to', 'trigger', 'uid', 'union', 'unique', 'update', 'user',
+  'validate', 'values', 'varchar', 'varchar2', 'view', 'whenever', 'where',
+  'with'
 ];
 
 // Wraps a value (column, tableName) with the correct ticks.
 Formatter_Oracle.prototype.wrapValue = function(value) {
-  return (value !== '*' ? '"' + value + '"' : '*');
+  // only wrap values that are not lower case
+  return (value === '*' || (
+      !this.isQuoting() &&
+      /^([a-z_])+([a-z0-9_]*)$/.test(value) &&
+      this.reservedWords.indexOf(value) === -1
+    )) ? value : '"' + value + '"';
 };
-
 
 // Coerce to string to prevent strange errors when it's not a string.
 Formatter_Oracle.prototype._wrapString = function(value) {
@@ -49,18 +72,7 @@ Formatter_Oracle.prototype._wrapString = function(value) {
   return wrapped.join('.');
 };
 
-// Memoize the calls to "wrap" for a little extra perf.
-var wrapperMemo = (function(){
-  var memo = Object.create(null);
-  return function(key) {
-    if (memo[key] === void 0) {
-      memo[key] = this._wrapString(key);
-    }
-    return memo[key];
-  };
-}());
-
-Formatter_Oracle.prototype._wrap = wrapperMemo;
+Formatter_Oracle.prototype._wrap = Formatter.prototype._wrapString;
 
 // Ensures the query is aliased if necessary.
 Formatter_Oracle.prototype.outputQuery = function(compiled, alwaysWrapped) {

--- a/lib/dialects/oracle/index.js
+++ b/lib/dialects/oracle/index.js
@@ -15,6 +15,7 @@ var oracle;
 function Client_Oracle(config) {
   Client.apply(this, arguments);
   if (config.debug) this.isDebugging = true;
+  this.isQuoting = !!config.quote;
   if (config.connection) {
     this.initDriver();
     this.initRunner();

--- a/lib/dialects/oracle/oracle-query-stream.js
+++ b/lib/dialects/oracle/oracle-query-stream.js
@@ -3,16 +3,18 @@
 /*jslint node:true, nomen: true*/
 var inherits = require('util').inherits;
 var Readable = require('stream').Readable;
+var utils = require('./utils');
 
 var _ = require('lodash');
 
-function OracleQueryStream(connection, sql, bindings, options) {
+function OracleQueryStream(forceQuoting, connection, sql, bindings, options) {
     try {
         Readable.call(this, _.merge({}, {
             objectMode: true,
             highWaterMark: 1000
         }, options));
 
+        this.forceQuoting = forceQuoting;
         this.oracleReader = connection.reader(sql, bindings || []);
     } catch (err) {
         throw err;
@@ -33,9 +35,10 @@ OracleQueryStream.prototype._read = function () {
             process.nextTick(function () {
                 self.push(null);
             });
+            return;
         }
 
-        self.push(row);
+        self.push(this.forceQuoting ? row : utils.convertQueryResultCase([row]));
     });
 };
 

--- a/lib/dialects/oracle/query.js
+++ b/lib/dialects/oracle/query.js
@@ -29,8 +29,8 @@ inherits(QueryBuilder_Oracle, QueryBuilder);
 // Set the "Formatter" to use for the queries,
 // ensuring that all parameterized values (even across sub-queries)
 // are properly built into the same query.
-function QueryCompiler_Oracle() {
-  this.formatter = new client.Formatter();
+function QueryCompiler_Oracle(builder) {
+  this.formatter = new client.Formatter(builder);
   QueryCompiler.apply(this, arguments);
 }
 inherits(QueryCompiler_Oracle, QueryCompiler);

--- a/lib/dialects/oracle/runner.js
+++ b/lib/dialects/oracle/runner.js
@@ -10,6 +10,7 @@ var inherits = require('inherits');
 var Promise  = require('../../promise');
 var Runner   = require('../../runner');
 var helpers  = require('../../helpers');
+var utils    = require('./utils');
 
 var OracleQueryStream = require('./oracle-query-stream');
 
@@ -30,7 +31,7 @@ Runner_Oracle.prototype._stream = Promise.method(function (obj, stream, options)
   return new Promise(function (resolver, rejecter) {
     stream.on('error', rejecter);
     stream.on('end', resolver);
-    var queryStream = new OracleQueryStream(self.connection, obj.sql, obj.bindings, options);
+    var queryStream = new OracleQueryStream(self.client.forceQuoting, self.connection, obj.sql, obj.bindings, options);
     queryStream.pipe(stream);
   });
 });
@@ -62,6 +63,7 @@ Runner_Oracle.prototype._query = Promise.method(function(obj) {
           resolver(obj);
         });
       } else {
+
         obj.response = response;
         resolver(obj);
       }
@@ -71,8 +73,11 @@ Runner_Oracle.prototype._query = Promise.method(function(obj) {
 
 // Process the response as returned from the query.
 Runner_Oracle.prototype.processResponse = function(obj) {
-  var response = obj.response;
+  // implicit convertsion of all upper case names to lowercase if quoting is disabled
+  var response = this.client.forceQuoting ? obj.response : utils.convertQueryResultCase(obj.response);
+
   var method   = obj.method;
+  var updateCount = response.updateCount;
   if (obj.output) return obj.output.call(this, response);
 
   switch (method) {
@@ -93,7 +98,7 @@ Runner_Oracle.prototype.processResponse = function(obj) {
         // return an array with values if only one returning value was specified
         return _.flatten(_.map(response, _.values));
       }
-      return response.updateCount;
+      return updateCount;
     default:
       return response;
   }

--- a/lib/dialects/oracle/utils.js
+++ b/lib/dialects/oracle/utils.js
@@ -34,8 +34,27 @@ ReturningHelper.prototype.toString = function () {
   return '[object ReturningHelper:' + this.columnName + ']';
 };
 
+function convertQueryResultCase(response) {
+  if (Array.isArray(response) && response.length) {
+    return response.map(function (row) {
+      return Object.keys(row).reduce(function (res, columnName) {
+        // if the name is all uppercase convert it to lower case
+        if (/^[A-Z0-9_\*\(\)]+$/.test(columnName)) {
+          res[columnName.toLowerCase()] = row[columnName];
+        } else {
+          res[columnName] = columnName;
+        }
+        return res;
+      }, {});
+    });
+  }
+
+  return response;
+}
+
 module.exports = {
   generateCombinedName: generateCombinedName,
   wrapSqlWithCatch: wrapSqlWithCatch,
-  ReturningHelper: ReturningHelper
+  ReturningHelper: ReturningHelper,
+  convertQueryResultCase: convertQueryResultCase
 };

--- a/lib/dialects/postgres/formatter.js
+++ b/lib/dialects/postgres/formatter.js
@@ -22,12 +22,41 @@ Formatter_PG.prototype.operators = [
   '&', '|', '#', '<<', '>>', '&&', '^', '@>', '<@', '||'
 ];
 
+// based on http://www.postgresql.org/docs/9.3/static/sql-keywords-appendix.html
+// also included reserved that can be used as function/name
+Formatter_PG.prototype.reservedWords = [
+  'all', 'analyse', 'analyze', 'and', 'any', 'array', 'as', 'asc', 'asymmetric',
+  'authorization', 'between', 'bigint', 'binary', 'bit', 'boolean', 'both',
+  'case', 'cast', 'check', 'collate', 'collation', 'column', 'concurrently',
+  'constraint', 'create', 'cross', 'current_catalog', 'current_date',
+  'current_role', 'current_schema', 'current_time', 'current_timestamp',
+  'current_user',  'default', 'deferrable', 'desc', 'distinct', 'do', 'else',
+  'end', 'except', 'exists', 'extract', 'false', 'fetch', 'float', 'for',
+  'foreign', 'freeze', 'from', 'full', 'grant', 'group', 'having', 'ilike',
+  'in', 'initially', 'intersect', 'into', 'is', 'isnull', 'join', 'lateral',
+  'leading', 'left', 'like', 'limit', 'localtime', 'localtimestamp', 'national',
+  'natural', 'nchar', 'none', 'not', 'notnull', 'null', 'offset', 'on', 'only',
+  'or', 'order', 'out', 'outer', 'over', 'overlaps', 'overlay', 'placing',
+  'position', 'precision', 'primary', 'real', 'references', 'returning',
+  'right', 'row', 'select', 'session_user', 'setof', 'similar', 'some',
+  'substring', 'symmetric', 'table', 'then', 'to', 'trailing', 'treat', 'trim',
+  'true', 'union', 'unique', 'user', 'using', 'values', 'varchar', 'variadic',
+  'verbose', 'when', 'where', 'window', 'with', 'xmlattributes', 'xmlconcat',
+  'xmlelement', 'xmlexists', 'xmlforest', 'xmlparse', 'xmlpi', 'xmlroot',
+  'xmlserialize'
+];
+
 // Wraps a value (column, tableName) with the correct ticks.
 Formatter_PG.prototype.wrapValue = function(value) {
-  if (value === '*') return value;
-  var matched = value.match(/(.*?)(\[[0-9]\])/);
+  // special handling for array index
+  var matched = value.match(/(.*?)((?:\[\d+\]){1,})$/);
   if (matched) return this.wrapValue(matched[1]) + matched[2];
-  return '"' + value + '"';
+
+  return (value === '*' || (
+      !this.isQuoting() &&
+      /^([a-z_])+([a-z0-9_]*)$/.test(value) &&
+      this.reservedWords.indexOf(value) === -1
+    )) ? value : '"' + value + '"';
 };
 
 // Memoize the calls to "wrap" for a little extra perf.

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -17,6 +17,8 @@ function Client_PG(config) {
   Client.apply(this, arguments);
   if (config.returning) this.defaultReturning = config.returning;
   if (config.debug) this.isDebugging = true;
+  this.isQuoting = !!config.quote;
+
   if (config.connection) {
     this.initDriver();
     this.initRunner();

--- a/lib/dialects/sqlite3/formatter.js
+++ b/lib/dialects/sqlite3/formatter.js
@@ -21,23 +21,37 @@ Formatter_SQLite3.prototype.operators = [
   '&', '|', '<<', '>>'
 ];
 
+// based on http://www.sqlite.org/lang_keywords.html
+Formatter_SQLite3.prototype.reservedWords = [
+  'abort', 'action', 'add', 'after', 'all', 'alter', 'analyze', 'and', 'as',
+  'asc', 'attach', 'autoincrement', 'before', 'begin', 'between', 'by',
+  'cascade', 'case', 'cast', 'check', 'collate', 'column', 'commit', 'conflict',
+  'constraint', 'create', 'cross', 'current_date', 'current_time',
+  'current_timestamp', 'database', 'default', 'deferrable', 'deferred',
+  'delete', 'desc', 'detach', 'distinct', 'drop', 'each', 'else', 'end',
+  'escape', 'except', 'exclusive', 'exists', 'explain', 'fail', 'for',
+  'foreign', 'from', 'full', 'glob', 'group', 'having', 'if', 'ignore',
+  'immediate', 'in', 'index', 'indexed', 'initially', 'inner', 'insert',
+  'instead', 'intersect', 'into', 'is', 'isnull', 'join', 'key', 'left',
+  'like', 'limit', 'match', 'natural', 'no', 'not', 'notnull', 'null', 'of',
+  'offset', 'on', 'or', 'order', 'outer', 'plan', 'pragma', 'primary', 'query',
+  'raise', 'recursive', 'references', 'regexp', 'reindex', 'release', 'rename',
+  'replace', 'restrict', 'right', 'rollback', 'row', 'savepoint', 'select',
+  'set', 'table', 'temp', 'temporary', 'then', 'to', 'transaction', 'trigger',
+  'union', 'unique', 'update', 'using', 'vacuum', 'values', 'view', 'virtual',
+  'when', 'where', 'with', 'without'
+];
+
 // Wraps a value (column, tableName) with the correct ticks.
 Formatter_SQLite3.prototype.wrapValue = function(value) {
-  return (value !== '*' ? '"' + value + '"' : '*');
+  return (value === '*' || (
+    !this.isQuoting() &&
+    /^([a-z_])+([a-z0-9_]*)$/.test(value) &&
+    this.reservedWords.indexOf(value) === -1
+  )) ? value : '"' + value + '"';
 };
 
-// Memoize the calls to "wrap" for a little extra perf.
-var wrapperMemo = (function(){
-  var memo = Object.create(null);
-  return function(key) {
-    if (memo[key] === void 0) {
-      memo[key] = this._wrapString(key);
-    }
-    return memo[key];
-  };
-}());
-
-Formatter_SQLite3.prototype._wrap = wrapperMemo;
+Formatter_SQLite3.prototype._wrap = Formatter.prototype._wrapString;
 
 // Assign the formatter to the the client.
 client.Formatter = Formatter_SQLite3;

--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -11,6 +11,7 @@ var Promise = require('../../promise');
 function Client_SQLite3(config) {
   Client.apply(this, arguments);
   if (config.debug) this.isDebugging = true;
+  this.isQuoting = !!config.quote;
   if (config.connection) {
     this.initDriver();
     this.initRunner();

--- a/lib/dialects/sqlite3/query.js
+++ b/lib/dialects/sqlite3/query.js
@@ -20,8 +20,8 @@ inherits(QueryBuilder_SQLite3, QueryBuilder);
 
 // Query Compiler
 // -------
-function QueryCompiler_SQLite3() {
-  this.formatter = new client.Formatter();
+function QueryCompiler_SQLite3(builder) {
+  this.formatter = new client.Formatter(builder);
   QueryCompiler.apply(this, arguments);
 }
 inherits(QueryCompiler_SQLite3, QueryCompiler);

--- a/lib/dialects/websql/index.js
+++ b/lib/dialects/websql/index.js
@@ -12,6 +12,7 @@ function Client_WebSQL(config) {
   config = config || {};
   Client_SQLite3.super_.apply(this, arguments);
   if (config.debug) this.isDebugging = true;
+  this.isQuoting = !!config.quote;
   this.name = config.name || 'knex_database';
   this.version = config.version || '1.0';
   this.displayName = config.displayName || this.name;

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -15,9 +15,21 @@ var orderBys  = ['asc', 'desc'];
 // parameterize values within a query, keeping track of all bindings
 // added to the query. This allows us to easily keep track of raw statements
 // arbitrarily added to queries.
-function Formatter() {
+function Formatter(builder) {
+  if (!builder) {
+    throw new Error("builder not defined");
+  }
+  this._builder = builder;
   this.bindings = [];
 }
+
+Formatter.prototype.isQuoting = function () {
+  if (this._builder._quote !== undefined) {
+    return this._builder._quote;
+  }
+
+  return this.client.isQuoting;
+};
 
 // Turns a list of values into a list of ?'s, joining them with commas unless
 // a "joining" value is specified (e.g. ' and ')

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -47,6 +47,12 @@ Target.prototype.debug = function(val) {
   return this;
 };
 
+// Set a debug flag for the current schema query stack.
+Target.prototype.quote = function(val) {
+  this._quote = (val === undefined || val === null) ? true : val;
+  return this;
+};
+
 // Set the transaction object for this query.
 Target.prototype.transacting = function(t) {
   this._transacting = t;

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -46,6 +46,7 @@ QueryBuilder.prototype.clone = function() {
     cloned._statements  = this._statements.slice();
     cloned._errors      = this._errors.slice();
     cloned._debug       = this._debug;
+    cloned._quote       = this._quote;
     cloned._transacting = this._transacting;
     cloned._connection  = this._connection;
   return cloned;

--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -17,6 +17,8 @@ function QueryCompiler(queryBuilder) {
   this.transacting = queryBuilder._transacting;
   this.grouped     = _.groupBy(queryBuilder._statements, 'grouping');
   this.tableName   = this.single.table ? this.formatter.wrap(this.single.table) : '';
+
+  this._builder = queryBuilder;
 }
 
 // Collapse the builder into a single object

--- a/lib/raw.js
+++ b/lib/raw.js
@@ -16,8 +16,9 @@ function Raw(sql, bindings) {
   this.bindings = _.isArray(bindings) ? bindings :
     bindings ? [bindings] : [];
   this.interpolateBindings();
-  this._debug       = void 0;
-  this._transacting = void 0;
+  this._debug       = undefined;
+  this._transacting = undefined;
+  this._quote       = undefined;
 }
 inherits(Raw, EventEmitter);
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -156,6 +156,15 @@ Runner.prototype.isDebugging = function() {
   return (this.client.isDebugging === true || this.builder._debug === true);
 };
 
+// Check whether we're "quoting", based on either calling `quote` on the query.
+Runner.prototype.isQuoting = function() {
+  if (this.builder._quote !== undefined) {
+    return this.builder._quote;
+  }
+
+  return this.client.isQuoting;
+};
+
 // Transaction Methods:
 // -------
 

--- a/lib/schema/columncompiler.js
+++ b/lib/schema/columncompiler.js
@@ -15,7 +15,7 @@ function ColumnCompiler(tableCompiler, columnBuilder) {
   this.grouped = _.groupBy(columnBuilder._statements, 'grouping');
   this.modified = columnBuilder._modifiers;
   this.isIncrements = (this.type.indexOf('increments') !== -1);
-  this.initCompiler();
+  this.initCompiler(tableCompiler.tableBuilder.builder);
 }
 
 // To convert to sql, we first go through and build the

--- a/lib/schema/compiler.js
+++ b/lib/schema/compiler.js
@@ -5,13 +5,13 @@
 // properly formatted / bound query strings.
 function SchemaCompiler(builder) {
   this.builder = builder;
-  this.initCompiler();
+  this.initCompiler(builder);
 }
 
 function buildTable(type) {
   return function(tableName, fn) {
     var TableBuilder = this.client.TableBuilder;
-    var sql = new TableBuilder(type, tableName, fn).toSQL();
+    var sql = new TableBuilder(type, tableName, fn, this.builder).toSQL();
     for (var i = 0, l = sql.length; i < l; i++) {
       this.sequence.push(sql[i]);
     }

--- a/lib/schema/index.js
+++ b/lib/schema/index.js
@@ -12,8 +12,12 @@ var ColumnCompiler = require('./columncompiler');
 // Initialize the compiler.
 Compiler.prototype.initCompiler =
 TableCompiler.prototype.initCompiler =
-ColumnCompiler.prototype.initCompiler = function() {
-  this.formatter = new this.Formatter();
+ColumnCompiler.prototype.initCompiler = function initCompiler(builder) {
+  if (!builder) {
+    throw new Error("Builder param missing");
+  }
+  this.formatter = new this.Formatter(builder);
+  this.__builder = builder;
   this.sequence  = [];
 };
 
@@ -32,7 +36,7 @@ ColumnCompiler.prototype.pushQuery = function(query) {
     query.bindings = this.formatter.bindings;
   }
   this.sequence.push(query);
-  this.formatter = new this.Formatter();
+  this.formatter = new this.Formatter(this.__builder);
 };
 
 // Used in cases where we need to push some additional column specific statements.

--- a/lib/schema/tablebuilder.js
+++ b/lib/schema/tablebuilder.js
@@ -43,7 +43,9 @@ AlterMethods.dropColumns = function() {
   return this;
 };
 
-function TableBuilder(method, tableName, fn) {
+function TableBuilder(method, tableName, fn, builder) {
+  this.builder = builder;
+
   this._fn         = fn;
   this._method     = method;
   this._tableName  = tableName;

--- a/lib/schema/tablecompiler.js
+++ b/lib/schema/tablecompiler.js
@@ -11,7 +11,9 @@ function TableCompiler(tableBuilder) {
   this.tableNameRaw   = tableBuilder._tableName;
   this.single         = tableBuilder._single;
   this.grouped        = _.groupBy(tableBuilder._statements, 'grouping');
-  this.initCompiler();
+
+  this.tableBuilder = tableBuilder;
+  this.initCompiler(tableBuilder.builder);
 }
 
 // Convert the tableCompiler toSQL


### PR DESCRIPTION
Added an option per client and per query to disable/enable quoting (`.quote(false/true)`) of non-reserved lowercase names (only a-z 0-9 and underscore) for table names, aliases and column names. Names may not start with a number. If quote(false) and the name does not match the criteria then it's automatically quoted. 

In case of the oracle dialect this also adds automatic conversion of all uppercase result-column-names to lowercase because oracle converts case insensitive names to uppercase. 

To allow the possibility to turn quotes on/off per query I had to remove the memoization in the Formatter. And pass the *Builder to the Formatter. Currently the formatter is reused for subqueries (because of the bindings) therefore changing the quote option in a subquery does not work correctly.

@tgriesser This is only beneficial if someone always wants to use lowercase for names and wants oracle compatibility. However there's really no need for this if all uppercase names are used instead.