### PR TITLE
fixed connection error handling for oracle dialect

### DIFF
--- a/lib/dialects/oracle/index.js
+++ b/lib/dialects/oracle/index.js
@@ -74,8 +74,8 @@ assign(Client_Oracle.prototype, {
     var client = this;
     return new Promise(function (resolver, rejecter) {
       client.driver.connect(client.connectionSettings, function (err, connection) {
-        Promise.promisifyAll(connection);
         if (err) return rejecter(err);
+        Promise.promisifyAll(connection);
         if (client.connectionSettings.prefetchRowCount) {
           connection.setPrefetchRowCount(client.connectionSettings.prefetchRowCount);
         }


### PR DESCRIPTION
right now connection error on oracle in the terminal looks like this:
```
TypeError: the target of promisifyAll must be an object or a function
```