### PR TITLE
Fix oracle stream - regression

### DIFF
--- a/src/dialects/oracle/stream.js
+++ b/src/dialects/oracle/stream.js
@@ -14,7 +14,7 @@ function OracleQueryStream(connection, sql, bindings, options) {
 inherits(OracleQueryStream, Readable)
 
 OracleQueryStream.prototype._read = function() {
-  function pushNull() {
+  var pushNull = () => {
     process.nextTick(() => {
       this.push(null)
     })


### PR DESCRIPTION
The new usage => for function introduced an error in streaming for oracle.
