### PR TITLE
allows array value given to .where to be treated as .whereIn by the queryBuilder

### DIFF
--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -175,8 +175,8 @@ QueryBuilder.prototype.andWhere = function(column, operator, value) {
   // are explicitly two arguments passed, so it's not possible to
   // do where('key', '!=') and have that turn into where key != null
   if (arguments.length === 2) {
-    value    = operator;
-    operator = '=';
+    value = operator;
+    operator = Array.isArray(value) ? 'in' : '=';
 
     // If the value is null, and it's a two argument query,
     // we assume we're going for a `whereNull`.
@@ -189,14 +189,12 @@ QueryBuilder.prototype.andWhere = function(column, operator, value) {
   var checkOperator = ('' + operator).toLowerCase().trim();
 
   // If there are 3 arguments, check whether 'in' is one of them.
-  if (arguments.length === 3) {
     if (checkOperator === 'in' || checkOperator === 'not in') {
-      return this._not(checkOperator === 'not in').whereIn(arguments[0], arguments[2]);
+      return this._not(checkOperator === 'not in').whereIn(column, value);
     }
     if (checkOperator === 'between' || checkOperator === 'not between') {
-      return this._not(checkOperator === 'not between').whereBetween(arguments[0], arguments[2]);
+      return this._not(checkOperator === 'not between').whereBetween(column, value);
     }
-  }
 
   // If the value is still null, check whether they're meaning
   // where value is null

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -126,7 +126,6 @@ module.exports = function(qb, clientName, aliasName) {
       });
     });
 
-
     it("where not", function() {
       testsql(qb().select('*').from('users').whereNot('id', '=', 1), {
         mysql: {
@@ -340,6 +339,25 @@ module.exports = function(qb, clientName, aliasName) {
           sql: 'select * from "users" where "id" in (?, ?, ?)',
           bindings: [1, 2, 3]
         }
+      });
+    });
+
+    it("auto whereIn", function() {
+      testsql(qb().select('*').from('users').where('id', [1,2]), {
+        mysql: {
+          sql: 'select * from `users` where `id` in (?, ?)',
+          bindings: [1,2]
+        },
+        default: {
+          sql: 'select * from "users" where "id" in (?, ?)',
+          bindings: [1,2]
+        }
+      });
+
+      testquery(qb().select('*').from('users').where({'id' : [1, 2]}), {
+        mysql: 'select * from `users` where `id` in (1, 2)',
+        postgres: 'select * from "users" where "id" in (\'1\', \'2\')',
+        default: 'select * from "users" where "id" in (1, 2)'
       });
     });
 


### PR DESCRIPTION
syntaxic sugar, allows for 
```
qb().select('*').from('product').where({size : 100, category : ['goodie', 'gift']})
=> to generate : 
SELECT * FROM `product` WHERE size = 100 AND category IN ('goodies', 'gift');
```