### PR TITLE
Adds trailing commas to seed stubs

### DIFF
--- a/lib/seed/stub/coffee.stub
+++ b/lib/seed/stub/coffee.stub
@@ -6,4 +6,4 @@ exports.seed = (knex, Promise) ->
     # Inserts seed entries
     knex('table_name').insert({id: 1, colName: 'rowValue'}),
     knex('table_name').insert({id: 2, colName: 'rowValue2'}),
-    knex('table_name').insert({id: 3, colName: 'rowValue3'}))
+    knex('table_name').insert({id: 3, colName: 'rowValue3'})),

--- a/lib/seed/stub/js.stub
+++ b/lib/seed/stub/js.stub
@@ -8,6 +8,6 @@ exports.seed = function(knex, Promise) {
     // Inserts seed entries
     knex('table_name').insert({id: 1, colName: 'rowValue'}),
     knex('table_name').insert({id: 2, colName: 'rowValue2'}),
-    knex('table_name').insert({id: 3, colName: 'rowValue3'})
+    knex('table_name').insert({id: 3, colName: 'rowValue3'}),
   );
 };


### PR DESCRIPTION
I just started started using the seed feature of knex, which is awesome!
I thought it might be nice to add a trailing comma to make it easier to
copy/paste new lines.

Just a minor tweak.