### PR TITLE
Enable 'npm test' on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "dev": "babel -L -D -w src/ --out-dir lib/",
     "build": "./scripts/build.sh",
     "tape": "node test/tape/index.js | tap-spec",
-    "test": "npm run jshint && istanbul --config=test/.istanbul.yml cover _mocha -- --check-leaks -t 5000 -b -R spec test/index.js && npm run tape",
+    "test": "npm run jshint && istanbul --config=test/.istanbul.yml cover node_modules/mocha/bin/_mocha -- --check-leaks -t 5000 -b -R spec test/index.js && npm run tape",
     "plaintest": "mocha --check-leaks -t 10000 -b -R spec test/index.js && npm run tape",
     "coveralls": "cat ./test/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "jshint": "jshint --exclude=test/coverage/. test/. src/."


### PR DESCRIPTION
Relative path to mocha binary makes the command work on Windows as well, see more info from
https://github.com/gotwarlost/istanbul/issues/90#issuecomment-22331096