### PR TITLE
Small grammatical change in index.html ("its self" >> "itself")

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,7 +370,7 @@ $ npm install sqlite3
     <h3 id="Installation-client">Initializing the Library</h3>
 
     <p>
-      The <tt>knex</tt> module is its self a function which takes a configuration object for
+      The <tt>knex</tt> module is itself a function which takes a configuration object for
       Knex, accepting a few parameters. The <tt>client</tt> parameter is required
       and determines which client adapter will be used with the library.
     </p>


### PR DESCRIPTION
Changed "its self" to "itself" under "Initializing the Library."