### PR TITLE
Warn when a migration does not return a promise

### DIFF
--- a/lib/migrate/index.js
+++ b/lib/migrate/index.js
@@ -7,6 +7,7 @@ var path     = require('path');
 var _        = require('lodash');
 var mkdirp   = require('mkdirp');
 var Promise  = require('../promise');
+var helpers  = require('../helpers');
 
 // Validates that migrations are present in the appropriate directories.
 function validateMigrationList(all, completed) {
@@ -16,6 +17,13 @@ function validateMigrationList(all, completed) {
       'The migration directory is corrupt, the following files are missing: ' + diff.join(', ')
     );
   }
+}
+
+function warnPromise(value, message) {
+  if (!value || typeof value.then !== 'function') {
+    helpers.warn(message);
+  }
+  return value;
 }
 
 // Ensure that we have 2 places for each of the date segments
@@ -240,7 +248,7 @@ Migrator.prototype._waterfallBatch = function(batchNo, migrations, direction) {
 
     // We're going to run each of the migrations in the current "up"
     current = current.then(function() {
-      return migration[direction](knex, Promise);
+      return warnPromise(migration[direction](knex, Promise), 'migration ' + name + ' did not return a promise');
     }).then(function() {
       log.push(path.join(directory, name));
       if (direction === 'up') {


### PR DESCRIPTION
Next major release this should be changed to an assertions. Can't see a reason you'd basically have a migration be a noop.