### PR TITLE
Fix bare subqueries in insert statements.

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -40,7 +40,7 @@ Formatter.prototype.checkRaw = function(value, parameter) {
   if (value instanceof QueryBuilder) {
     var query = value.toSQL();
     if (query.bindings) push.apply(this.bindings, query.bindings);
-    return this.outputQuery(query);
+    return this.outputQuery(query, parameter);
   }
   if (value instanceof Raw) {
     if (value.bindings) push.apply(this.bindings, value.bindings);

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -731,7 +731,7 @@ module.exports = function(qb, clientName, aliasName) {
         default: 'select * from "users" having "email" > ?'
       });
     });
-    
+
     it("nested having", function() {
       testsql(qb().select('*').from('users').having(function(){
         this.where('email', '>', 1);
@@ -740,7 +740,7 @@ module.exports = function(qb, clientName, aliasName) {
         default: 'select * from "users" having ("email" > ?)'
       });
     });
-    
+
     it("nested or havings", function() {
       testsql(qb().select('*').from('users').having(function(){
         this.where('email', '>', 10);
@@ -2131,6 +2131,22 @@ module.exports = function(qb, clientName, aliasName) {
             bindings: []
           }
         });
+    });
+
+    it('allows insert values of sub-select without raw, #627', function() {
+      testsql(qb().table('entries').insert({
+        secret: 123,
+        sequence: qb().count('*').from('entries').where('secret', 123)
+      }), {
+        mysql: {
+          sql: 'insert into `entries` (`secret`, `sequence`) values (?, (select count(*) from `entries` where `secret` = ?))',
+          bindings: [123, 123]
+        },
+        default: {
+          sql: 'insert into "entries" ("secret", "sequence") values (?, (select count(*) from "entries" where "secret" = ?))',
+          bindings: [123, 123]
+        }
+      });
     });
 
   });


### PR DESCRIPTION
This updates `Formatter#checkRaw()` to pass the `parameter` flag to `outputQuery()` as `alwaysWrapped`.

Fixes #627.