### PR TITLE
whereNot and orWhereNot added

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
 
       <li><b><a href="#Builder-wheres">Where Methods:</a></b></li>
       <li>&nbsp;&nbsp;- <a href="#Builder-where">where</a></li>
+      <li>&nbsp;&nbsp;- <a href="#Builder-where">whereNot</a></li>
       <li>&nbsp;&nbsp;- <a href="#Builder-whereIn">whereIn</a></li>
       <li>&nbsp;&nbsp;- <a href="#Builder-whereNotIn">whereNotIn</a></li>
       <li>&nbsp;&nbsp;- <a href="#Builder-whereNull">whereNull</a></li>
@@ -611,6 +612,55 @@ var subquery = knex('users').where('votes', '>', 100).andWhere('status', 'active
 
 knex('accounts').where('id', 'in', subquery)
 </pre>
+
+
+
+    <p id="Builder-whereNot">
+      <b class="header">whereNot</b><code>.whereNot(~mixed~)</code>
+    </p>
+
+    <p class="title">Object Syntax:</p>
+
+<pre class="display">
+knex('users').whereNot({
+  first_name: 'Test',
+  last_name:  'User'
+}).select('id')
+</pre>
+
+    <p class="title">Key, Value:</p>
+
+<pre class="display">
+knex('users').whereNot('id', 1)
+</pre>
+
+    <p class="title">Grouped Chain:</p>
+
+<pre class="display">
+knex('users').whereNot(function() {
+  this.where('id', 1).orWhereNot('id', '>', 10)
+}).orWhereNot({name: 'Tester'})
+</pre>
+
+    <p class="title">Operator:</p>
+
+<pre class="display">
+knex('users').whereNot('votes', '>', 100)
+</pre>
+
+<p>
+  CAVEAT:
+  WhereNot is not suitable for "in" and "between" type subqueries. You should use "not in" and "not between" instead.
+</p>
+
+<pre class="display">
+var subquery = knex('users').whereNot('votes', '>', 100).andWhere('status', 'active').orWhere('name', 'John').select('id');
+
+<span style='text-decoration:line-through'>knex('accounts').whereNot('id', 'in', subquery)</span>
+  knex('accounts').where('id', 'not in', subquery)
+</pre>
+
+
 
     <p id="Builder-whereIn">
       <b class="header">whereIn</b><code>.whereIn(column, array|callback|builder) / .orWhereIn</code><br />

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -215,6 +215,7 @@ QueryBuilder.prototype.andWhere = function(column, operator, value) {
     column: column,
     operator: operator,
     value: value,
+    not: this._not(),
     bool: this._bool()
   });
   return this;
@@ -223,6 +224,17 @@ QueryBuilder.prototype.andWhere = function(column, operator, value) {
 QueryBuilder.prototype.orWhere = function() {
   return this._bool('or').where.apply(this, arguments);
 };
+
+// Adds an `not where` clause to the query.
+QueryBuilder.prototype.whereNot = function() {
+  return this._not(true).where.apply(this, arguments);
+};
+
+// Adds an `or not where` clause to the query.
+QueryBuilder.prototype.orWhereNot = function() {
+  return this._bool('or').whereNot.apply(this, arguments);
+};
+
 
 // Processes an object literal provided in a "where" clause.
 QueryBuilder.prototype._objectWhere = function(obj) {
@@ -255,10 +267,12 @@ QueryBuilder.prototype.whereWrapped = function(callback) {
     grouping: 'where',
     type: 'whereWrapped',
     value: callback,
+    not: this._not(),
     bool: this._bool()
   });
   return this;
 };
