### PR TITLE
Allow mysql2 to use a non-default port

### DIFF
--- a/lib/dialects/mysql2/index.js
+++ b/lib/dialects/mysql2/index.js
@@ -8,7 +8,7 @@ var _            = require('lodash');
 var Client_MySQL = require('../mysql');
 var Promise      = require('../../promise');
 
-var configOptions = ['user', 'database', 'host', 'password', 'ssl', 'connection', 'stream'];
+var configOptions = ['user', 'database', 'host', 'password', 'port', 'ssl', 'connection', 'stream'];
 
 var mysql2;
 

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,11 @@ var clients = {
     name: 'mysql',
     client: knex({client: 'mysql'}).client,
   },
+  mysql2: {
+    name: 'mysql2',
+    client: knex({client: 'mysql2'}).client,
+    alias: 'mysql'
+  },
   sqlite3: {
     name: 'sqlite3',
     client: knex({client: 'sqlite3'}).client


### PR DESCRIPTION
I'm struggling with how to add unit tests for the dialect adapter so that I can test the changed behavior of acquireRawConnection.  I hope to push that back before too long.