### PR TITLE
only position bindings if bindings

### DIFF
--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -106,7 +106,10 @@ assign(Client_PG.prototype, {
 
   _stream: function _stream(connection, obj, stream, options) {
     PGQueryStream = process.browser ? undefined : require('pg-query-stream');
-    var sql = obj.sql = this.positionBindings(obj.sql);
+
+    var sql = obj.sql;
+    if(obj.bindings) sql = obj.sql = this.positionBindings(obj.sql);
+
     return new Promise(function (resolver, rejecter) {
       var queryStream = connection.query(new PGQueryStream(sql, obj.bindings, options));
       queryStream.on('error', rejecter);
@@ -121,7 +124,10 @@ assign(Client_PG.prototype, {
   // Runs the query on the specified connection, providing the bindings
   // and any other necessary prep work.
   _query: function _query(connection, obj) {
-    var sql = obj.sql = this.positionBindings(obj.sql);
+
+    var sql = obj.sql;
+    if(obj.bindings) sql = obj.sql = this.positionBindings(obj.sql);
+
     if (obj.options) sql = _.extend({ text: sql }, obj.options);
     return new Promise(function (resolver, rejecter) {
       connection.query(sql, obj.bindings, function (err, response) {

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -98,17 +98,20 @@ assign(Client_PG.prototype, {
   // Position the bindings for the query.
   positionBindings: function positionBindings(sql) {
     var questionCount = 0;
-    return sql.replace(/\?/g, function () {
-      questionCount++;
-      return '$' + questionCount;
-    });
+    return s.match(/'[^']+'|"[^"]+"|./g).map(function (c) {
+        if(c === '?'){
+          questionCount++
+          return '$'+questionCount
+        }
+        return c
+    })
   },
 
   _stream: function _stream(connection, obj, stream, options) {
     PGQueryStream = process.browser ? undefined : require('pg-query-stream');
 
     var sql = obj.sql;
-    if(obj.bindings) sql = obj.sql = this.positionBindings(obj.sql);
+    sql = obj.sql = this.positionBindings(obj.sql);
 
     return new Promise(function (resolver, rejecter) {
       var queryStream = connection.query(new PGQueryStream(sql, obj.bindings, options));
@@ -126,7 +129,7 @@ assign(Client_PG.prototype, {
   _query: function _query(connection, obj) {
 
     var sql = obj.sql;
-    if(obj.bindings) sql = obj.sql = this.positionBindings(obj.sql);
+    sql = obj.sql = this.positionBindings(obj.sql);
 
     if (obj.options) sql = _.extend({ text: sql }, obj.options);
     return new Promise(function (resolver, rejecter) {


### PR DESCRIPTION
if you have a query with a '?' mark in it, it is replaced with a numbered param for pg prepared statements.
if you provide no bindings your queries are not run as a prepared statements and `?` should be preserved in text fields.

...
trx.raw("insert into table(name) values('foo?');")
...

right  now this will insert a row in your "table" table with a name value of "foo$1"

```
select * from table;
[name]
foo$1
```

after this fix "?" is preserved as it should be. 

note: you cannot use bindings when you are running batch queries/ multiples statements so you will have a time where you need to pass escaped user input in the sql string.