### PR TITLE
Add inherits to postgres. Updated dialect-specific methods.

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,7 @@
       <li>– <a href="#Schema-engine">engine</a></li>
       <li>– <a href="#Schema-charset">charset</a></li>
       <li>– <a href="#Schema-collate">collate</a></li>
+      <li>– <a href="#Schema-inherits">inherits</a></li>
       <li>– <a href="#Schema-specificType">specificType</a></li>
       <li>– <a href="#Schema-index">index</a></li>
       <li>– <a href="#Schema-dropIndex">dropIndex</a></li>
@@ -2038,6 +2039,13 @@ knex.table('users')
       <br />
       Sets the collation for the database table, only available within a <tt>createTable</tt> call, and only
       applicable to MySQL.
+    </p>
+
+    <p id="Schema-inherits">
+      <b class="header">inherits</b><code>table.inherits(val)</code>
+      <br />
+      Sets the tables that this table inherits, only available within a <tt>createTable</tt> call, and only
+      applicable to PostgreSQL.
     </p>
 
     <p id="Schema-specificType">

--- a/src/dialects/postgres/schema/tablecompiler.js
+++ b/src/dialects/postgres/schema/tablecompiler.js
@@ -29,8 +29,10 @@ TableCompiler_PG.prototype.compileAdd = function(builder) {
 // Adds the "create" query to the query sequence.
 TableCompiler_PG.prototype.createQuery = function(columns, ifNot) {
   var createStatement = ifNot ? 'create table if not exists ' : 'create table ';
+  var sql = createStatement + this.tableName() + ' (' + columns.sql.join(', ') + ')';
+  if (this.single.inherits) sql += ' inherits (' + this.formatter.wrap(this.single.inherits) + ')';
   this.pushQuery({
-    sql: createStatement + this.tableName() + ' (' + columns.sql.join(', ') + ')',
+    sql: sql,
     bindings: columns.bindings
   });
   var hasComment = has(this.single, 'comment');

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -488,6 +488,14 @@ describe(dialect + " SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('create table `default_raw_test` (`created_at` timestamp default CURRENT_TIMESTAMP)');
   });
 
+  it('sets myISAM engine', function() {
+    tableSql = client.schemaBuilder().createTable('users', function(t) {
+      t.string('username');
+      t.engine('myISAM');
+    }).toSQL();
+    expect(tableSql[0].sql).to.equal('create table `users` (`username` varchar(255)) engine = myISAM');
+  });
+
 });
 
 

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -499,4 +499,20 @@ describe("PostgreSQL SchemaBuilder", function() {
     expect(sql[0].sql).to.equal('drop extension if exists "test"');
   });
 
+  it('table inherits another table', function() {
+    tableSql = client.schemaBuilder().createTable('inheriteeTable', function(t) {
+      t.string('username');
+      t.inherits('inheritedTable');
+    }).toSQL();
+    expect(tableSql[0].sql).to.equal('create table "inheriteeTable" ("username" varchar(255)) inherits ("inheritedTable")');
+  });
+
+  it('should warn on disallowed method', function() {
+    tableSql = client.schemaBuilder().createTable('users', function(t) {
+      t.string('username');
+      t.engine('myISAM');
+    }).toSQL();
+    expect(tableSql[0].sql).to.equal('create table "users" ("username" varchar(255))');
+  });
+
 });


### PR DESCRIPTION
Allow postgres tables to inherit. http://www.postgresql.org/docs/9.1/static/ddl-inherit.html