### PR TITLE
fix to work in browserify

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,9 @@ var makeClient      = require('./util/make-client')
 var makeKnex        = require('./util/make-knex')
 var parseConnection = require('./util/parse-connection')
 var assign          = require('lodash/object/assign')
-
+if (process.browser) {
+    require('./dialects/websql/index.js')
+}
 function Knex(config) {
   if (typeof config === 'string') {
     return new Knex(assign(parseConnection(config), arguments[2]))

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "directories": {
     "test": "test"
   },
-  "browser": "./browser/websql.js",
   "dependencies": {
     "bluebird": "^2.9.24",
     "chalk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "directories": {
     "test": "test"
   },
+  "browser": {
+    "../migrate":"lodash/utility/noop",
+    "../seed":"lodash/utility/noop",
+    "bluebird/js/main/promise": "./lib/util/bluebird.js"
+  },
   "dependencies": {
     "bluebird": "^2.9.24",
     "chalk": "^1.0.0",


### PR DESCRIPTION
using webpack to create a static build doesn't actually work because webpack uses different methods to look up the modules or something I don't know it through an error when I tried to bundle it, this doesn't and we can add more files to explicitly ignore if it gets too big