### PR TITLE
Improve query composability and support for utility functions

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,7 @@
       <li>– <a href="#Builder-pluck">pluck</a></li>
       <li>– <a href="#Builder-first">first</a></li>
       <li>– <a href="#Builder-clone">clone</a></li>
+      <li>– <a href="#Builder-compose">compose</a></li>
       <li>– <a href="#Builder-columnInfo">columnInfo</a></li>
       <li>– <a href="#Builder-debug">debug</a></li>
       <li>– <a href="#Builder-connection">connection</a></li>
@@ -1371,6 +1372,32 @@ knex('accounts').truncate()
       without mutating the original.
     </p>
 
+    <p id="Builder-compose">
+      <b class="header">compose</b><code>.compose(fn, *arguments)</code>
+      <br />
+      Allows encapsulating and re-using query snippets and common behaviors as functions. 
+      The first parameter is a callback whose this context is bound to the current query chain.
+      Rest of the (optional) parameters are passed to the callback.
+
+<pre>
+<code class="js">var withUserName = function(foreignKey) {
+  this
+    .leftJoin('users', foreignKey, 'users.id')
+    .select('users.user_name');
+};
+
+knex
+  .table('articles')
+  .select('title', 'body')
+  .compose(withUserName, 'articles_user.id')
+  .then(function(article) {
+    console.log(article.user_name);
+  });
+</code>
+</pre>    
+      
+      
+    </p>
 
     <p id="Builder-columnInfo">
       <b class="header">columnInfo</b><code>.columnInfo([columnName])</code>

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
       <li>– <a href="#Builder-pluck">pluck</a></li>
       <li>– <a href="#Builder-first">first</a></li>
       <li>– <a href="#Builder-clone">clone</a></li>
-      <li>– <a href="#Builder-compose">compose</a></li>
+      <li>– <a href="#Builder-modify">modify</a></li>
       <li>– <a href="#Builder-columnInfo">columnInfo</a></li>
       <li>– <a href="#Builder-debug">debug</a></li>
       <li>– <a href="#Builder-connection">connection</a></li>
@@ -1372,8 +1372,8 @@ knex('accounts').truncate()
       without mutating the original.
     </p>
 
-    <p id="Builder-compose">
-      <b class="header">compose</b><code>.compose(fn, *arguments)</code>
+    <p id="Builder-modify">
+      <b class="header">modify</b><code>.modify(fn, *arguments)</code>
       <br />
       Allows encapsulating and re-using query snippets and common behaviors as functions. 
       The first parameter is a callback whose this context is bound to the current query chain.
@@ -1389,7 +1389,7 @@ knex('accounts').truncate()
 knex
   .table('articles')
   .select('title', 'body')
-  .compose(withUserName, 'articles_user.id')
+  .modify(withUserName, 'articles_user.id')
   .then(function(article) {
     console.log(article.user_name);
   });

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -283,7 +283,8 @@ assign(Builder.prototype, {
       type: 'whereExists',
       value: callback,
       not: this._not(),
-      bool: this._bool() });
+      bool: this._bool()
+    });
     return this;
   },
 
@@ -687,6 +688,13 @@ assign(Builder.prototype, {
         this[key](val);
       }
     }, this);
