### PR TITLE
Added schema dump/load/drop/create/reset

### DIFF
--- a/knex.js
+++ b/knex.js
@@ -149,6 +149,14 @@ Knex.initialize = function(config) {
       }
     },
 
+    // Lazy-load / return a `SchemaLoader` object.
+    schemaLoader: {
+      get: function() {
+        if (!client.SchemaLoader) client.initSchemaLoader();
+        return new client.SchemaLoader(knex);
+      }
+    },
+
     // Lazy-load / return a `Seeder` object.
     seed: {
       get: function() {

--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -50,7 +50,7 @@ function initKnex(env) {
   var environment = commander.env || process.env.NODE_ENV;
   var defaultEnv  = 'development';
   var config      = require(env.configPath);
-  
+
   if (!environment && typeof config[defaultEnv] === 'object') {
     environment = defaultEnv;
   }
@@ -146,6 +146,51 @@ function invoke(env) {
     .action(function () {
       pending = initKnex(env).migrate.currentVersion().then(function(version) {
         success(chalk.green('Current Version: ') + chalk.blue(version));
+      }).catch(exit);
+    });
+
+  commander
+    .command('schema:dump')
+    .description('       Dump the current database schema.')
+    .action(function() {
+      pending = initKnex(env).schemaLoader.dump().then(function() {
+        success(chalk.green('Dumped schema successfully'));
+      }).catch(exit);
+    });
+
+  commander
+    .command('schema:load')
+    .description('       Load the schema into the database.')
+    .action(function() {
+      pending = initKnex(env).schemaLoader.load().then(function() {
+        success(chalk.green('Loaded schema successfully'));
+      }).catch(exit);
+    });
+
+  commander
+    .command('schema:drop')
+    .description('       Drop the current database schema.')
+    .action(function() {
+      pending = initKnex(env).schemaLoader.drop().then(function() {
+        success(chalk.green('Dropped schema successfully'));
+      }).catch(exit);
+    });
+
+  commander
+    .command('schema:create')
+    .description('       Create the current database schema.')
+    .action(function() {
+      pending = initKnex(env).schemaLoader.create().then(function() {
+        success(chalk.green('Created schema successfully'));
+      }).catch(exit);
+    });
+
+  commander
+    .command('schema:reset')
+    .description('       Reset the current database schema (drop, create, load).')
+    .action(function() {
+      pending = initKnex(env).schemaLoader.reset().then(function() {
+        success(chalk.green('Schema reset successfully'));
       }).catch(exit);
     });
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -17,6 +17,7 @@ function Client(config) {
   this.initTransaction();
   this.initQuery();
   this.migrationConfig = _.clone(config && config.migrations);
+  this.schemaConfig = _.clone(config && config.schema);
   this.seedConfig = _.clone(config && config.seeds);
 }
 inherits(Client, EventEmitter);

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -76,6 +76,11 @@ Client_MySQL.prototype.initSchema = function() {
   require('./schema')(this);
 };
 
+// Lazy-load the schema loader dependency
+Client_MySQL.prototype.initSchemaLoader = function() {
+  require('./schema/loader')(this);
+};
+
 // Lazy-load the migration dependency
 Client_MySQL.prototype.initMigrator = function() {
     require('./migrator')(this);

--- a/lib/dialects/mysql/schema/loader.js
+++ b/lib/dialects/mysql/schema/loader.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = function(client) {
+
+  var SchemaLoader = require('../../../schema/loader');
+  var inherits = require('inherits');
+
+  function SchemaLoader_MySQL() {
+    this.client = client;
+    SchemaLoader.apply(this, arguments);
+  }
+  inherits(SchemaLoader_MySQL, SchemaLoader);
+
+  client.SchemaLoader = SchemaLoader_MySQL;
+
+};

--- a/lib/migrate/index.js
+++ b/lib/migrate/index.js
@@ -45,7 +45,7 @@ function Migrator(knex) {
 }
 
 // Migrators to the latest configuration.
-Migrator.prototype.latest = Promise.method(function(config) {
+Migrator.prototype.latest = Promise.method(function(config) {  
   this.config = this.setConfig(config);
   return this._migrationData()
     .tap(validateMigrationList)

--- a/lib/schema/loader.js
+++ b/lib/schema/loader.js
@@ -1,0 +1,83 @@
+"use strict";
+
+var fs       = require('fs');
+var path     = require('path');
+var _        = require('lodash');
+var Promise  = require('../promise');
+
+var exec = Promise.promisify(require('child_process').exec);
+
+// The new load we're performing, typically called from the `knex.schema`
+// interface on the main `knex` object. Passes the `knex` instance performing
+// the migration.
+function Loader(knex) {
+  this.knex   = knex;
+  this.connectionSettings = knex.client.connectionSettings;
+  this.config = this.setConfig(knex.client.schemaConfig);
+}
+
+function dump(settings, filename) {
+  var commands = ['mysqldump', '-u' + settings.user, '--no-data', settings.database, '>', filename];
+  var command = commands.join(' ');
+  return exec(command);
+}
+
+function load(settings, filename) {
+  var commands = ['mysql', '-u' + settings.user, settings.database, '<', filename];
+  var command = commands.join(' ');
+  return exec(command);
+}
+
+function drop(settings) {
+  var commands = ['mysql', '-u' + settings.user, '-e', '"DROP DATABASE IF EXISTS ' + settings.database + ';"'];
+  var command = commands.join(' ');
+  return exec(command);
+}
+
+function create(settings) {
+  var commands = ['mysql', '-u' + settings.user, '-e', '"CREATE DATABASE IF NOT EXISTS ' + settings.database + ';"'];
+  var command = commands.join(' ');
+  return exec(command);
+}
+
+// Dump the schema from the database into a file
+Loader.prototype.dump = Promise.method(function(config) {
+  this.config = this.setConfig(config);
+  return dump(this.connectionSettings, this.config.filename);
+});
+
+// Load the schema into the database
+Loader.prototype.load = Promise.method(function(config) {
+  this.config = this.setConfig(config);
+  return load(this.connectionSettings, this.config.filename);
+});
+
+// Drop the current schema
+Loader.prototype.drop = Promise.method(function(config) {
+  this.config = this.setConfig(config);
+  return drop(this.connectionSettings);
+});
+
+// Create the current schema
+Loader.prototype.create = Promise.method(function(config) {
+  this.config = this.setConfig(config);
+  return create(this.connectionSettings);
+});
+
+// Reset the current schema (drop, create, load)
+Loader.prototype.reset = Promise.method(function(config) {
+  var settings = this.connectionSettings;
+  var config = this.config = this.setConfig(config);
+  return drop(settings).then(function() {
+    return create(settings);
+  }).then(function() {
+    return load(settings, config.filename);
+  });
+});
+
+
+Loader.prototype.setConfig = function(config) {
+  return _.extend({}, this.config || {}, config);
+};
+
+module.exports = Loader;


### PR DESCRIPTION
I created a few more command line commands that mirror Rails commands I frequently used.
* knex schema:dump = Dump the schema the DB to an .sql file
* knex schema:load = Load the schema in a .sql file into the DB
* knex schema:create = Create the schema in the DB
* knex schema:drop = Drop the schema from the DB
* knex schema:reset = Run drop, create and load in sequence