### PR TITLE
Treat undefined values as null

### DIFF
--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -172,7 +172,7 @@ assign(Builder.prototype, {
 
       // If the value is null, and it's a two argument query,
       // we assume we're going for a `whereNull`.
-      if (value === null) {
+      if (value == null) {
         return this.whereNull(column);
       }
     }
@@ -192,7 +192,7 @@ assign(Builder.prototype, {
 
     // If the value is still null, check whether they're meaning
     // where value is null
-    if (value === null) {
+    if (value == null) {
 
       // Check for .where(key, 'is', null) or .where(key, 'is not', 'null');
       if (checkOperator === 'is' || checkOperator === 'is not') {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -1808,8 +1808,29 @@ describe("QueryBuilder", function() {
   //   expect(chain.sql).to.equal('select * from (select *, row_number() over (order by [email] desc) as row_num from [users]) as temp_table where row_num between 11 and 20');
   // });
 
-  it("providing null or false as second parameter builds correctly", function() {
+  it("providing null as second parameter builds correctly", function() {
     testsql(qb().select('*').from('users').where('foo', null), {
+      mysql: 'select * from `users` where `foo` is null',
+      default: 'select * from "users" where "foo" is null'
+    });
+  });
+
+  it("providing null as third parameter builds correctly", function() {
+    testsql(qb().select('*').from('users').where('foo', 'is', null), {
+      mysql: 'select * from `users` where `foo` is null',
+      default: 'select * from "users" where "foo" is null'
+    });
+  });
+
+  it("providing undefined as second parameter builds correctly", function() {
+    testsql(qb().select('*').from('users').where('foo', undefined), {
+      mysql: 'select * from `users` where `foo` is null',
+      default: 'select * from "users" where "foo" is null'
+    });
+  });
+
+  it("providing undefined as third parameter builds correctly", function() {
+    testsql(qb().select('*').from('users').where('foo', 'is', undefined), {
       mysql: 'select * from `users` where `foo` is null',
       default: 'select * from "users" where "foo" is null'
     });


### PR DESCRIPTION
It used to be working in previous versions of knex (0.5.x), but it's broken in 0.8.x. Let's bring back the backward compatibility! :)