### PR TITLE
added LiveScript stub template for seed:make

### DIFF
--- a/src/seed/stub/ls.stub
+++ b/src/seed/stub/ls.stub
@@ -1,0 +1,9 @@
+export seed = (knex, Promise) ->
+  Promise.join(
+    # Deletes ALL existing entries
+    knex('table_name').del(),
+
+    # Inserts seed entries
+    knex('table_name').insert({id: 1, colName: 'rowValue'}),
+    knex('table_name').insert({id: 2, colName: 'rowValue2'}),
+    knex('table_name').insert({id: 3, colName: 'rowValue3'}))


### PR DESCRIPTION
I forgot to provide a LiveScript template for the `seed:make` subcommand.  #903 
