### PR TITLE
Fix sqlite3 rename column

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,5 +9,5 @@
   "undef": true,
   "trailing": true,
   "unused": true,
-  "predef": [ "-Promise" ]
+  "predef": [ "-Promise", "before", "after" ]
 }

--- a/lib/dialects/mysql/schema/table.js
+++ b/lib/dialects/mysql/schema/table.js
@@ -8,6 +8,8 @@ var inherits = require('inherits');
 var Schema   = require('../../../schema');
 var helpers  = require('../../../helpers');
 
+var Promise  = require('../../../promise');
+    
 // Table Builder
 // ------
 
@@ -68,20 +70,85 @@ TableCompiler_MySQL.prototype.changeType = function() {
 
 // Renames a column on the table.
 TableCompiler_MySQL.prototype.renameColumn = function(from, to) {
-  var table   = this.tableName();
-  var wrapped = this.formatter.wrap(from) + ' ' + this.formatter.wrap(to);
+  var compiler = this;
+  var table    = this.tableName();
+  var wrapped  = this.formatter.wrap(from) + ' ' + this.formatter.wrap(to);
   this.pushQuery({
     sql: 'show fields from ' + table + ' where field = ' +
       this.formatter.parameter(from),
     output: function(resp) {
       var column = resp[0];
-      return this.query({
-        sql: 'alter table ' + table + ' change ' + wrapped + ' ' + column.Type
+      var runner = this;
+      
+      return compiler.getFKRefs(runner).get(0)
+      .then(function (refs) {
+        return Promise.try(function () {
+          if (!refs.length) { return; }
+          return compiler.dropFKRefs(runner, refs);
+        }).then(function () {
+          return runner.query({
+            sql: 'alter table ' + table + ' change ' + wrapped + ' ' + column.Type
+          });
+        }).then(function () {
+          if (!refs.length) { return; }
+          return compiler.createFKRefs(runner, refs.map(function (ref) {
+            if (ref.REFERENCED_COLUMN_NAME === from) {
+              ref.REFERENCED_COLUMN_NAME = to;
+            }
+            if (ref.COLUMN_NAME === from) {
+              ref.COLUMN_NAME = to;
+            }
+            return ref;
+          }));
+        });
       });
     }
   });
 };
+TableCompiler_MySQL.prototype.getFKRefs = function (runner) {
+  var formatter = new this.Formatter();
 
+  var sql = 'SELECT KCU.CONSTRAINT_NAME, KCU.TABLE_NAME, KCU.COLUMN_NAME, '+
+            '       KCU.REFERENCED_TABLE_NAME, KCU.REFERENCED_COLUMN_NAME, '+
+            '       RC.UPDATE_RULE, RC.DELETE_RULE '+
+            'FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU '+
+            'JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS RC '+
+            '       USING(CONSTRAINT_NAME)' +
+            'WHERE KCU.REFERENCED_TABLE_NAME = ' + formatter.parameter(this.tableNameRaw) + ' '+
+            '  AND KCU.CONSTRAINT_SCHEMA = ' + formatter.parameter(this.client.databaseName);
+
+  return runner.query({
+    sql: sql,
+    bindings: formatter.bindings
+  });
+};
+TableCompiler_MySQL.prototype.dropFKRefs = function (runner, refs) {
+  var formatter = new this.Formatter();
+  
+  return Promise.all(refs.map(function (ref) {
+    var constraintName = formatter.wrap(ref.CONSTRAINT_NAME);
+    return runner.query({
+      sql: 'alter table ' + this.tableName() + ' drop foreign key ' + constraintName
+    });
+  }.bind(this)));
+};
+TableCompiler_MySQL.prototype.createFKRefs = function (runner, refs) {
+  var formatter = new this.Formatter();
+  
+  return Promise.all(refs.map(function (ref) {
+    var keyName    = formatter.wrap(ref.COLUMN_NAME);
+    var column     = formatter.columnize(ref.COLUMN_NAME);
+    var references = formatter.columnize(ref.REFERENCED_COLUMN_NAME);
+    var inTable    = formatter.wrap(ref.REFERENCED_TABLE_NAME);
+    var onUpdate   = ' ON UPDATE ' + ref.UPDATE_RULE;
+    var onDelete   = ' ON DELETE ' + ref.DELETE_RULE;
+    
+    return runner.query({
+      sql: 'alter table ' + this.tableName() + ' add constraint ' + keyName + ' ' + 
+        'foreign key (' + column + ') references ' + inTable + ' (' + references + ')' + onUpdate + onDelete
+    });
+  }.bind(this)));
+};
 TableCompiler_MySQL.prototype.index = function(columns, indexName) {
   indexName = indexName || this._indexCommand('index', this.tableNameRaw, columns);
   this.pushQuery('alter table ' + this.tableName() + " add index " + indexName + "(" + this.formatter.columnize(columns) + ")");

--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -102,6 +102,87 @@ SQLite3_DDL.prototype.createTempTable = function(createTable) {
   };
 };
 
+SQLite3_DDL.prototype._doReplace = function (sql, from, to) {
+  var matched = sql.match(/^CREATE TABLE (\S+) \((.*)\)/);
+  
+  var tableName = matched[1],
+      defs = matched[2];
+  
+  if (!defs) { throw new Error('No column definitions in this statement!'); }
+
+  var parens = 0, args = [ ], ptr = 0;
+  for (var i = 0, x = defs.length; i < x; i++) {
+    switch (defs[i]) {
+      case '(':
+        parens++;
+      break;
+      case ')':
+        parens--;
+      break;
+      case ',':
+        if (parens === 0) {
+          args.push(defs.slice(ptr, i));
+          ptr = i + 1;
+        }
+      break;
+      case ' ':
+        if (ptr === i) {
+          ptr = i + 1;
+        }
+      break;
+    }
+  }
+  args.push(defs.slice(ptr, i));
+  
+  args = args.map(function (item) {
+    var split = item.split(' ');
+
+    if (split[0] === from) {
+      // column definition
+      if (to) {
+        split[0] = to;
+        return split.join(' ');
+      }
+      return ''; // for deletions
+    }
+    
+    // skip constraint name
+    var idx = (/constraint/i.test(split[0]) ? 2 : 0);
+    
+    // primary key and unique constraints have one or more
+    // columns from this table listed between (); replace
+    // one if it matches
+    if (/primary|unique/i.test(split[idx])) {
+      return item.replace(/\(.*\)/, function (columns) {
+        return columns.replace(from, to);
+      });
+    }
+    
+    // foreign keys have one or more columns from this table
+    // listed between (); replace one if it matches
+    // foreign keys also have a 'references' clause
+    // which may reference THIS table; if it does, replace
+    // column references in that too!
+    if (/foreign/.test(split[idx])) {
+      split = item.split(/ references /i);
+      // the quoted column names save us from having to do anything
+      // other than a straight replace here
+      split[0] = split[0].replace(from, to);
+      
+      if (split[1].slice(0, tableName.length) === tableName) {
+        split[1] = split[1].replace(/\(.*\)/, function (columns) {
+          return columns.replace(from, to);
+        });
+      }
+      return split.join(' references ');
+    }
+    
+    return item;
+  });
+  return sql.replace(/\(.*\)/, function () {
+    return '(' + args.join(', ') + ')';
+  }).replace(/,\s*([,)])/, '$1');
+};
 // Boy, this is quite a method.
 SQLite3_DDL.prototype.renameColumn = Promise.method(function(from, to) {
   var currentCol;
@@ -113,18 +194,21 @@ SQLite3_DDL.prototype.renameColumn = Promise.method(function(from, to) {
     .tap(function(col) { currentCol = col; })
     .then(this.getTableSql)
     .then(function(sql) {
+      var a = this.formatter.wrap(from);
+      var b = this.formatter.wrap(to);
       var createTable = sql[0];
-      var a = this.formatter.wrap(from) + ' ' + currentCol.type;
-      var b = this.formatter.wrap(to)   + ' ' + currentCol.type;
-      if (createTable.sql.indexOf(a) === -1) {
+      
+      var newSql = this._doReplace(createTable.sql, a, b);
+      if (sql === newSql) {
         throw new Error('Unable to find the column to change');
       }
+      
       return Promise.bind(this)
       .then(this.createTempTable(createTable))
       .then(this.copyData)
       .then(this.dropOriginal)
       .then(function() {
-        return this.runner.query({sql: createTable.sql.replace(a, b)});
+        return this.runner.query({sql: newSql });
       })
       .then(this.reinsertData(function(row) {
         row[to] = row[from];
@@ -147,26 +231,19 @@ SQLite3_DDL.prototype.dropColumn = Promise.method(function(column) {
     .then(this.getTableSql)
     .then(function(sql) {
       var createTable = sql[0];
-      var a;
-      var a0 = this.formatter.wrap(column) + ' ' + currentCol.type;
-      var al = a0 + ', ';
-       if (createTable.sql.indexOf(al) !== -1) {
-         a = al;
-       } else {
-         var af = ', ' + a0;
-         if (createTable.sql.indexOf(af) !== -1) {
-           a = af;
-         }
-       }
-      if (!a) {
+      var a = this.formatter.wrap(column);
+      
+      var newSql = this._doReplace(createTable.sql, a, '');
+      if (sql === newSql) {
         throw new Error('Unable to find the column to change');
       }
+      
       return Promise.bind(this)
         .then(this.createTempTable(createTable))
         .then(this.copyData)
         .then(this.dropOriginal)
         .then(function() {
-          return this.runner.query({sql: createTable.sql.replace(a, '')});
+          return this.runner.query({sql: newSql});
         })
         .then(this.reinsertData(function(row) {
           return _.omit(row, column);

--- a/test/unit/schema/sqlite3.js
+++ b/test/unit/schema/sqlite3.js
@@ -421,6 +421,29 @@ module.exports = function(client) {
       equal(2, tableSql.length);
       equal(tableSql[0].sql, 'create table "users" ("user_id" varchar(36), foreign key("user_id") references "user"("id") on delete CASCADE)');
     });
-
+    
+    describe('SQLite3_DDL.prototype._doReplace', function () {
+      it('should not change a query that has no matches', function () {
+        return new SchemaBuilder().table('foo', function (tbl) {
+          // i don't really know how to get at an instance of this 'correctly'
+          var doReplace = tbl.client.SQLite3_DDL.prototype._doReplace;
+          
+          var sql1 = 'CREATE TABLE "foo" ("id" integer not null primary key autoincrement, '+
+                '"parent_id_test" integer, foreign key("parent_id") references "foo"("id"))';
+          var sql2 = 'CREATE TABLE "foo" ("id" integer not null primary key autoincrement, '+
+                '"parent_id_test" integer, foreign key("parent_id") references "bar"("id"))';
+          
+          var sql1b = 'CREATE TABLE "foo" ("id_foo" integer not null primary key autoincrement, '+
+                '"parent_id_test" integer, foreign key("parent_id") references "foo"("id_foo"))';
+          var sql2b = 'CREATE TABLE "foo" ("id_foo" integer not null primary key autoincrement, '+
+                '"parent_id_test" integer, foreign key("parent_id") references "bar"("id"))';
+          
+          
+          expect(doReplace(sql1, '"bar"', '"lar"')).to.equal(sql1);
+          expect(doReplace(sql1, '"id"', '"id_foo"')).to.equal(sql1b);
+          expect(doReplace(sql2, '"id"', '"id_foo"')).to.equal(sql2b);
+        }).toSQL();
+      });
+    });
   });
 };


### PR DESCRIPTION
This turned more into a general refactor of the column name replacement code. Besides the problems I've mentioned previously, I realized/encountered a couple more to do with self-referencing foreign keys. A general search and replace on the strings is undesirable unless we can guarantee that nothing bad will happen, which is also I assume why the replacement strings were qualified with commas and stuff. The new method breaks the query into a few pieces and performs replacements only in appropriate places. It does NOT handle expressions in the query flow, since they can basically be just any SQL, but this shouldn't matter for where/how it's being used?

Cases tested: Do nothing if no match, replace column name in string only in the column definition, and not matching string in a foreign key reference to a different table, replace column name in string and self-referencing foreign key