### PR TITLE
wrap index names

### DIFF
--- a/lib/dialects/mysql/schema/tablecompiler.js
+++ b/lib/dialects/mysql/schema/tablecompiler.js
@@ -140,29 +140,29 @@ assign(TableCompiler_MySQL.prototype, {
     }));
   },
   index: function index(columns, indexName) {
-    indexName = indexName || this._indexCommand('index', this.tableNameRaw, columns);
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
     this.pushQuery('alter table ' + this.tableName() + " add index " + indexName + "(" + this.formatter.columnize(columns) + ")");
   },
 
   primary: function primary(columns, indexName) {
-    indexName = indexName || this._indexCommand('primary', this.tableNameRaw, columns);
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('primary', this.tableNameRaw, columns);
     this.pushQuery('alter table ' + this.tableName() + " add primary key " + indexName + "(" + this.formatter.columnize(columns) + ")");
   },
 
   unique: function unique(columns, indexName) {
-    indexName = indexName || this._indexCommand('unique', this.tableNameRaw, columns);
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, columns);
     this.pushQuery('alter table ' + this.tableName() + " add unique " + indexName + "(" + this.formatter.columnize(columns) + ")");
   },
 
   // Compile a drop index command.
   dropIndex: function dropIndex(columns, indexName) {
-    indexName = indexName || this._indexCommand('index', this.tableNameRaw, columns);
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
     this.pushQuery('alter table ' + this.tableName() + ' drop index ' + indexName);
   },
 
   // Compile a drop foreign key command.
   dropForeign: function dropForeign(columns, indexName) {
-    indexName = indexName || this._indexCommand('foreign', this.tableNameRaw, columns);
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('foreign', this.tableNameRaw, columns);
     this.pushQuery('alter table ' + this.tableName() + ' drop foreign key ' + indexName);
   },
 
