### PR TITLE
Allow to turn off debugging for the query chain

### DIFF
--- a/index.html
+++ b/index.html
@@ -1337,9 +1337,10 @@ knex('accounts').truncate()
 </pre>
 
     <p id="Builder-debug">
-      <b class="header">debug</b><code>.debug()</code>
+      <b class="header">debug</b><code>.debug([flag])</code>
       <br />
-      Turns on debugging for the current query chain.
+      Turns debugging on (by default) or off for the current query chain.
+      One-time debug muting might be useful in case of especially long queries.
     </p>
 
     <p id="Builder-connection">

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -44,7 +44,10 @@ Target.prototype.connection = function(connection) {
 
 // Set a debug flag for the current schema query stack.
 Target.prototype.debug = function(val) {
-  this._debug = (val === undefined || val === null) ? true : val;
+  if (arguments.length && typeof val !== 'boolean') {
+    throw new Error('Argument must be a boolean');
+  }
+  this._debug = arguments.length ? val : true;
   return this;
 };
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -153,7 +153,10 @@ Runner.prototype.debug = function(obj) {
 
 // Check whether we're "debugging", based on either calling `debug` on the query.
 Runner.prototype.isDebugging = function() {
-  return (this.client.isDebugging === true || this.builder._debug === true);
+  return (
+    (this.client.isDebugging === true && this.builder._debug !== false) ||
+    this.builder._debug === true
+  );
 };
 
 // Transaction Methods:


### PR DESCRIPTION
Fixes #725

Bottom line: I wasted a lot of time trying to figure out why I can't control logging in transactions, then I realized I need to run `.debug` method on the transaction promise itself.