### PR TITLE
Adds test for escaping MySQL column names containing backticks

### DIFF
--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -2273,15 +2273,15 @@ module.exports = function(qb, clientName, aliasName) {
 
     it('escapes queries properly, #737', function() {
       testsql(qb()
-        .select('id","name')
-        .from('test'),
+        .select('id","name', 'id`name')
+        .from('test`'),
         {
           mysql: {
-            sql: 'select `id","name` from `test`',
+            sql: 'select `id","name`, `id``name` from `test```',
             bindings: []
           },
           default: {
-            sql: 'select "id"",""name" from "test"',
+            sql: 'select "id"",""name", "id`name" from "test`"',
             bindings: []
           }
         });


### PR DESCRIPTION
- MySQL column and table names can contain backticks.
- They are escaped with a double-backtick, just like how PGSQL escapes doublequotes
- I am not 100% sure that the `default` SQL in this test is correct.  Someone should double-check