### PR TITLE
Respect union wrap parameter as last argument

### DIFF
--- a/index.html
+++ b/index.html
@@ -1014,9 +1014,10 @@ knex.select('*').from('users').limit(10).offset(30)
 </pre>
 
     <p id="Builder-union">
-      <b class="header">union</b><code>.union(query)</code>
+      <b class="header">union</b><code>.union([*queries], [wrap])</code>
       <br />
-      Creates a <tt>union</tt> query, taking a callback to build the union statement.
+      Creates a <tt>union</tt> query, taking an array or a list of callbacks to build the union statement, with optional
+      boolean wrap. The queries will be individually wrapped in parentheses with a <tt>true</tt> wrap parameter.
     </p>
 
 <pre class="display">

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -450,11 +450,11 @@ QueryBuilder.prototype.union = function(callbacks, wrap) {
       });
     }
   } else {
-    callbacks = _.toArray(arguments).slice(0, arguments.length - 2);
+    callbacks = _.toArray(arguments).slice(0, arguments.length - 1);
     wrap = arguments[arguments.length - 1];
     if (!_.isBoolean(wrap)) {
       callbacks.push(wrap);
-      wrap = undefined;
+      wrap = false;
     }
     this.union(callbacks, wrap);
   }

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -435,21 +435,29 @@ QueryBuilder.prototype.orderByRaw = function(sql, bindings) {
 };
 
 // Add a union statement to the query.
-QueryBuilder.prototype.union = function(callback, wrap) {
-  if (arguments.length > 1) {
-    var args = new Array(arguments.length);
-    for (var i = 0, l = args.length; i < l; i++) {
-      args[i] = arguments[i];
-      this.union(args[i]);
+QueryBuilder.prototype.union = function(callbacks, wrap) {
+  if (arguments.length === 1 ||
+      (arguments.length === 2 && _.isBoolean(wrap))) {
+    if (!_.isArray(callbacks)) {
+      callbacks = [callbacks];
     }
-    return this;
+    for (var i = 0, l = callbacks.length; i < l; i++) {
+      this._statements.push({
+        grouping: 'union',
+        clause: 'union',
+        value: callbacks[i],
+        wrap: wrap || false
+      });
+    }
+  } else {
+    callbacks = _.toArray(arguments).slice(0, arguments.length - 2);
+    wrap = arguments[arguments.length - 1];
+    if (!_.isBoolean(wrap)) {
+      callbacks.push(wrap);
+      wrap = undefined;
+    }
+    this.union(callbacks, wrap);
   }
-  this._statements.push({
-    grouping: 'union',
-    clause: 'union',
-    value: callback,
-    wrap: wrap || false
-  });
   return this;
 };
 

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -476,6 +476,24 @@ module.exports = function(qb, clientName, aliasName) {
       });
     });
 
+    it("wraps unions", function() {
+      var wrappedChain = qb().select('*').from('users').where('id', 'in', function() {
+        this.table('users').max("id").union(function() {
+          this.table('users').min("id");
+        }, true);
+      });
+      testsql(wrappedChain, {
+        mysql: {
+          sql: 'select * from `users` where `id` in (select max(`id`) from `users` union (select min(`id`) from `users`))',
+          bindings: []
+        },
+        default: {
+          sql: 'select * from "users" where "id" in (select max("id") from "users" union (select min("id") from "users"))',
+          bindings: []
+        }
+      });
+    });
+
     // it("handles grouped mysql unions", function() {
     //   chain = myqb().union(
     //     raw(myqb().select('*').from('users').where('id', '=', 1)).wrap('(', ')'),


### PR DESCRIPTION
union's wrap parameter was being ignored and misinterpreted when
building statements.  Maintain the spirit of the original implementation
(variable number of callbacks) consistent with other instances of
variadic-like behavior (select/columns), including handling list of
callbacks in array, while still processing the wrap parameter.

Updated documentation which was missing a reference to wrap, and
provided a unit test for wrapped unions.