### PR TITLE
Removes semicolon from example, allows it to render correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -772,7 +772,7 @@ knex.select('*').from('users').join('accounts', function() {
   If you need to use a literal value (string, number, or boolean) in a join instead of a column, use <tt>knex.raw</tt>.
 
   <pre class="display">
-  knex.select('*').from('users').join('accounts', 'accounts.type', knex.raw('?', ['admin']));
+  knex.select('*').from('users').join('accounts', 'accounts.type', knex.raw('?', ['admin']))
   </pre>
 
     <p id="Builder-innerJoin">


### PR DESCRIPTION
There's a trailing semicolon on this JS sample which was preventing it from rendering the generated SQL below.