+
 
 // Helper for compiling any advanced `having` queries.
 QueryBuilder.prototype.havingWrapped = function(callback) {

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -226,6 +226,7 @@ QueryBuilder.prototype.orWhere = function() {
 };
 
 // Adds an `not where` clause to the query.
+QueryBuilder.prototype.andWhereNot =
 QueryBuilder.prototype.whereNot = function() {
   return this._not(true).where.apply(this, arguments);
 };
@@ -239,8 +240,9 @@ QueryBuilder.prototype.orWhereNot = function() {
 // Processes an object literal provided in a "where" clause.
 QueryBuilder.prototype._objectWhere = function(obj) {
   var boolVal = this._bool();
+  var notVal = this._not() ? 'Not' : '';
   for (var key in obj) {
-    this[boolVal + 'Where'](key, obj[key]);
+    this[boolVal + 'Where' + notVal](key, obj[key]);
   }
   return this;
 };

--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -320,7 +320,8 @@ QueryCompiler.prototype.whereNull = function(statement) {
 
 // Compiles a basic "where" clause.
 QueryCompiler.prototype.whereBasic = function(statement) {
-  return this.formatter.wrap(statement.column) + ' ' +
+  return this._not(statement, '') +
+    this.formatter.wrap(statement.column) + ' ' +
     this.formatter.operator(statement.operator) + ' ' +
     this.formatter.parameter(statement.value);
 };
@@ -330,7 +331,7 @@ QueryCompiler.prototype.whereExists = function(statement) {
 };
 
 QueryCompiler.prototype.whereWrapped = function(statement) {
-  return '(' + this.formatter.rawOrFn(statement.value, 'where').slice(6) + ')';
+  return this._not(statement, '') + '(' + this.formatter.rawOrFn(statement.value, 'where').slice(6) + ')';
 };
 
 QueryCompiler.prototype.whereBetween = function(statement) {

--- a/lib/query/methods.js
+++ b/lib/query/methods.js
@@ -24,6 +24,8 @@ module.exports = [
   'where',
   'andWhere',
   'orWhere',
+  'whereNot',
+  'orWhereNot',
   'whereRaw',
   'whereWrapped',
   'havingWrapped',

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -126,6 +126,64 @@ module.exports = function(qb, clientName, aliasName) {
       });
     });
 
+
+    it("where not", function() {
+      testsql(qb().select('*').from('users').whereNot('id', '=', 1), {
+        mysql: {
+          sql: 'select * from `users` where not `id` = ?',
+          bindings: [1]
+        },
+        default: {
+          sql: 'select * from "users" where not "id" = ?',
+          bindings: [1]
+        }
+      });
+
+      testquery(qb().select('*').from('users').whereNot('id', '=', 1), {
+        mysql: 'select * from `users` where not `id` = 1',
+        postgres: 'select * from "users" where not "id" = \'1\'',
+        default: 'select * from "users" where not "id" = 1'
+      });
+    });
+
+    it("grouped or where not", function() {
+      testsql(qb().select('*').from('users').whereNot(function() { this.where('id', '=', 1).orWhereNot('id', '=', 3); } ), {
+        mysql: {
+          sql: 'select * from `users` where not (`id` = ? or not `id` = ?)',
+          bindings: [1, 3]
+        },
+        default: {
+          sql: 'select * from "users" where not ("id" = ? or not "id" = ?)',
+          bindings: [1, 3]
+        }
+      });
+
+      testquery(qb().select('*').from('users').whereNot(function() { this.where('id', '=', 1).orWhereNot('id', '=', 3); } ), {
+        mysql: 'select * from `users` where not (`id` = 1 or not `id` = 3)',
+        postgres: 'select * from "users" where not ("id" = \'1\' or not "id" = \'3\')',
+        default: 'select * from "users" where not ("id" = 1 or not "id" = 3)'
+      });
+    });
+
+    it("grouped or where not alternate", function() {
+      testsql(qb().select('*').from('users').where(function() { this.where('id', '=', 1).orWhereNot('id', '=', 3); } ), {
+        mysql: {
+          sql: 'select * from `users` where (`id` = ? or not `id` = ?)',
+          bindings: [1, 3]
+        },
+        default: {
+          sql: 'select * from "users" where ("id" = ? or not "id" = ?)',
+          bindings: [1, 3]
+        }
+      });
+
+      testquery(qb().select('*').from('users').where(function() { this.where('id', '=', 1).orWhereNot('id', '=', 3); } ), {
+        mysql: 'select * from `users` where (`id` = 1 or not `id` = 3)',
+        postgres: 'select * from "users" where ("id" = \'1\' or not "id" = \'3\')',
+        default: 'select * from "users" where ("id" = 1 or not "id" = 3)'
+      });
+    });
+
     it('where bool', function() {
       testquery(qb().select('*').from('users').where(true), {
         mysql: 'select * from `users` where true',

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -147,7 +147,7 @@ module.exports = function(qb, clientName, aliasName) {
     });
 
     it("grouped or where not", function() {
-      testsql(qb().select('*').from('users').whereNot(function() { this.where('id', '=', 1).orWhereNot('id', '=', 3); } ), {
+      testsql(qb().select('*').from('users').whereNot(function() { this.where('id', '=', 1).orWhereNot('id', '=', 3); }), {
         mysql: {
           sql: 'select * from `users` where not (`id` = ? or not `id` = ?)',
           bindings: [1, 3]
@@ -158,7 +158,7 @@ module.exports = function(qb, clientName, aliasName) {
         }
       });
 
-      testquery(qb().select('*').from('users').whereNot(function() { this.where('id', '=', 1).orWhereNot('id', '=', 3); } ), {
+      testquery(qb().select('*').from('users').whereNot(function() { this.where('id', '=', 1).orWhereNot('id', '=', 3); }), {
         mysql: 'select * from `users` where not (`id` = 1 or not `id` = 3)',
         postgres: 'select * from "users" where not ("id" = \'1\' or not "id" = \'3\')',
         default: 'select * from "users" where not ("id" = 1 or not "id" = 3)'
@@ -166,7 +166,7 @@ module.exports = function(qb, clientName, aliasName) {
     });
 
     it("grouped or where not alternate", function() {
-      testsql(qb().select('*').from('users').where(function() { this.where('id', '=', 1).orWhereNot('id', '=', 3); } ), {
+      testsql(qb().select('*').from('users').where(function() { this.where('id', '=', 1).orWhereNot('id', '=', 3); }), {
         mysql: {
           sql: 'select * from `users` where (`id` = ? or not `id` = ?)',
           bindings: [1, 3]
@@ -177,12 +177,33 @@ module.exports = function(qb, clientName, aliasName) {
         }
       });
 
-      testquery(qb().select('*').from('users').where(function() { this.where('id', '=', 1).orWhereNot('id', '=', 3); } ), {
+      testquery(qb().select('*').from('users').where(function() { this.where('id', '=', 1).orWhereNot('id', '=', 3); }), {
         mysql: 'select * from `users` where (`id` = 1 or not `id` = 3)',
         postgres: 'select * from "users" where ("id" = \'1\' or not "id" = \'3\')',
         default: 'select * from "users" where ("id" = 1 or not "id" = 3)'
       });
     });
+
+
+    it("where not object", function() {
+      testsql(qb().select('*').from('users').whereNot({first_name: 'Test', last_name: 'User'}), {
+        mysql: {
+          sql: 'select * from `users` where not `first_name` = ? and not `last_name` = ?',
+          bindings: ['Test', 'User']
+        },
+        default: {
+          sql: 'select * from "users" where not "first_name" = ? and not "last_name" = ?',
+          bindings: ['Test', 'User']
+        }
+      });
+
+      testquery(qb().select('*').from('users').whereNot({first_name: 'Test', last_name: 'User'}), {
+        mysql: 'select * from `users` where not `first_name` = \'Test\' and not `last_name` = \'User\'',
+        postgres: 'select * from "users" where not "first_name" = \'Test\' and not "last_name" = \'User\'',
+        default: 'select * from "users" where not "first_name" = \'Test\' and not "last_name" = \'User\''
+      });
+    });
+
 
     it('where bool', function() {
       testquery(qb().select('*').from('users').where(true), {


### PR DESCRIPTION
whereNot, orWhereNot methods added to single and wrapped wheres. Related tests are also added.

Example:

    var result = knex.whereNot(function() {
        this.where('a', '=', 1).orWhereNot('b', '=', 3);
    });

Produces:

    ... where not (a = 1 or not b = 3)

Note: I could not be sure how to update documentation. So I didn't add documentation to the repository. Below is documentation necessary:

whereNot.    whereNot(~mixed~)

Object Syntax:

    knex('users').whereNot({
        first_name: 'Test',
        last_name:  'User'
    }).select('id')


Outputs:
    select "id" from "users" where not "first_name" = 'Test' and not "last_name" = 'User'
Key, Value:

knex('users').whereNot('id', 1)


Outputs:
    select * from "users" where not "id" = '1'
Grouped Chain:

    knex('users').whereNot(function() {
        this.where('id', 1).whereNot('id', '>', 10)
    }).orWhereNot({name: 'Tester'})


Outputs:
    select * from "users" where not("id" = '1' or "id" > '10') or not "name" = 'Tester'
Operator:

    knex('users').whereNot('votes', '>', 100)


Outputs:
    select * from "users" where not "votes" > '100'

CAVEAT and TODO:
WhereNot is not suitable for "in" and "between" type subqueries. You should use "not in" and "not between" instead.
var subquery = knex('users').whereNot('votes', '>', 100).andWhere('status', 'active').orWhere('name', 'John').select('id');

knex('accounts').whereNot('id', 'in', subquery)


Outputs: (CAVEAT: Should produce "not in", but is not.)
    select * from "accounts" where "id" in (select "id" from "users" where not "votes" > '100' and "status" = 'active' or "name" = 'John')