### PR TITLE
Fixes an issue where a transaction never rolls back as expected.

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -34,19 +34,15 @@ function Transaction(client, container, config, outerTx) {
     init.then(function () {
       return makeTransactor(_this, connection, trxClient);
     }).then(function (transactor) {
-
-      var result = container(transactor);
-
-      // If we've returned a "thenable" from the transaction container,
-      // and it's got the transaction object we're running for this, assume
-      // the rollback and commit are chained to this object's success / failure.
-      if (result && result.then && typeof result.then === 'function') {
-        result.then(function (val) {
+      return Promise.resolve()
+        .then(function () {
+          return container(transactor);
+        })
+        .then(function (val){
           transactor.commit(val);
         })['catch'](function (err) {
           transactor.rollback(err);
         });
-      }
     })['catch'](function (e) {
       return _this._rejecter(e);
     });


### PR DESCRIPTION
This PR fixes an issue where a connection may have a transaction that was never rolled back.

Steps to reproduce:
1. Acquire connection.
2. Create transaction (BEGIN).
3. Execute [`container(transactor)`](https://github.com/tgriesser/knex/blob/master/lib/transaction.js#L38).
4. Instead of returning a promise, [`container(transactor)`](https://github.com/tgriesser/knex/blob/master/lib/transaction.js#L38) throws an exception.

Result: Transaction will not be rolled back.  Next time someone uses the same connection, their changes will be done as part of the transaction.  This may result with the changes that are not saved to the DB.