### PR TITLE
add LiveScript support back in to knex migrations

### DIFF
--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -71,7 +71,7 @@ function initKnex(env) {
 function invoke(env) {
 
   var pending,
-      filetypes = ['js', 'coffee'];
+      filetypes = ['js', 'coffee', 'ls'];
 
   commander.version(chalk.blue('Knex CLI version: ', chalk.green(cliPkg.version)) + '\n' + chalk.blue('Local Knex version: ', chalk.green(env.modulePackage.version)) + '\n').option('--debug', 'Run with debugging.').option('--knexfile [path]', 'Specify the knexfile path.').option('--cwd [path]', 'Specify the working directory.').option('--env [name]', 'environment, default: process.env.NODE_ENV || development');
 

--- a/lib/migrate/stub/knexfile-ls.stub
+++ b/lib/migrate/stub/knexfile-ls.stub
@@ -1,0 +1,34 @@
+# Update with your config settings.
+
+module.exports =
+
+  development:
+    client: 'sqlite3'
+    connection:
+      filename: './dev.sqlite3'
+    migrations:
+      tableName: 'knex_migrations'
+
+  staging:
+    client: 'postgresql'
+    connection:
+      database: 'my_db'
+      user:     'username'
+      password: 'password'
+    pool:
+      min: 2
+      max: 10
+    migrations:
+      tableName: 'knex_migrations'
+
+  production:
+    client: 'postgresql'
+    connection:
+      database: 'my_db'
+      user:     'username'
+      password: 'password'
+    pool:
+      min: 2
+      max: 10
+    migrations:
+      tableName: 'knex_migrations'


### PR DESCRIPTION
We upgraded the version of knex we were using, and noticed that the migration system received a big overhaul since the last time we looked.  Unfortunately for us, it lost LiveScript support which our migrations were using, so this pull request should add it back in.