### PR TITLE
Added a fastForward migration method

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -92,7 +92,7 @@ gulp.task('build', function() {
 gulp.task('jshint', function () {
   gulp.src([
       '*.js', 'lib/**/*.js', 'test/**/*.js',
-      '!test/coverage/**/*.js', '!test/integration/migrate/migrations/*.js'
+      '!test/coverage/**/*.js', '!test/integration/migrate/migration/*.js'
     ])
     .pipe(jshint())
     .pipe(jshint.reporter('default'))

--- a/lib/migrate/index.js
+++ b/lib/migrate/index.js
@@ -58,10 +58,37 @@ function Migrator(knex) {
 Migrator.prototype.latest = Promise.method(function(config) {
   this.config = this.setConfig(config);
   return this._migrationData()
-    .tap(validateMigrationList)
-    .bind(this)
     .spread(function(all, completed) {
-      return this._runBatch(_.difference(all, completed), 'up');
+      return _.difference(all, completed);
+    })
+    .map(this._validateMigrationStructure)
+    .then(function(migrations) {
+      return this._getBatchNumber('up').then(function(batchNo) {
+        return this._waterfallBatch(batchNo, migrations, 'up');
+      });
+    });
+});
+
+// Fast forwards to the latest configuration.
+Migrator.prototype.fastForward = Promise.method(function(config) {
+  this.config = this.setConfig(config);
+
+  var batchNo;
+
+  return this._migrationData()
+    .spread(function(all, completed) {
+      return _.difference(all, completed);
+    })
+    .map(this._validateMigrationStructure)
+    .then(function(migrations) {
+      return this._getBatchNumber('up')
+        .then(function(result) {
+          batchNo = result;
+        })
+        .thenReturn(migrations);
+    })
+    .map(function(name) {
+      return this._updateMigrationStatus(batchNo, name, 'up');
     });
 });
 
@@ -69,11 +96,12 @@ Migrator.prototype.latest = Promise.method(function(config) {
 Migrator.prototype.rollback = Promise.method(function(config) {
   this.config = this.setConfig(config);
   return this._migrationData()
-    .tap(validateMigrationList)
-    .bind(this)
     .then(this._getLastBatch)
+    .map(this._validateMigrationStructure)
     .then(function(migrations) {
-      return this._runBatch(_.pluck(migrations, 'name'), 'down');
+      return this._getBatchNumber('down').then(function(batchNo) {
+        return this._waterfallBatch(batchNo, migrations, 'down');
+      });
     });
 });
 
@@ -144,20 +172,13 @@ Migrator.prototype._createMigrationTable = function(tableName) {
   });
 };
 
-// Run a batch of current migrations, in sequence.
-Migrator.prototype._runBatch = function(migrations, direction) {
-  return Promise.all(_.map(migrations, this._validateMigrationStructure, this))
+// Get a batch number for the current run of migrations.
+Migrator.prototype._getBatchNumber = function(direction) {
+  return this._latestBatchNumber()
     .bind(this)
-    .then(function(migrations) {
-      return Promise.bind(this)
-        .then(this._latestBatchNumber)
-        .then(function(batchNo) {
-          if (direction === 'up') batchNo++;
-          return batchNo;
-        })
-        .then(function(batchNo) {
-          return this._waterfallBatch(batchNo, migrations, direction);
-        });
+    .then(function (batchNo) {
+      if (direction === 'up') batchNo++;
+      return batchNo;
     });
 };
 
@@ -190,7 +211,9 @@ Migrator.prototype._migrationData = function() {
   return Promise.all([
     this._listAll(),
     this._listCompleted()
-  ]);
+  ])
+    .bind(this)
+    .tap(validateMigrationList);
 };
 
 // Generates the stub template for the current migration, returning a compiled template.
@@ -225,7 +248,8 @@ Migrator.prototype._getLastBatch = function() {
     .where('batch', function() {
       this.select(knex.raw('MAX(batch)')).from(tableName);
     })
-    .orderBy('id', 'desc');
+    .orderBy('id', 'desc')
+    .pluck('name');
 };
 
 // Returns the latest batch number.
@@ -236,11 +260,27 @@ Migrator.prototype._latestBatchNumber = function() {
     });
 };
 
+// Update migration database.
+Migrator.prototype._updateMigrationStatus = function(batchNo, name, direction) {
+  var knex = this.knex;
+  var tableName = this.config.tableName;
+
+  if (direction === 'up') {
+    return knex(tableName).insert({
+      name: name,
+      batch: batchNo,
+      migration_time: new Date()
+    });
+  }
+  if (direction === 'down') {
+    return knex(tableName).where({name: name}).del();
+  }
+};
+
 // Runs a batch of `migrations` in a specified `direction`,
 // saving the appropriate database information as the migrations are run.
 Migrator.prototype._waterfallBatch = function(batchNo, migrations, direction) {
   var knex      = this.knex;
-  var tableName = this.config.tableName;
   var directory = this._absoluteConfigDir();
   var current   = Promise.bind({failed: false, failedOn: 0});
   var log       = [];
@@ -253,18 +293,9 @@ Migrator.prototype._waterfallBatch = function(batchNo, migrations, direction) {
       return warnPromise(migration[direction](knex, Promise), 'migration ' + name + ' did not return a promise');
     }).then(function() {
       log.push(path.join(directory, name));
-      if (direction === 'up') {
-        return knex(tableName).insert({
-          name: name,
-          batch: batchNo,
-          migration_time: new Date()
-        });
-      }
-      if (direction === 'down') {
-        return knex(tableName).where({name: name}).del();
-      }
-    });
-  });
+      return this._updateMigrationStatus(batchNo, name, direction);
+    }.bind(this));
+  }.bind(this));
 
   return current.thenReturn([batchNo, log]);
 };


### PR DESCRIPTION
Moving this code to its own PR as there were no comments on it when linked in #279 and as new PR:s like #513 that relates to migrations are getting submitted.

For now we should probably **keep the general discussion about how to move forward with migrations in #279** and only have comments related to the code of specific PR in here. We might need many PR:s like this one to solve #279 as every contributor needs their own, but thats okay I think.

Also: This PR only adds a `knex.migrate.fastForward()` and refactors the migration system to minimize duplicated code in that method – the CLI tool requested in #279 has not been added – the CLI should in my opinion wait until a `knex.migrate.fastForward()` has been accepted.

**What does this PR add?**

This PR adds a `knex.migrate.fastForward()` method which just like `knex.migrate.latest()` creates a new batch and includes all non-run migrations in it, but unlike `knex.migrate.latest()` it doesn't actually execute any of the migrations.

I myself am interested in pairing `knex.migrate.fastForward()` with my projects' installation scripts to ensure that no old migration scripts gets run on fresh new installations – see eg. the scripts of my [one-page project](https://github.com/voxpelli/node-one-page/blob/master/lib/install-schema.js#L69) and [WebMention project](https://github.com/voxpelli/webpage-webmentions/blob/master/lib/install-schema.js#L67).
