### PR TITLE
Wraps migrations in transations

### DIFF
--- a/lib/migrate/index.js
+++ b/lib/migrate/index.js
@@ -155,6 +155,8 @@ Migrator.prototype._runBatch = function(migrations, direction) {
         })
         .then(function(batchNo) {
           return this._waterfallBatch(batchNo, migrations, direction);
+        }).catch(function(error) {
+          helpers.warn('migrations failed with error: ' + error.message);
         });
     });
 };
@@ -248,10 +250,9 @@ Migrator.prototype._waterfallBatch = function(batchNo, migrations, direction) {
 
     // We're going to run each of the migrations in the current "up"
     current = current.then(function() {
-      var transaction = knex.transaction(function(trx) {
-        return migration[direction](trx, Promise);
+      return knex.transaction(function(trx) {
+        return warnPromise(migration[direction](trx, Promise), 'migration ' + name + ' did not return a promise');
       });
-      return warnPromise(transaction, 'migration ' + name + ' did not return a promise');
     }).then(function() {
       log.push(path.join(directory, name));
       if (direction === 'up') {

--- a/lib/migrate/index.js
+++ b/lib/migrate/index.js
@@ -248,7 +248,10 @@ Migrator.prototype._waterfallBatch = function(batchNo, migrations, direction) {
 
     // We're going to run each of the migrations in the current "up"
     current = current.then(function() {
-      return warnPromise(migration[direction](knex, Promise), 'migration ' + name + ' did not return a promise');
+      var transaction = knex.transaction(function(trx) {
+        return migration[direction](trx, Promise);
+      });
+      return warnPromise(transaction, 'migration ' + name + ' did not return a promise');
     }).then(function() {
       log.push(path.join(directory, name));
       if (direction === 'up') {

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -68,13 +68,23 @@ module.exports = function(knex) {
                 }),
                 knex.schema.hasColumn(table, 'name').then(function(exists) {
                   expect(exists).to.equal(true);
-                }),
-                knex.schema.hasColumn(table, 'transaction').then(function(exists) {
-                  expect(exists).to.equal(false);
                 })
               ]);
             }
           });
+        });
+      });
+
+      it('should not create column for invalid migration', function() {
+        knex.schema.hasColumn('migration_test_1', 'transaction').then(function(exists) {
+          // MySQL commits transactions implicit for most common
+          // migration statements (e.g. CREATE TABLE, ALTER TABLE, DROP TABLE),
+          // so we need to check for dialect
+          if (knex.toString() === '[object Knex:mysql]') {
+            expect(exists).to.equal(true);
+          } else {
+            expect(exists).to.equal(false);
+          }
         });
       });
 

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -68,10 +68,19 @@ module.exports = function(knex) {
                 }),
                 knex.schema.hasColumn(table, 'name').then(function(exists) {
                   expect(exists).to.equal(true);
+                }),
+                knex.schema.hasColumn(table, 'transaction').then(function(exists) {
+                  expect(exists).to.equal(false);
                 })
               ]);
             }
           });
+        });
+      });
+
+      it('should not proceed after invalid migration', function() {
+        return knex.schema.hasTable('should_not_be_run').then(function(exists) {
+          expect(exists).to.equal(false);
         });
       });
 

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -80,7 +80,7 @@ module.exports = function(knex) {
           // MySQL commits transactions implicit for most common
           // migration statements (e.g. CREATE TABLE, ALTER TABLE, DROP TABLE),
           // so we need to check for dialect
-          if (knex.toString() === '[object Knex:mysql]') {
+          if (knex.client.dialect === 'mysql') {
             expect(exists).to.equal(true);
           } else {
             expect(exists).to.equal(false);

--- a/test/integration/migrate/test/20150109002832_invalid_migration.js
+++ b/test/integration/migrate/test/20150109002832_invalid_migration.js
@@ -1,0 +1,11 @@
+'use strict';
+
+exports.up = function(knex) {
+  return knex.schema.table('migration_test_1', function (table) {
+      table.string('transaction');
+    }).raw('SELECT foo FROM unknown_table');
+};
+
+exports.down = function() {
+
+};

--- a/test/integration/migrate/test/20150109095253_migration_after_invalid.js
+++ b/test/integration/migrate/test/20150109095253_migration_after_invalid.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('should_not_be_run', function(t) {
+      t.increments();
+      t.string('name');
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('should_not_be_run');
+};


### PR DESCRIPTION
Hey,

I thought solving #567 would be a great start for contributing to `knex`, as I found this lovely project looking for a migration tool.

Tests are still running for me, but does anyone has a good idea on how to simulate a broken migration?
Thought about changing a column type, e.g. `enum` to `timestamp`, shouldn't have an automated conversion.
Seems not clean, though.

Hope to provide more contribution soon!