### PR TITLE
.as method on JoinClause objects. See issue #915

### DIFF
--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -57,7 +57,7 @@ assign(QueryCompiler.prototype, {
     }
     return _.compact(statements).join(' ');
   },
-  
+
   pluck: function() {
     return {
       sql: this.select(),
@@ -84,7 +84,7 @@ assign(QueryCompiler.prototype, {
       sql += insertData;
     } else  {
       if (insertData.columns.length) {
-        sql += '(' + this.formatter.columnize(insertData.columns) 
+        sql += '(' + this.formatter.columnize(insertData.columns)
         sql += ') values ('
         var i = -1
         while (++i < insertData.values.length) {
@@ -124,14 +124,14 @@ assign(QueryCompiler.prototype, {
         if (stmt.distinct) distinct = true
         if (stmt.type === 'aggregate') {
           sql.push(this.aggregate(stmt))
-        } 
+        }
         else if (stmt.value && stmt.value.length > 0) {
           sql.push(this.formatter.columnize(stmt.value))
         }
       }
     }
     if (sql.length === 0) sql = ['*'];
-    return 'select ' + (distinct ? 'distinct ' : '') + 
+    return 'select ' + (distinct ? 'distinct ' : '') +
       sql.join(', ') + (this.tableName ? ' from ' + this.tableName : '');
   },
 
@@ -159,6 +159,9 @@ assign(QueryCompiler.prototype, {
         sql += this.formatter.unwrapRaw(join.table)
       } else {
         sql += join.joinType + ' join ' + this.formatter.wrap(join.table)
+        if (join.as) {
+          sql += ' as ' + this.formatter.wrap(join.as) + ' ';
+        }
         var ii = -1
         while (++ii < join.clauses.length) {
           var clause = join.clauses[ii]
@@ -356,7 +359,7 @@ assign(QueryCompiler.prototype, {
     if (statement.not) return 'not ' + str;
     return str;
   },
-  
+
   _prepInsert: function(data) {
     var isRaw = this.formatter.rawOrFn(data);
     if (isRaw) return isRaw;

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -159,8 +159,8 @@ assign(QueryCompiler.prototype, {
         sql += this.formatter.unwrapRaw(join.table)
       } else {
         sql += join.joinType + ' join ' + this.formatter.wrap(join.table)
-        if (join.as) {
-          sql += ' as ' + this.formatter.wrap(join.as) + ' ';
+        if (join.joinAs) {
+          sql += ' as ' + this.formatter.wrap(join.joinAs);
         }
         var ii = -1
         while (++ii < join.clauses.length) {

--- a/src/query/joinclause.js
+++ b/src/query/joinclause.js
@@ -63,6 +63,11 @@ assign(JoinClause.prototype, {
     return this;
   },
 
+  as: function(as) {
+    this.as = as;
+    return this;
+  },
+
   _bool: function(bool) {
     if (arguments.length === 1) {
       this._boolFlag = bool;

--- a/src/query/joinclause.js
+++ b/src/query/joinclause.js
@@ -64,7 +64,7 @@ assign(JoinClause.prototype, {
   },
 
   as: function(as) {
-    this.as = as;
+    this.joinAs = as;
     return this;
   },
 


### PR DESCRIPTION
See issue https://github.com/tgriesser/knex/issues/915. Oops sorry, just noticed vim auto deleted white characters.