### PR TITLE
Add 'Error' event should a query fail.

### DIFF
--- a/knex.js
+++ b/knex.js
@@ -108,12 +108,15 @@ Knex.initialize = function(config) {
     Dialect = Clients[clientName]();
     client  = new Dialect(config);
 
-    // Passthrough all "start" and "query" events to the knex object.
+    // Passthrough all "start", "query" and "error" events to the knex object.
     client.on('start', function(obj) {
       knex.emit('start', obj);
     });
     client.on('query', function(obj) {
       knex.emit('query', obj);
+    });
+    client.on('error', function(obj) {
+      knex.emit('error', obj);
     });
   }
 

--- a/knex.js
+++ b/knex.js
@@ -115,8 +115,8 @@ Knex.initialize = function(config) {
     client.on('query', function(obj) {
       knex.emit('query', obj);
     });
-    client.on('error', function(obj) {
-      knex.emit('error', obj);
+    client.on('notify:error', function(obj) {
+      knex.emit('notify:error', obj);
     });
   }
 

--- a/knex.js
+++ b/knex.js
@@ -115,8 +115,8 @@ Knex.initialize = function(config) {
     client.on('query', function(obj) {
       knex.emit('query', obj);
     });
-    client.on('notify:error', function(obj) {
-      knex.emit('notify:error', obj);
+    client.on('query-error', function(obj) {
+      knex.emit('query-error', obj);
     });
   }
 

--- a/lib/dialects/maria/runner.js
+++ b/lib/dialects/maria/runner.js
@@ -47,7 +47,7 @@ Runner_MariaSQL.prototype._query = Promise.method(function(obj) {
   if (!sql) throw new Error('The query is empty');
   return new Promise(function(resolver, rejecter) {
     var rejectHandler = function(error) {
-      client.emit('notify:error', error);
+      client.emit('query-error', error);
       rejecter(error);
     };
     var rows = [];

--- a/lib/dialects/maria/runner.js
+++ b/lib/dialects/maria/runner.js
@@ -47,7 +47,7 @@ Runner_MariaSQL.prototype._query = Promise.method(function(obj) {
   if (!sql) throw new Error('The query is empty');
   return new Promise(function(resolver, rejecter) {
     var rejectHandler = function(error) {
-      client.emit('error', error);
+      client.emit('notify:error', error);
       rejecter(error);
     };
     var rows = [];

--- a/lib/dialects/maria/runner.js
+++ b/lib/dialects/maria/runner.js
@@ -43,8 +43,13 @@ Runner_MariaSQL.prototype._query = Promise.method(function(obj) {
   if (this.isDebugging()) this.debug(obj);
   var connection = this.connection;
   var tz = this.client.connectionSettings.timezone || 'local';
+  var client = this.client;
   if (!sql) throw new Error('The query is empty');
   return new Promise(function(resolver, rejecter) {
+    var rejectHandler = function(error) {
+      client.emit('error', error);
+      rejecter(error);
+    };
     var rows = [];
     var query = connection.query(SqlString.format(sql, obj.bindings, false, tz), []);
     query.on('result', function(result) {
@@ -54,7 +59,7 @@ Runner_MariaSQL.prototype._query = Promise.method(function(obj) {
         resolver(obj);
       });
     })
-    .on('error', rejecter);
+    .on('error', rejectHandler);
 
   });
 });

--- a/lib/dialects/mysql/runner.js
+++ b/lib/dialects/mysql/runner.js
@@ -42,7 +42,7 @@ Runner_MySQL.prototype._query = Promise.method(function(obj) {
   return new Promise(function(resolver, rejecter) {
     connection.query(sql, obj.bindings, function(err, rows, fields) {
       if (err){
-       client.emit('error', err);
+       client.emit('notify:error', err);
        return rejecter(err);
       }
       obj.response = [rows, fields];

--- a/lib/dialects/mysql/runner.js
+++ b/lib/dialects/mysql/runner.js
@@ -42,7 +42,7 @@ Runner_MySQL.prototype._query = Promise.method(function(obj) {
   return new Promise(function(resolver, rejecter) {
     connection.query(sql, obj.bindings, function(err, rows, fields) {
       if (err){
-       client.emit('notify:error', err);
+       client.emit('query-error', err);
        return rejecter(err);
       }
       obj.response = [rows, fields];

--- a/lib/dialects/mysql/runner.js
+++ b/lib/dialects/mysql/runner.js
@@ -37,10 +37,14 @@ Runner_MySQL.prototype._query = Promise.method(function(obj) {
   if (this.isDebugging()) this.debug(obj);
   if (obj.options) sql = _.extend({sql: sql}, obj.options);
   var connection = this.connection;
+  var client = this.client;
   if (!sql) throw new Error('The query is empty');
   return new Promise(function(resolver, rejecter) {
     connection.query(sql, obj.bindings, function(err, rows, fields) {
-      if (err) return rejecter(err);
+      if (err){
+       client.emit('error', err);
+       return rejecter(err);
+      }
       obj.response = [rows, fields];
       resolver(obj);
     });

--- a/lib/dialects/mysql2/runner.js
+++ b/lib/dialects/mysql2/runner.js
@@ -49,7 +49,7 @@ Runner_MySQL2.prototype._query = Promise.method(function(obj) {
   return new Promise(function(resolver, rejecter) {
     connection.query(sql, obj.bindings, function(err, rows, fields) {
       if (err){
-       client.emit('error', err);
+       client.emit('notify:error', err);
        return rejecter(err);
       }
       obj.response = [rows, fields];

--- a/lib/dialects/mysql2/runner.js
+++ b/lib/dialects/mysql2/runner.js
@@ -49,7 +49,7 @@ Runner_MySQL2.prototype._query = Promise.method(function(obj) {
   return new Promise(function(resolver, rejecter) {
     connection.query(sql, obj.bindings, function(err, rows, fields) {
       if (err){
-       client.emit('notify:error', err);
+       client.emit('query-error', err);
        return rejecter(err);
       }
       obj.response = [rows, fields];

--- a/lib/dialects/mysql2/runner.js
+++ b/lib/dialects/mysql2/runner.js
@@ -44,10 +44,14 @@ Runner_MySQL2.prototype._query = Promise.method(function(obj) {
   if (this.isDebugging()) this.debug(obj);
   if (obj.options) sql = _.extend({sql: sql}, obj.options);
   var connection = this.connection;
+  var client = this.client;
   if (!sql) throw new Error('The query is empty');
   return new Promise(function(resolver, rejecter) {
     connection.query(sql, obj.bindings, function(err, rows, fields) {
-      if (err) return rejecter(err);
+      if (err){
+       client.emit('error', err);
+       return rejecter(err);
+      }
       obj.response = [rows, fields];
       resolver(obj);
     });

--- a/lib/dialects/oracle/runner.js
+++ b/lib/dialects/oracle/runner.js
@@ -51,7 +51,7 @@ Runner_Oracle.prototype._query = Promise.method(function(obj) {
   return new Promise(function(resolver, rejecter) {
     connection.execute(obj.sql, obj.bindings, function(err, response) {
       if (err){
-       client.emit('error', err);
+       client.emit('notify:error', err);
        return rejecter(err);
       }
 

--- a/lib/dialects/oracle/runner.js
+++ b/lib/dialects/oracle/runner.js
@@ -51,7 +51,7 @@ Runner_Oracle.prototype._query = Promise.method(function(obj) {
   return new Promise(function(resolver, rejecter) {
     connection.execute(obj.sql, obj.bindings, function(err, response) {
       if (err){
-       client.emit('notify:error', err);
+       client.emit('query-error', err);
        return rejecter(err);
       }
 

--- a/lib/dialects/oracle/runner.js
+++ b/lib/dialects/oracle/runner.js
@@ -39,6 +39,7 @@ Runner_Oracle.prototype._stream = Promise.method(function (obj, stream, options)
 // and any other necessary prep work.
 Runner_Oracle.prototype._query = Promise.method(function(obj) {
   var connection = this.connection;
+  var client = this.client;
 
   // convert ? params into positional bindings (:1)
   obj.sql = this.client.positionBindings(obj.sql);
@@ -49,7 +50,10 @@ Runner_Oracle.prototype._query = Promise.method(function(obj) {
   if (this.isDebugging()) this.debug(obj);
   return new Promise(function(resolver, rejecter) {
     connection.execute(obj.sql, obj.bindings, function(err, response) {
-      if (err) return rejecter(err);
+      if (err){
+       client.emit('error', err);
+       return rejecter(err);
+      }
 
       if (obj.returning) {
         var rowIds = obj.outParams.map(function (v, i) {

--- a/lib/dialects/postgres/runner.js
+++ b/lib/dialects/postgres/runner.js
@@ -40,7 +40,7 @@ Runner_PG.prototype._query = Promise.method(function(obj) {
   return new Promise(function(resolver, rejecter) {
     connection.query(sql, obj.bindings, function(err, response) {
       if (err){
-       client.emit('notify:error', err);
+       client.emit('query-error', err);
        return rejecter(err);
       }
       obj.response = response;

--- a/lib/dialects/postgres/runner.js
+++ b/lib/dialects/postgres/runner.js
@@ -34,11 +34,15 @@ Runner_PG.prototype._stream = Promise.method(function(obj, stream, options) {
 Runner_PG.prototype._query = Promise.method(function(obj) {
   var connection = this.connection;
   var sql = obj.sql = this.client.positionBindings(obj.sql);
+  var client = this.client;
   if (this.isDebugging()) this.debug(obj);
   if (obj.options) sql = _.extend({text: sql}, obj.options);
   return new Promise(function(resolver, rejecter) {
     connection.query(sql, obj.bindings, function(err, response) {
-      if (err) return rejecter(err);
+      if (err){
+       client.emit('error', err);
+       return rejecter(err);
+      }
       obj.response = response;
       resolver(obj);
     });

--- a/lib/dialects/postgres/runner.js
+++ b/lib/dialects/postgres/runner.js
@@ -40,7 +40,7 @@ Runner_PG.prototype._query = Promise.method(function(obj) {
   return new Promise(function(resolver, rejecter) {
     connection.query(sql, obj.bindings, function(err, response) {
       if (err){
-       client.emit('error', err);
+       client.emit('notify:error', err);
        return rejecter(err);
       }
       obj.response = response;

--- a/lib/dialects/sqlite3/runner.js
+++ b/lib/dialects/sqlite3/runner.js
@@ -44,7 +44,7 @@ Runner_SQLite3.prototype._query = Promise.method(function(obj) {
     }
     connection[callMethod](obj.sql, obj.bindings, function(err, response) {
       if (err){
-       client.emit('notify:error', err);
+       client.emit('query-error', err);
        return rejecter(err);
       }
       obj.response = response;

--- a/lib/dialects/sqlite3/runner.js
+++ b/lib/dialects/sqlite3/runner.js
@@ -44,7 +44,7 @@ Runner_SQLite3.prototype._query = Promise.method(function(obj) {
     }
     connection[callMethod](obj.sql, obj.bindings, function(err, response) {
       if (err){
-       client.emit('error', err);
+       client.emit('notify:error', err);
        return rejecter(err);
       }
       obj.response = response;

--- a/lib/dialects/sqlite3/runner.js
+++ b/lib/dialects/sqlite3/runner.js
@@ -37,12 +37,16 @@ Runner_SQLite3.prototype._query = Promise.method(function(obj) {
       callMethod = 'all';
   }
   var connection = this.connection;
+  var client = this.client;
   return new Promise(function(resolver, rejecter) {
     if (!connection || !connection[callMethod]) {
       return rejecter(new Error('Error calling ' + callMethod + ' on connection.'));
     }
     connection[callMethod](obj.sql, obj.bindings, function(err, response) {
-      if (err) return rejecter(err);
+      if (err){
+       client.emit('error', err);
+       return rejecter(err);
+      }
       obj.response = response;
 
       // We need the context here, as it contains


### PR DESCRIPTION
In reference to Issue #593 , rather than requesting, figured I'd do pull request..

Tested on Postgresql, should work on rest. Purpose is to be able to listen on query errors should they occur, so that it can be used for logging purposes rather than placing your log-logic in the promise-reject/callback() functions of each Runner.query call. Convenient, and less code.

IE:
knex.on('error', myQueryErrorHandler);