### PR TITLE
Do not lose domain during query runtime

### DIFF
--- a/lib/dialects/sqlite3/runner.js
+++ b/lib/dialects/sqlite3/runner.js
@@ -41,7 +41,9 @@ Runner_SQLite3.prototype._query = Promise.method(function(obj) {
     if (!connection || !connection[callMethod]) {
       return rejecter(new Error('Error calling ' + callMethod + ' on connection.'));
     }
-    connection[callMethod](obj.sql, obj.bindings, function(err, response) {
+
+    function handleResponse(err, response) {
+      /* jshint -W040: true */
       if (err) return rejecter(err);
       obj.response = response;
 
@@ -49,7 +51,13 @@ Runner_SQLite3.prototype._query = Promise.method(function(obj) {
       // the "this.lastID" or "this.changes"
       obj.context  = this;
       return resolver(obj);
-    });
+    }
+
+    connection[callMethod](
+      obj.sql,
+      obj.bindings,
+      !! process.domain ? process.domain.bind(handleResponse) : handleResponse
+    );
   });
 });
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -26,10 +26,24 @@ Runner.prototype.run = Promise.method(function() {
   if (this.builder._transacting) {
     return this.transactionQuery();
   }
+
+  // Avoid binding domains to connections (EventEmitter).
+  // Handle nested domains.
+  var domains = [];
+  while (!! process.domain) {
+    domains.push(process.domain);
+    process.domain.exit();
+  }
+
   return Promise.bind(this)
     .then(this.ensureConnection)
     .then(function(connection) {
       this.connection = connection;
+
+      // Enter previous domains stack.
+      _.each(domains, function (domain) {
+        domain.enter();
+      });
 
       // Emit a "start" event on both the builder and the client,
       // allowing us to listen in on any events. We fire on the "client"

--- a/test/integration/builder/domain.js
+++ b/test/integration/builder/domain.js
@@ -1,0 +1,46 @@
+/*global describe, expect, it, testPromise*/
+
+'use strict';
+
+module.exports = function(knex) {
+
+  var _ = require('lodash');
+
+  describe('Domain', function () {
+    it('should keep domain during connections requests', function (done) {
+      testPromise.all(_.range(1, 20).map(function (index) {
+        var domain = require('domain').create();
+        domain.data = index;
+        return domain.run(function () {
+          return knex('accounts')
+          .select()
+          .limit(1)
+          .bind({ index: index })
+          .then(function () {
+            expect(this.index).to.equal(process.domain.data);
+            process.domain.exit();
+          });
+        });
+      }))
+      .then(function () {
+        process.domain.exit();
+        done();
+      })
+      .catch(function (err) {
+        while (!! process.domain) process.domain.exit();
+        done(err);
+      });
+    });
+
+    it('should not bound previous domains to connections', function (done) {
+        return knex('accounts')
+        .select()
+        .limit(1)
+        .then(function () {
+          expect(process).to.not.have.property('domain');
+          done();
+        })
+        .catch(done);
+    });
+  });
+};

--- a/test/integration/suite.js
+++ b/test/integration/suite.js
@@ -21,6 +21,7 @@ module.exports = function(knex) {
     require('./builder/transaction')(knex);
     require('./builder/deletes')(knex);
     require('./builder/additional')(knex);
+    require('./builder/domain')(knex);
 
     describe('knex.destroy', function() {
 


### PR DESCRIPTION
It is not really a pull-request, more or less a question or a way to use domains on a Knex/Bookshelf based application.

The main problem resides in the way emitters and domains work together, and the fact that the pool is a collection of emitter singletons (created before or after inclusion in a domain).

I could use the same pattern which leads to unstack/restack domains before entering and after leaving a Knex/Bookshelf component. I'm just curious about your point of view, or the way used by people to bypass this domain caveat.
