### PR TITLE
Fix migration bug where database is empty

### DIFF
--- a/lib/migrate/index.js
+++ b/lib/migrate/index.js
@@ -10,7 +10,9 @@ var Promise  = require('../promise');
 var helpers  = require('../helpers');
 
 // Validates that migrations are present in the appropriate directories.
-function validateMigrationList(all, completed) {
+function validateMigrationList(migrations) {
+  var all = migrations[0];
+  var completed = migrations[1];
   var diff = _.difference(completed, all);
   if (!_.isEmpty(diff)) {
     throw new Error(


### PR DESCRIPTION
The function `validateMigrationList()` should be given one parameter (an array of the promises returned by `Promise.all()`), rather than two arguments as was previously the case. 

This fixed an error I was having and then I was unable to reproduce it.