+    return this;
+  },
+
+  // Passes query to provided callback function, useful for e.g. composing
+  // domain-specific helpers
+  compose: function compose(callback) {
+    callback.apply(this, _.rest(arguments));
     return this;
   },
 

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -693,7 +693,7 @@ assign(Builder.prototype, {
 
   // Passes query to provided callback function, useful for e.g. composing
   // domain-specific helpers
-  compose: function compose(callback) {
+  modify: function modify(callback) {
     callback.apply(this, _.rest(arguments));
     return this;
   },

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -691,7 +691,7 @@ assign(Builder.prototype, {
 
   // Passes query to provided callback function, useful for e.g. composing
   // domain-specific helpers
-  compose: function(callback) {
+  modify: function(callback) {
     callback.apply(this, _.rest(arguments));
     return this;
   },

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -689,6 +689,13 @@ assign(Builder.prototype, {
     return this
   },
 
+  // Passes query to provided callback function, useful for e.g. composing
+  // domain-specific helpers
+  compose: function(callback) {
+    callback.apply(this, _.rest(arguments));
+    return this;
+  },
+
   // ----------------------------------------------------------------------
 
   // Helper for the incrementing/decrementing queries.

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -2344,6 +2344,24 @@ describe("QueryBuilder", function() {
       }
     })
   })
+  
+  it('has a compose method which accepts a function that can modify the query', function() {
+    // arbitrary number of arguments can be passed to `.compose`, builder is bound to `this`
+    var withBars = function(table, fk) {
+      this
+        .leftJoin('bars', table + '.' + fk, 'bars.id')
+        .select('bars.*')
+    };
+    
+    testsql(qb().select('foo_id').from('foos').compose(withBars, 'foos', 'bar_id'), {
+      mysql: {
+        sql: 'select `foo_id`, `bars`.* from `foos` left join `bars` on `foos`.`bar_id` = `bars`.`id`'
+      },
+      default: {
+        sql: 'select "foo_id", "bars".* from "foos" left join "bars" on "foos"."bar_id" = "bars"."id"'
+      }
+    })
+  })
 
   it('Allows for empty where #749', function() {
     testsql(qb().select('foo').from('tbl').where(function() {}), {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -2345,15 +2345,15 @@ describe("QueryBuilder", function() {
     })
   })
   
-  it('has a compose method which accepts a function that can modify the query', function() {
-    // arbitrary number of arguments can be passed to `.compose`, builder is bound to `this`
+  it('has a modify method which accepts a function that can modify the query', function() {
+    // arbitrary number of arguments can be passed to `.modify`, builder is bound to `this`
     var withBars = function(table, fk) {
       this
         .leftJoin('bars', table + '.' + fk, 'bars.id')
         .select('bars.*')
     };
     
-    testsql(qb().select('foo_id').from('foos').compose(withBars, 'foos', 'bar_id'), {
+    testsql(qb().select('foo_id').from('foos').modify(withBars, 'foos', 'bar_id'), {
       mysql: {
         sql: 'select `foo_id`, `bars`.* from `foos` left join `bars` on `foos`.`bar_id` = `bars`.`id`'
       },


### PR DESCRIPTION
Recently moved from Bookshelf to writing raw `knex` queries and loving the experience. One thing that's bugging me is that there doesn't seem to be a great way to extract commonly used domain-specific query patterns and reuse them as functions.

This spike adds `.compose(fn)` method to the query builder to achieve this. The method takes in a callback function, whose `this` context is bound to the current query builder. From syntax point of view it works similarly with `.whereWrapped(fn)`, but additionally allows the function to add arbitrary operations to the query. See example below for details.

Just testing waters here, are you interested in this type of new functionality? If yes, I can contribute tests and documentation. Naming and semantics of the method can be changed if you see fit.

#### Example
In my domain many tables have a foreign key `image_asset_id` referencing `image_assets` table, and I would like to include certain fields from this table into my query results.

Currently I have this pattern in multiple queries:
```
  return knex('some_table')
    //...snip...
    .leftJoin('image_assets', some_table.image_asset_id', 'image_assets.id')
    .select(
      'some_table.*',
      'image_assets.asset_url',
      'image_assets.asset_height',
      'image_assets.asset_width');
    .then(rows => rows.map(modelify));
```

With compose I could do the following
```
  return knex('some_table')
    //...snip...
    .select('some_table.*')
    .compose(withImageAssetOf, 'some_table')
    .then(rows => rows.map(modelify));
```

Where the `withImageAssetOf` function can be defined reusably e.g. as follows:
```
function withImageAssetOf(tableName) {
  this
    .leftJoin('image_assets', tableName + '.image_asset_id', 'image_assets.id')
    .select(
      'image_assets.asset_url',
      'image_assets.asset_height',
      'image_assets.asset_width');
}
```

Thanks for your great work on knex!


