### PR TITLE
Don't use camelCase in aliased column names

### DIFF
--- a/lib/migrate/index.js
+++ b/lib/migrate/index.js
@@ -231,8 +231,8 @@ Migrator.prototype._getLastBatch = function() {
 // Returns the latest batch number.
 Migrator.prototype._latestBatchNumber = function() {
   return this.knex(this.config.tableName)
-    .max('batch as batchNo').then(function(obj) {
-      return (obj[0].batchNo || 0);
+    .max('batch as max_batch').then(function(obj) {
+      return (obj[0].max_batch || 0);
     });
 };
 


### PR DESCRIPTION
The query to get the highest batch aliases the field to a camel-case name (`select max(batch) as batchNo`). Since Redshift downcases table and column names, the result comes back as `batchno` instead of `batchNo`. Using a snake-cased name instead fixes this.

Closes #758