### PR TITLE
Don't call .then on promises when not giving callbacks

### DIFF
--- a/lib/interface.js
+++ b/lib/interface.js
@@ -24,6 +24,7 @@ Target.prototype._formatQuery = function(sql, bindings, tz) {
 // Create a new instance of the `Runner`, passing in the current object.
 Target.prototype.then = function(onFulfilled, onRejected) {
   var Runner = this.client.Runner;
+  if (arguments.length === 0) { return new Runner(this).run(); }
   return new Runner(this).run().then(onFulfilled, onRejected);
 };
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -77,19 +77,21 @@ require('./interface')(Transaction);
 Transaction.prototype.then = function(onFulfilled, onRejected) {
   var Runner  = this.client.Runner;
   var promise = this;
-  
+    
   // Create a new "runner" object, passing the "runner"
   // object along, so we can easily keep track of every
   // query run on the current connection.
-  return new Runner(this)
+  var runner = new Runner(this)
     .startTransaction()
     .then(function(obj) {
       return promise.containerObject(obj);
     })
     .then(function(obj) {
       return promise.initiateDeferred(obj);
-    })
-    .then(onFulfilled, onRejected);
+    });
+
+  if (arguments.length === 0) { return runner; }
+  return runner.then(onFulfilled, onRejected);
 };
 
 module.exports = Transaction;


### PR DESCRIPTION
This gets rid of the warning spam when running tests due to the (ab?)use of promise.then() in the .then-wrapping code