### PR TITLE
Allow raw columns in where clauses

### DIFF
--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -181,10 +181,10 @@ QueryBuilder.prototype.andWhere = function(column, operator, value) {
   }
 
   // Allow a raw statement to be passed along to the query.
-  if (column instanceof Raw) return this.whereRaw(column);
+  if (column instanceof Raw && arguments.length === 1) return this.whereRaw(column);
 
   // Allows `where({id: 2})` syntax.
-  if (_.isObject(column)) return this._objectWhere(column);
+  if (_.isObject(column) && !(column instanceof Raw)) return this._objectWhere(column);
 
   // Enable the where('key', value) syntax, only when there
   // are explicitly two arguments passed, so it's not possible to

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -291,6 +291,19 @@ module.exports = function(qb, clientName, aliasName) {
       });
     });
 
+    it("raw column wheres", function() {
+      testsql(qb().select('*').from('users').where(raw('LCASE("name")'), 'foo'), {
+        mysql: {
+          sql: 'select * from `users` where LCASE("name") = ?',
+          bindings: ['foo']
+        },
+        default: {
+          sql: 'select * from "users" where LCASE("name") = ?',
+          bindings: ['foo']
+        }
+      });
+    });
+
     it("raw wheres", function() {
       testsql(qb().select('*').from('users').where(raw('id = ? or email = ?', [1, 'foo'])), {
         mysql: {


### PR DESCRIPTION
This change allows to pass column as raw instead of having to pass the whole condition. This should be completely back compatible and allows the following syntax which is already allowed on `.whereIn` and `.whereBetween`:

```js
qb.where(knex.raw('"metadata"->\'width\''), operator, value)
```
I know that you can still achieve this by passing everything on the raw query but it was surprising to me that you couldn't do it this way. Feel free to close this if you think it's completely unnecessary.

regards