### PR TITLE
Add select lock arguments

### DIFF
--- a/index.html
+++ b/index.html
@@ -1312,7 +1312,7 @@ knex.transaction(function(trx) {
 </pre>
 
     <p id="Builder-forUpdate">
-      <b class="header">forUpdate</b><code>.transacting(t).forUpdate()</code>
+      <b class="header">forUpdate</b><code>.transacting(t).forUpdate([tables], [nowait])</code>
       <br />
       Dynamically added after a <a href="#Builder-transacting">transaction</a> is specified,
       the <tt>forUpdate</tt> adds a <tt>FOR UPDATE</tt> in PostgreSQL and MySQL during a select statement.
@@ -1325,8 +1325,15 @@ knex('tableName')
   .select('*')
 </pre>
 
+<pre class="display">
+knex('tableName')
+  .transacting(trx)
+  .forUpdate('tableName', true)
+  .select('*')
+</pre>
+
     <p id="Builder-forShare">
-      <b class="header">forShare</b><code>.transacting(t).forShare()</code>
+      <b class="header">forShare</b><code>.transacting(t).forShare([tables], [nowait])</code>
       <br />
       Dynamically added after a <a href="#Builder-transacting">transaction</a> is specified,
       the <tt>forShare</tt> adds a <tt>FOR SHARE</tt> in PostgreSQL and a <tt>LOCK IN SHARE MODE</tt>
@@ -1337,6 +1344,13 @@ knex('tableName')
 knex('tableName')
   .transacting(trx)
   .forShare()
+  .select('*')
+</pre>
+
+<pre class="display">
+knex('tableName')
+  .transacting(trx)
+  .forShare('tableName', true)
   .select('*')
 </pre>
 

--- a/src/dialects/postgres/query/compiler.js
+++ b/src/dialects/postgres/query/compiler.js
@@ -62,11 +62,24 @@ assign(QueryCompiler_PG.prototype, {
   },
 
   forUpdate: function() {
-    return 'for update';
+    return this._lock('update', this.single.of, this.single.noWait);
   },
 
   forShare: function() {
-    return 'for share';
+    return this._lock('share', this.single.of, this.single.noWait);
+  },
+
+  _lock: function(strength, tables, noWait) {
+    var sql = 'for ' + strength;
+    if (tables.length > 0) {
+      sql += ' of ' + _.map(tables, function(table) {
+        return this.formatter.wrap(table);
+      }, this).join(', ');
+    }
+    if (noWait) {
+      sql += ' nowait';
+    }
+    return sql;
   },
 
   // Compiles a columnInfo query

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -491,13 +491,13 @@ assign(Builder.prototype, {
     if (column instanceof Raw && arguments.length === 1) {
       return this._havingRaw(column);
     }
-    
+
     // Check if the column is a function, in which case it's
     // a having statement wrapped in parens.
     if (typeof column === 'function') {
       return this.havingWrapped(column);
     }
-    
+
     this._statements.push({
       grouping: 'having',
       type: 'havingBasic',
@@ -542,7 +542,7 @@ assign(Builder.prototype, {
     if (isNaN(val)) {
       helpers.warn('A valid integer must be provided to limit')
     } else {
-      this._single.limit = val;  
+      this._single.limit = val;
     }
     return this;
   },
@@ -694,12 +694,16 @@ assign(Builder.prototype, {
   // Set a lock for update constraint.
   forUpdate: function() {
     this._single.lock = 'forUpdate';
+    this._single.of = _.filter(arguments, _.isString);
+    this._single.noWait = _.isBoolean(_.last(arguments)) ? _.last(arguments) : false;
     return this;
   },
 
   // Set a lock for share constraint.
   forShare: function() {
     this._single.lock = 'forShare';
+    this._single.of = _.filter(arguments, _.isString);
+    this._single.noWait = _.isBoolean(_.last(arguments)) ? _.last(arguments) : false;
     return this;
   },
 


### PR DESCRIPTION
This feature allows to specify `OF table_name` and `NOWAIT`in a `SELECT`query with `FOR UPDATE` and `FOR SHARE` when the dialect is `postgres`.

Reference:
`[ FOR { UPDATE | SHARE } [ OF table_name [, ...] ] [ NOWAIT ] [...] ]`