@@ -173,7 +173,7 @@ assign(TableCompiler_MySQL.prototype, {
 
   // Compile a drop unique key command.
   dropUnique: function dropUnique(column, indexName) {
-    indexName = indexName || this._indexCommand('unique', this.tableNameRaw, column);
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, column);
     this.pushQuery('alter table ' + this.tableName() + ' drop index ' + indexName);
   }
 

--- a/lib/dialects/postgres/schema/tablecompiler.js
+++ b/lib/dialects/postgres/schema/tablecompiler.js
@@ -51,26 +51,26 @@ TableCompiler_PG.prototype.primary = function (columns) {
   this.pushQuery('alter table ' + this.tableName() + " add primary key (" + this.formatter.columnize(columns) + ")");
 };
 TableCompiler_PG.prototype.unique = function (columns, indexName) {
-  indexName = indexName || this._indexCommand('unique', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, columns);
   this.pushQuery('alter table ' + this.tableName() + ' add constraint ' + indexName + ' unique (' + this.formatter.columnize(columns) + ')');
 };
 TableCompiler_PG.prototype.index = function (columns, indexName, indexType) {
-  indexName = indexName || this._indexCommand('index', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
   this.pushQuery('create index ' + indexName + ' on ' + this.tableName() + (indexType && ' using ' + indexType || '') + ' (' + this.formatter.columnize(columns) + ')');
 };
 TableCompiler_PG.prototype.dropPrimary = function () {
   this.pushQuery('alter table ' + this.tableName() + " drop constraint " + this.tableNameRaw + "_pkey");
 };
 TableCompiler_PG.prototype.dropIndex = function (columns, indexName) {
-  indexName = indexName || this._indexCommand('index', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
   this.pushQuery('drop index ' + indexName);
 };
 TableCompiler_PG.prototype.dropUnique = function (columns, indexName) {
-  indexName = indexName || this._indexCommand('unique', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, columns);
   this.pushQuery('alter table ' + this.tableName() + ' drop constraint ' + indexName);
 };
 TableCompiler_PG.prototype.dropForeign = function (columns, indexName) {
-  indexName = indexName || this._indexCommand('foreign', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('foreign', this.tableNameRaw, columns);
   this.pushQuery('alter table ' + this.tableName() + ' drop constraint ' + indexName);
 };
 

--- a/lib/dialects/sqlite3/schema/tablecompiler.js
+++ b/lib/dialects/sqlite3/schema/tablecompiler.js
@@ -39,25 +39,25 @@ TableCompiler_SQLite3.prototype.addColumns = function (columns) {
 
 // Compile a drop unique key command.
 TableCompiler_SQLite3.prototype.dropUnique = function (columns, indexName) {
-  indexName = indexName || this._indexCommand('unique', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, columns);
   this.pushQuery('drop index ' + indexName);
 };
 
 TableCompiler_SQLite3.prototype.dropIndex = function (columns, indexName) {
-  indexName = indexName || this._indexCommand('index', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
   this.pushQuery('drop index ' + indexName);
 };
 
 // Compile a unique key command.
 TableCompiler_SQLite3.prototype.unique = function (columns, indexName) {
-  indexName = indexName || this._indexCommand('unique', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, columns);
   columns = this.formatter.columnize(columns);
   this.pushQuery('create unique index ' + indexName + ' on ' + this.tableName() + ' (' + columns + ')');
 };
 
 // Compile a plain index key command.
 TableCompiler_SQLite3.prototype.index = function (columns, indexName) {
-  indexName = indexName || this._indexCommand('index', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
   columns = this.formatter.columnize(columns);
   this.pushQuery('create index ' + indexName + ' on ' + this.tableName() + ' (' + columns + ')');
 };

--- a/lib/schema/tablecompiler.js
+++ b/lib/schema/tablecompiler.js
@@ -165,7 +165,8 @@ TableCompiler.prototype.dropColumn = function () {
 TableCompiler.prototype._indexCommand = function (type, tableName, columns) {
   if (!_.isArray(columns)) columns = columns ? [columns] : [];
   var table = tableName.replace(/\.|-/g, '_');
-  return (table + '_' + columns.join('_') + '_' + type).toLowerCase();
+  var indexName = (table + '_' + columns.join('_') + '_' + type).toLowerCase();
+  return this.formatter.wrap(indexName);
 };
 
 module.exports = TableCompiler;

--- a/src/dialects/mysql/schema/tablecompiler.js
+++ b/src/dialects/mysql/schema/tablecompiler.js
@@ -144,29 +144,29 @@ assign(TableCompiler_MySQL.prototype, {
     }));
   },
   index: function(columns, indexName) {
-    indexName = indexName || this._indexCommand('index', this.tableNameRaw, columns);
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
     this.pushQuery('alter table ' + this.tableName() + " add index " + indexName + "(" + this.formatter.columnize(columns) + ")");
   },
 
   primary: function(columns, indexName) {
-    indexName = indexName || this._indexCommand('primary', this.tableNameRaw, columns);
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('primary', this.tableNameRaw, columns);
     this.pushQuery('alter table ' + this.tableName() + " add primary key " + indexName + "(" + this.formatter.columnize(columns) + ")");
   },
 
   unique: function(columns, indexName) {
-    indexName = indexName || this._indexCommand('unique', this.tableNameRaw, columns);
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, columns);
     this.pushQuery('alter table ' + this.tableName() + " add unique " + indexName + "(" + this.formatter.columnize(columns) + ")");
   },
 
   // Compile a drop index command.
   dropIndex: function(columns, indexName) {
-    indexName = indexName || this._indexCommand('index', this.tableNameRaw, columns);
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
     this.pushQuery('alter table ' + this.tableName() + ' drop index ' + indexName);
   },
 
   // Compile a drop foreign key command.
   dropForeign: function(columns, indexName) {
-    indexName = indexName || this._indexCommand('foreign', this.tableNameRaw, columns);
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('foreign', this.tableNameRaw, columns);
     this.pushQuery('alter table ' + this.tableName() + ' drop foreign key ' + indexName);
   },
 
@@ -177,7 +177,7 @@ assign(TableCompiler_MySQL.prototype, {
 
   // Compile a drop unique key command.
   dropUnique: function(column, indexName) {
-    indexName = indexName || this._indexCommand('unique', this.tableNameRaw, column);
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, column);
     this.pushQuery('alter table ' + this.tableName() + ' drop index ' + indexName);
   }
 

--- a/src/dialects/postgres/schema/tablecompiler.js
+++ b/src/dialects/postgres/schema/tablecompiler.js
@@ -49,12 +49,12 @@ TableCompiler_PG.prototype.primary = function(columns) {
   this.pushQuery('alter table ' + this.tableName() + " add primary key (" + this.formatter.columnize(columns) + ")");
 };
 TableCompiler_PG.prototype.unique = function(columns, indexName) {
-  indexName = indexName || this._indexCommand('unique', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, columns);
   this.pushQuery('alter table ' + this.tableName() + ' add constraint ' + indexName +
     ' unique (' + this.formatter.columnize(columns) + ')');
 };
 TableCompiler_PG.prototype.index = function(columns, indexName, indexType) {
-  indexName = indexName || this._indexCommand('index', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
   this.pushQuery('create index ' + indexName + ' on ' + this.tableName() + (indexType && (' using ' + indexType) || '') +
     ' (' + this.formatter.columnize(columns) + ')');
 };
@@ -62,15 +62,15 @@ TableCompiler_PG.prototype.dropPrimary = function() {
   this.pushQuery('alter table ' + this.tableName() + " drop constraint " + this.tableNameRaw + "_pkey");
 };
 TableCompiler_PG.prototype.dropIndex = function(columns, indexName) {
-  indexName = indexName || this._indexCommand('index', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
   this.pushQuery('drop index ' + indexName);
 };
 TableCompiler_PG.prototype.dropUnique = function(columns, indexName) {
-  indexName = indexName || this._indexCommand('unique', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, columns);
   this.pushQuery('alter table ' + this.tableName() + ' drop constraint ' + indexName);
 };
 TableCompiler_PG.prototype.dropForeign = function(columns, indexName) {
-  indexName = indexName || this._indexCommand('foreign', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('foreign', this.tableNameRaw, columns);
   this.pushQuery('alter table ' + this.tableName() + ' drop constraint ' + indexName);
 };
 

--- a/src/dialects/sqlite3/schema/tablecompiler.js
+++ b/src/dialects/sqlite3/schema/tablecompiler.js
@@ -38,25 +38,25 @@ TableCompiler_SQLite3.prototype.addColumns = function(columns) {
 
 // Compile a drop unique key command.
 TableCompiler_SQLite3.prototype.dropUnique = function(columns, indexName) {
-  indexName = indexName || this._indexCommand('unique', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, columns);
   this.pushQuery('drop index ' + indexName);
 };
 
 TableCompiler_SQLite3.prototype.dropIndex = function(columns, indexName) {
-  indexName = indexName || this._indexCommand('index', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
   this.pushQuery('drop index ' + indexName);
 };
 
 // Compile a unique key command.
 TableCompiler_SQLite3.prototype.unique = function(columns, indexName) {
-  indexName = indexName || this._indexCommand('unique', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, columns);
   columns = this.formatter.columnize(columns);
   this.pushQuery('create unique index ' + indexName + ' on ' + this.tableName() + ' (' + columns + ')');
 };
 
 // Compile a plain index key command.
 TableCompiler_SQLite3.prototype.index = function(columns, indexName) {
-  indexName = indexName || this._indexCommand('index', this.tableNameRaw, columns);
+  indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
   columns = this.formatter.columnize(columns);
   this.pushQuery('create index ' + indexName + ' on ' + this.tableName() + ' (' + columns + ')');
 };

--- a/src/schema/tablecompiler.js
+++ b/src/schema/tablecompiler.js
@@ -165,7 +165,8 @@ TableCompiler.prototype.dropColumn = function() {
 TableCompiler.prototype._indexCommand = function(type, tableName, columns) {
   if (!_.isArray(columns)) columns = columns ? [columns] : [];
   var table = tableName.replace(/\.|-/g, '_');
-  return (table + '_' + columns.join('_') + '_' + type).toLowerCase();
+  var indexName = (table + '_' + columns.join('_') + '_' + type).toLowerCase();
+  return this.formatter.wrap(indexName);
 };
 
 module.exports = TableCompiler;

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -37,6 +37,7 @@ module.exports = function(knex) {
             .dropTableIfExists('test_default_table3')
             .dropTableIfExists('knex_migrations')
             .dropTableIfExists('bool_test')
+            .dropTableIfExists('10_test_table')
             .dropTableIfExists('rename_column_foreign_test')
             .dropTableIfExists('rename_column_test')
             .dropTableIfExists('should_not_be_run')
@@ -74,9 +75,9 @@ module.exports = function(knex) {
             }
             table.timestamps();
           }).testSql(function(tester) {
-            tester('mysql', ['create table `test_table_one` (`id` bigint unsigned not null auto_increment primary key, `first_name` varchar(255), `last_name` varchar(255), `email` varchar(255) null, `logins` int default \'1\', `about` text comment \'A comment.\', `created_at` datetime, `updated_at` datetime) default character set utf8 engine = InnoDB comment = \'A table comment.\'','alter table `test_table_one` add index test_table_one_first_name_index(`first_name`)','alter table `test_table_one` add unique test_table_one_email_unique(`email`)','alter table `test_table_one` add index test_table_one_logins_index(`logins`)']);
-            tester('pg', ['create table "test_table_one" ("id" bigserial primary key, "first_name" varchar(255), "last_name" varchar(255), "email" varchar(255) null, "logins" integer default \'1\', "about" text, "created_at" timestamptz, "updated_at" timestamptz)','comment on table "test_table_one" is \'A table comment.\'',"comment on column \"test_table_one\".\"logins\" is NULL",'comment on column "test_table_one"."about" is \'A comment.\'','create index test_table_one_first_name_index on "test_table_one" ("first_name")','alter table "test_table_one" add constraint test_table_one_email_unique unique ("email")','create index test_table_one_logins_index on "test_table_one" ("logins")']);
-            tester('sqlite3', ['create table "test_table_one" ("id" integer not null primary key autoincrement, "first_name" varchar(255), "last_name" varchar(255), "email" varchar(255) null, "logins" integer default \'1\', "about" text, "created_at" datetime, "updated_at" datetime)','create index test_table_one_first_name_index on "test_table_one" ("first_name")','create unique index test_table_one_email_unique on "test_table_one" ("email")','create index test_table_one_logins_index on "test_table_one" ("logins")']);
+            tester('mysql', ['create table `test_table_one` (`id` bigint unsigned not null auto_increment primary key, `first_name` varchar(255), `last_name` varchar(255), `email` varchar(255) null, `logins` int default \'1\', `about` text comment \'A comment.\', `created_at` datetime, `updated_at` datetime) default character set utf8 engine = InnoDB comment = \'A table comment.\'','alter table `test_table_one` add index `test_table_one_first_name_index`(`first_name`)','alter table `test_table_one` add unique `test_table_one_email_unique`(`email`)','alter table `test_table_one` add index `test_table_one_logins_index`(`logins`)']);
+            tester('pg', ['create table "test_table_one" ("id" bigserial primary key, "first_name" varchar(255), "last_name" varchar(255), "email" varchar(255) null, "logins" integer default \'1\', "about" text, "created_at" timestamptz, "updated_at" timestamptz)','comment on table "test_table_one" is \'A table comment.\'',"comment on column \"test_table_one\".\"logins\" is NULL",'comment on column "test_table_one"."about" is \'A comment.\'','create index "test_table_one_first_name_index" on "test_table_one" ("first_name")','alter table "test_table_one" add constraint "test_table_one_email_unique" unique ("email")','create index "test_table_one_logins_index" on "test_table_one" ("logins")']);
+            tester('sqlite3', ['create table "test_table_one" ("id" integer not null primary key autoincrement, "first_name" varchar(255), "last_name" varchar(255), "email" varchar(255) null, "logins" integer default \'1\', "about" text, "created_at" datetime, "updated_at" datetime)','create index "test_table_one_first_name_index" on "test_table_one" ("first_name")','create unique index "test_table_one_email_unique" on "test_table_one" ("email")','create index "test_table_one_logins_index" on "test_table_one" ("logins")']);
             tester('oracle', [
               'create table "test_table_one" ("id" number(20, 0) not null primary key, "first_name" varchar2(255), "last_name" varchar2(255), "email" varchar2(255) null, "logins" integer default \'1\', "about" varchar2(4000), "created_at" timestamp with time zone, "updated_at" timestamp with time zone)',
               'comment on table "test_table_one" is \'A table comment.\'',
@@ -116,7 +117,7 @@ module.exports = function(knex) {
             table.integer('main').primary();
             table.text('paragraph').defaultTo('Lorem ipsum Qui quis qui in.');
           }).testSql(function(tester) {
-            tester('mysql', ['create table `test_table_three` (`main` int, `paragraph` text) default character set utf8 engine = InnoDB','alter table `test_table_three` add primary key test_table_three_main_primary(`main`)']);
+            tester('mysql', ['create table `test_table_three` (`main` int, `paragraph` text) default character set utf8 engine = InnoDB','alter table `test_table_three` add primary key `test_table_three_main_primary`(`main`)']);
             tester('pg', ['create table "test_table_three" ("main" integer, "paragraph" text default \'Lorem ipsum Qui quis qui in.\')','alter table "test_table_three" add primary key ("main")']);
             tester('sqlite3', ['create table "test_table_three" ("main" integer, "paragraph" text default \'Lorem ipsum Qui quis qui in.\', primary key ("main"))']);
             tester('oracle', ['create table "test_table_three" ("main" integer, "paragraph" clob default \'Lorem ipsum Qui quis qui in.\')','alter table "test_table_three" add primary key ("main")']);
@@ -144,8 +145,8 @@ module.exports = function(knex) {
             .references('id')
             .inTable('test_table_two');
         }).testSql(function(tester) {
-          tester('mysql', ['create table `test_foreign_table_two` (`id` int unsigned not null auto_increment primary key, `fkey_two` int unsigned) default character set utf8','alter table `test_foreign_table_two` add constraint test_foreign_table_two_fkey_two_foreign foreign key (`fkey_two`) references `test_table_two` (`id`)']);
-          tester('pg', ['create table "test_foreign_table_two" ("id" serial primary key, "fkey_two" integer)','alter table "test_foreign_table_two" add constraint test_foreign_table_two_fkey_two_foreign foreign key ("fkey_two") references "test_table_two" ("id")']);
+          tester('mysql', ['create table `test_foreign_table_two` (`id` int unsigned not null auto_increment primary key, `fkey_two` int unsigned) default character set utf8','alter table `test_foreign_table_two` add constraint `test_foreign_table_two_fkey_two_foreign` foreign key (`fkey_two`) references `test_table_two` (`id`)']);
+          tester('pg', ['create table "test_foreign_table_two" ("id" serial primary key, "fkey_two" integer)','alter table "test_foreign_table_two" add constraint "test_foreign_table_two_fkey_two_foreign" foreign key ("fkey_two") references "test_table_two" ("id")']);
           tester('sqlite3', ['create table "test_foreign_table_two" ("id" integer not null primary key autoincrement, "fkey_two" integer, foreign key("fkey_two") references "test_table_two"("id"))']);
           tester('oracle', [
             'create table "test_foreign_table_two" ("id" integer not null primary key, "fkey_two" integer)',
@@ -165,9 +166,9 @@ module.exports = function(knex) {
             table.tinyint('status');
             table.unique(['column_a', 'column_b']);
           }).testSql(function(tester) {
-            tester('mysql', ['create table `composite_key_test` (`column_a` int, `column_b` int, `details` text, `status` tinyint) default character set utf8','alter table `composite_key_test` add unique composite_key_test_column_a_column_b_unique(`column_a`, `column_b`)']);
-            tester('pg', ['create table "composite_key_test" ("column_a" integer, "column_b" integer, "details" text, "status" smallint)','alter table "composite_key_test" add constraint composite_key_test_column_a_column_b_unique unique ("column_a", "column_b")']);
-            tester('sqlite3', ['create table "composite_key_test" ("column_a" integer, "column_b" integer, "details" text, "status" tinyint)','create unique index composite_key_test_column_a_column_b_unique on "composite_key_test" ("column_a", "column_b")']);
+            tester('mysql', ['create table `composite_key_test` (`column_a` int, `column_b` int, `details` text, `status` tinyint) default character set utf8','alter table `composite_key_test` add unique `composite_key_test_column_a_column_b_unique`(`column_a`, `column_b`)']);
+            tester('pg', ['create table "composite_key_test" ("column_a" integer, "column_b" integer, "details" text, "status" smallint)','alter table "composite_key_test" add constraint "composite_key_test_column_a_column_b_unique" unique ("column_a", "column_b")']);
+            tester('sqlite3', ['create table "composite_key_test" ("column_a" integer, "column_b" integer, "details" text, "status" tinyint)','create unique index "composite_key_test_column_a_column_b_unique" on "composite_key_test" ("column_a", "column_b")']);
             tester('oracle', ['create table "composite_key_test" ("column_a" integer, "column_b" integer, "details" clob, "status" smallint)','alter table "composite_key_test" add constraint "zYmMt0VQwlLZ20XnrMicXZ0ufZk" unique ("column_a", "column_b")']);
           }).then(function() {
             return knex('composite_key_test').insert([{
@@ -229,6 +230,45 @@ module.exports = function(knex) {
             });
       });
 
+      it('accepts table names starting with numeric values', function() {
+        return knex.schema
+          .createTable('10_test_table', function(table) {
+            table.bigIncrements('id');
+            table.string('first_name').index();
+            table.string('last_name');
+            table.string('email').unique().nullable();
+            table.integer('logins').defaultTo(1).index().comment();
+          }).testSql(function(tester) {
+            tester('mysql', [
+              'create table `10_test_table` (`id` bigint unsigned not null auto_increment primary key, `first_name` varchar(255), `last_name` varchar(255), `email` varchar(255) null, `logins` int default \'1\') default character set utf8',
+              'alter table `10_test_table` add index `10_test_table_first_name_index`(`first_name`)',
+              'alter table `10_test_table` add unique `10_test_table_email_unique`(`email`)',
+              'alter table `10_test_table` add index `10_test_table_logins_index`(`logins`)'
+            ]);
+            tester('pg', [
+              'create table "10_test_table" ("id" bigserial primary key, "first_name" varchar(255), "last_name" varchar(255), "email" varchar(255) null, "logins" integer default \'1\')',
+              'comment on column \"10_test_table\".\"logins\" is NULL',
+              'create index "10_test_table_first_name_index" on "10_test_table" ("first_name")',
+              'alter table "10_test_table" add constraint "10_test_table_email_unique" unique ("email")',
+              'create index "10_test_table_logins_index" on "10_test_table" ("logins")'
+            ]);
+            tester('sqlite3', [
+              'create table "10_test_table" ("id" integer not null primary key autoincrement, "first_name" varchar(255), "last_name" varchar(255), "email" varchar(255) null, "logins" integer default \'1\')',
+              'create index "10_test_table_first_name_index" on "10_test_table" ("first_name")',
+              'create unique index "10_test_table_email_unique" on "10_test_table" ("email")',
+              'create index "10_test_table_logins_index" on "10_test_table" ("logins")'
+            ]);
+            tester('oracle', [
+              'create table "10_test_table" ("id" number(20, 0) not null primary key, "first_name" varchar2(255), "last_name" varchar2(255), "email" varchar2(255) null, "logins" integer default \'1\')',
+              "begin execute immediate 'create sequence \"10_test_table_seq\"'; exception when others then if sqlcode != -955 then raise; end if; end;",
+              "create or replace trigger \"10_test_table_id_trg\" before insert on \"10_test_table\" for each row when (new.\"id\" is null)  begin select \"10_test_table_seq\".nextval into :new.\"id\" from dual; end;",
+              "comment on column \"10_test_table\".\"logins\" is \'\'",
+              'create index "NkZo/dGRI9O73/NE2fHo+35d4jk" on "10_test_table" ("first_name")',
+              'alter table "10_test_table" add constraint "10_test_table_email_unique" unique ("email")',
+              'create index "10_test_table_logins_index" on "10_test_table" ("logins")'
+            ]);
+          });
+      });
     });
 
     describe('table', function() {
@@ -322,11 +362,11 @@ module.exports = function(knex) {
           return knex.insert({parent_id_test: 1}).into('rename_column_test');
         });
       });
-      
+
       after(function () {
         return knex.schema.dropTable('rename_column_foreign_test').dropTable('rename_column_test');
       });
-      
+
       it('renames the column', function () {
         return knex.schema.table('rename_column_test', function (tbl) {
           return tbl.renameColumn('id_test', 'id');
@@ -338,7 +378,7 @@ module.exports = function(knex) {
           expect(exists).to.equal(true);
         });
       });
-      
+
       it('successfully renames a column referenced in a foreign key', function () {
         return knex.schema.table('rename_column_test', function (tbl) {
           tbl.renameColumn('parent_id_test', 'parent_id');

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -99,7 +99,7 @@ describe(dialect + " SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table `users` drop index users_foo_unique');
+    expect(tableSql[0].sql).to.equal('alter table `users` drop index `users_foo_unique`');
   });
 
   it('test drop unique, custom', function() {
@@ -108,7 +108,7 @@ describe(dialect + " SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table `users` drop index foo');
+    expect(tableSql[0].sql).to.equal('alter table `users` drop index `foo`');
   });
 
   it('test drop index', function() {
@@ -117,7 +117,7 @@ describe(dialect + " SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table `users` drop index users_foo_index');
+    expect(tableSql[0].sql).to.equal('alter table `users` drop index `users_foo_index`');
   });
 
   it('test drop index, custom', function() {
@@ -126,7 +126,7 @@ describe(dialect + " SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table `users` drop index foo');
+    expect(tableSql[0].sql).to.equal('alter table `users` drop index `foo`');
   });
 
   it('test drop foreign', function() {
@@ -135,7 +135,7 @@ describe(dialect + " SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table `users` drop foreign key users_foo_foreign');
+    expect(tableSql[0].sql).to.equal('alter table `users` drop foreign key `users_foo_foreign`');
   });
 
   it('test drop foreign, custom', function() {
@@ -144,7 +144,7 @@ describe(dialect + " SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table `users` drop foreign key foo');
+    expect(tableSql[0].sql).to.equal('alter table `users` drop foreign key `foo`');
   });
 
   it('test drop timestamps', function() {
@@ -169,7 +169,7 @@ describe(dialect + " SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table `users` add primary key bar(`foo`)');
+    expect(tableSql[0].sql).to.equal('alter table `users` add primary key `bar`(`foo`)');
   });
 
   it('test adding unique key', function() {
@@ -178,7 +178,7 @@ describe(dialect + " SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table `users` add unique bar(`foo`)');
+    expect(tableSql[0].sql).to.equal('alter table `users` add unique `bar`(`foo`)');
   });
 
   it('test adding index', function() {
@@ -187,7 +187,7 @@ describe(dialect + " SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table `users` add index baz(`foo`, `bar`)');
+    expect(tableSql[0].sql).to.equal('alter table `users` add index `baz`(`foo`, `bar`)');
   });
 
   it('test adding foreign key', function() {
@@ -196,7 +196,7 @@ describe(dialect + " SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table `users` add constraint users_foo_id_foreign foreign key (`foo_id`) references `orders` (`id`)');
+    expect(tableSql[0].sql).to.equal('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`)');
   });
 
   it("adds foreign key with onUpdate and onDelete", function() {
@@ -205,8 +205,8 @@ describe(dialect + " SchemaBuilder", function() {
       table.integer('account_id').notNull().references('id').inTable('accounts').onUpdate('cascade');
     }).toSQL();
     equal(3, tableSql.length);
-    expect(tableSql[1].sql).to.equal('alter table `person` add constraint person_user_id_foreign foreign key (`user_id`) references `users` (`id`) on delete SET NULL');
-    expect(tableSql[2].sql).to.equal('alter table `person` add constraint person_account_id_foreign foreign key (`account_id`) references `accounts` (`id`) on update cascade');
+    expect(tableSql[1].sql).to.equal('alter table `person` add constraint `person_user_id_foreign` foreign key (`user_id`) references `users` (`id`) on delete SET NULL');
+    expect(tableSql[2].sql).to.equal('alter table `person` add constraint `person_account_id_foreign` foreign key (`account_id`) references `accounts` (`id`) on update cascade');
   });
 
   it('test adding incrementing id', function() {
@@ -466,7 +466,7 @@ describe(dialect + " SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table `composite_key_test` drop index composite_key_test_column_a_column_b_unique');
+    expect(tableSql[0].sql).to.equal('alter table `composite_key_test` drop index `composite_key_test_column_a_column_b_unique`');
   });
 
   it('allows default as alias for defaultTo', function() {

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -99,7 +99,7 @@ describe("PostgreSQL SchemaBuilder", function() {
       table.dropUnique('foo');
     }).toSQL();
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint users_foo_unique');
+    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint "users_foo_unique"');
   });
 
   it("drop unique, custom", function() {
@@ -107,7 +107,7 @@ describe("PostgreSQL SchemaBuilder", function() {
       table.dropUnique(null, 'foo');
     }).toSQL();
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint foo');
+    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint "foo"');
   });
 
   it("drop index", function() {
@@ -115,7 +115,7 @@ describe("PostgreSQL SchemaBuilder", function() {
       table.dropIndex('foo');
     }).toSQL();
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('drop index users_foo_index');
+    expect(tableSql[0].sql).to.equal('drop index "users_foo_index"');
   });
 
   it("drop index, custom", function() {
@@ -123,7 +123,7 @@ describe("PostgreSQL SchemaBuilder", function() {
       table.dropIndex(null, 'foo');
     }).toSQL();
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('drop index foo');
+    expect(tableSql[0].sql).to.equal('drop index "foo"');
   });
 
   it("drop foreign", function() {
@@ -131,7 +131,7 @@ describe("PostgreSQL SchemaBuilder", function() {
       table.dropForeign('foo');
     }).toSQL();
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint users_foo_foreign');
+    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint "users_foo_foreign"');
   });
 
   it("drop foreign", function() {
@@ -139,7 +139,7 @@ describe("PostgreSQL SchemaBuilder", function() {
       table.dropForeign(null, 'foo');
     }).toSQL();
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint foo');
+    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint "foo"');
   });
 
   it("drop timestamps", function() {
@@ -177,7 +177,7 @@ describe("PostgreSQL SchemaBuilder", function() {
     tableSql = client.schemaBuilder().createTable('accounts', function(table) {
       table.integer('account_id').references('users.id');
     }).toSQL();
-    expect(tableSql[1].sql).to.equal('alter table "accounts" add constraint accounts_account_id_foreign foreign key ("account_id") references "users" ("id")');
+    expect(tableSql[1].sql).to.equal('alter table "accounts" add constraint "accounts_account_id_foreign" foreign key ("account_id") references "users" ("id")');
   });
 
   it("adds foreign key with onUpdate and onDelete", function() {
@@ -186,8 +186,8 @@ describe("PostgreSQL SchemaBuilder", function() {
       table.integer('account_id').notNull().references('id').inTable('accounts').onUpdate('cascade');
     }).toSQL();
     equal(3, tableSql.length);
-    expect(tableSql[1].sql).to.equal('alter table "person" add constraint person_user_id_foreign foreign key ("user_id") references "users" ("id") on delete SET NULL');
-    expect(tableSql[2].sql).to.equal('alter table "person" add constraint person_account_id_foreign foreign key ("account_id") references "accounts" ("id") on update cascade');
+    expect(tableSql[1].sql).to.equal('alter table "person" add constraint "person_user_id_foreign" foreign key ("user_id") references "users" ("id") on delete SET NULL');
+    expect(tableSql[2].sql).to.equal('alter table "person" add constraint "person_account_id_foreign" foreign key ("account_id") references "accounts" ("id") on update cascade');
   });
 
   it("adding unique key", function() {
@@ -195,7 +195,7 @@ describe("PostgreSQL SchemaBuilder", function() {
       table.unique('foo', 'bar');
     }).toSQL();
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table "users" add constraint bar unique ("foo")');
+    expect(tableSql[0].sql).to.equal('alter table "users" add constraint "bar" unique ("foo")');
   });
 
   it("adding unique key fluently", function() {
@@ -204,7 +204,7 @@ describe("PostgreSQL SchemaBuilder", function() {
     }).toSQL();
     equal(2, tableSql.length);
     expect(tableSql[0].sql).to.equal('create table "users" ("email" varchar(255))');
-    expect(tableSql[1].sql).to.equal('alter table "users" add constraint users_email_unique unique ("email")');
+    expect(tableSql[1].sql).to.equal('alter table "users" add constraint "users_email_unique" unique ("email")');
   });
 
   it("adding index without value", function() {
@@ -212,7 +212,7 @@ describe("PostgreSQL SchemaBuilder", function() {
       table.index(['foo', 'bar']);
     }).toSQL();
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('create index users_foo_bar_index on "users" ("foo", "bar")');
+    expect(tableSql[0].sql).to.equal('create index "users_foo_bar_index" on "users" ("foo", "bar")');
   });
 
   it("adding index", function() {
@@ -220,7 +220,7 @@ describe("PostgreSQL SchemaBuilder", function() {
       table.index(['foo', 'bar'], 'baz');
     }).toSQL();
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('create index baz on "users" ("foo", "bar")');
+    expect(tableSql[0].sql).to.equal('create index "baz" on "users" ("foo", "bar")');
   });
 
   it("adding index fluently", function() {
@@ -229,7 +229,7 @@ describe("PostgreSQL SchemaBuilder", function() {
     }).toSQL();
     equal(2, tableSql.length);
     expect(tableSql[0].sql).to.equal('alter table "users" add column "name" varchar(255)');
-    expect(tableSql[1].sql).to.equal('create index users_name_index on "users" ("name")');
+    expect(tableSql[1].sql).to.equal('create index "users_name_index" on "users" ("name")');
   });
 
   it("adding index with an index type", function() {
@@ -237,7 +237,7 @@ describe("PostgreSQL SchemaBuilder", function() {
       table.index(['foo', 'bar'], 'baz', 'gist');
     }).toSQL();
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('create index baz on "users" using gist ("foo", "bar")');
+    expect(tableSql[0].sql).to.equal('create index "baz" on "users" using gist ("foo", "bar")');
   });
 
   it("adding index with an index type fluently", function() {
@@ -246,7 +246,7 @@ describe("PostgreSQL SchemaBuilder", function() {
     }).toSQL();
     equal(2, tableSql.length);
     expect(tableSql[0].sql).to.equal('alter table "users" add column "name" varchar(255)');
-    expect(tableSql[1].sql).to.equal('create index baz on "users" using gist ("name")');
+    expect(tableSql[1].sql).to.equal('create index "baz" on "users" using gist ("name")');
   });
 
   it("adding index with an index type and default name fluently", function() {
@@ -255,7 +255,7 @@ describe("PostgreSQL SchemaBuilder", function() {
     }).toSQL();
     equal(2, tableSql.length);
     expect(tableSql[0].sql).to.equal('alter table "users" add column "name" varchar(255)');
-    expect(tableSql[1].sql).to.equal('create index users_name_index on "users" using gist ("name")');
+    expect(tableSql[1].sql).to.equal('create index "users_name_index" on "users" using gist ("name")');
   });
 
   it("adding incrementing id", function() {

--- a/test/unit/schema/sqlite3.js
+++ b/test/unit/schema/sqlite3.js
@@ -57,7 +57,7 @@ describe("SQLite SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'drop index users_foo_unique');
+    equal(tableSql[0].sql, 'drop index "users_foo_unique"');
   });
 
   it("drop unique, custom", function() {
@@ -66,7 +66,7 @@ describe("SQLite SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'drop index foo');
+    equal(tableSql[0].sql, 'drop index "foo"');
   });
 
   it("drop index", function() {
@@ -75,7 +75,7 @@ describe("SQLite SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'drop index users_foo_index');
+    equal(tableSql[0].sql, 'drop index "users_foo_index"');
   });
 
   it("drop index, custom", function() {
@@ -84,7 +84,7 @@ describe("SQLite SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'drop index foo');
+    equal(tableSql[0].sql, 'drop index "foo"');
   });
 
   it("rename table", function() {
@@ -160,7 +160,7 @@ describe("SQLite SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'create unique index users_foo_unique on "users" ("foo")');
+    equal(tableSql[0].sql, 'create unique index "users_foo_unique" on "users" ("foo")');
   });
 
   it("adding unique key with specific name", function() {
@@ -169,7 +169,7 @@ describe("SQLite SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'create unique index bar on "users" ("foo")');
+    equal(tableSql[0].sql, 'create unique index "bar" on "users" ("foo")');
   });
 
   it("adding index", function() {
@@ -178,7 +178,7 @@ describe("SQLite SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'create index baz on "users" ("foo", "bar")');
+    equal(tableSql[0].sql, 'create index "baz" on "users" ("foo", "bar")');
   });
 
   it("adding incrementing id", function() {
@@ -421,24 +421,24 @@ describe("SQLite SchemaBuilder", function() {
     equal(2, tableSql.length);
     equal(tableSql[0].sql, 'create table "users" ("user_id" varchar(36), foreign key("user_id") references "user"("id") on delete CASCADE)');
   });
-  
+
   describe('SQLite3_DDL.prototype._doReplace', function () {
     it('should not change a query that has no matches', function () {
       return client.schemaBuilder().table('foo', function() {
-        
+
         var doReplace = SQLite3_DDL.prototype._doReplace;
-        
+
         var sql1 = 'CREATE TABLE "foo" ("id" integer not null primary key autoincrement, '+
               '"parent_id_test" integer, foreign key("parent_id") references "foo"("id"))';
         var sql2 = 'CREATE TABLE "foo" ("id" integer not null primary key autoincrement, '+
               '"parent_id_test" integer, foreign key("parent_id") references "bar"("id"))';
-        
+
         var sql1b = 'CREATE TABLE "foo" ("id_foo" integer not null primary key autoincrement, '+
               '"parent_id_test" integer, foreign key("parent_id") references "foo"("id_foo"))';
         var sql2b = 'CREATE TABLE "foo" ("id_foo" integer not null primary key autoincrement, '+
               '"parent_id_test" integer, foreign key("parent_id") references "bar"("id"))';
-        
-        
+
+
         expect(doReplace(sql1, '"bar"', '"lar"')).to.equal(sql1);
         expect(doReplace(sql1, '"id"', '"id_foo"')).to.equal(sql1b);
         expect(doReplace(sql2, '"id"', '"id_foo"')).to.equal(sql2b);


### PR DESCRIPTION
The current implementation I have been using at work for multi tenants is based in different tables for each client (tenant). To distinguish each table for each client we use the client id (number) as prefix name. For example I have these tables for client 1 (1_authorization, 1_user) and these tables for client 2 (2_authorization, 2_user).

Due that I have tables starting with number values. And this pull request fixes the problem of executing queries with index names starting with number values.  Since I have been working only with Mysql and Postgres I have applied the changes only in those databases types.