### PR TITLE
Improve tests and docs for migrate API

### DIFF
--- a/index.html
+++ b/index.html
@@ -2891,6 +2891,7 @@ $ knex seed:run
       <li><tt>directory</tt>: a relative path to the directory containing the migration files (default <tt>./migrations</tt>)</li>
       <li><tt>extension</tt>: the file extension used for the generated migration files (default <tt>js</tt>)</li>
       <li><tt>tableName</tt>: the table name used for storing the migration state (default <tt>knex_migrations</tt>)</li>
+      <li><tt>disableTransactions</tt>: don't run migrations inside transactions (default <tt>false</tt>)</li>
     </ul>
 
     <h4 id="Migrations-API-transactions">Transactions in migrations</h4>

--- a/index.html
+++ b/index.html
@@ -2880,10 +2880,18 @@ $ knex seed:run
     <h3 id="Migrations-API">Migration API</h3>
 
     <p>
-      <tt>knex.migrate</tt> is the class utilized by the knex migrations cli. Each method
-      takes an optional <tt>config</tt> object, which may specify the <tt>database</tt>,
-      <tt>directory</tt>, <tt>extension</tt>, and <tt>tableName</tt> for the migrations.
+      <tt>knex.migrate</tt> is the class utilized by the knex migrations cli.
     </p>
+
+    <p>
+      Each method takes an optional <tt>config</tt> object, which may specify the following properties:
+    </p>
+
+    <ul>
+      <li><tt>directory</tt>: a relative path to the directory containing the migration files (default <tt>./migrations</tt>)</li>
+      <li><tt>extension</tt>: the file extension used for the generated migration files (default <tt>js</tt>)</li>
+      <li><tt>tableName</tt>: the table name used for storing the migration state (default <tt>knex_migrations</tt>)</li>
+    </ul>
 
     <h4 id="Migrations-API-transactions">Transactions in migrations</h4>
 

--- a/src/migrate/index.js
+++ b/src/migrate/index.js
@@ -16,6 +16,13 @@ function LockError(msg) {
 }
 inherits(LockError, Error);
 
+const CONFIG_DEFAULT = Object.freeze({
+  extension: 'js',
+  tableName: 'knex_migrations',
+  directory: './migrations',
+  disableTransactions: false
+});
+
 // The new migration we're performing, typically called from the `knex.migrate`
 // interface on the main `knex` object. Passes the `knex` instance performing
 // the migration.
@@ -349,11 +356,7 @@ export default class Migrator {
   }
 
   setConfig(config) {
-    return assign({
-      extension: 'js',
-      tableName: 'knex_migrations',
-      directory: './migrations'
-    }, this.config || {}, config);
+    return assign({}, CONFIG_DEFAULT, this.config || {}, config);
   }
 
 }

--- a/test/tape/index.js
+++ b/test/tape/index.js
@@ -10,6 +10,7 @@ Object.keys(knexfile).forEach(function(key) {
   require('./raw')
   require('./query-builder')
   require('./seed')
+  require('./migrate')
   require('./pool')
   require('./knex')
 

--- a/test/tape/migrate.js
+++ b/test/tape/migrate.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var tape  = require('tape')
+var Migrator  = require('../../lib/migrate/index.js')
+
+tape('migrate: constructor uses config.migrations', function(t) {
+  t.plan(1)
+  var migrator = new Migrator({client: {config: {migrations: {directory: '/some/dir'}}}})
+  t.equal(migrator.config.directory, '/some/dir')
+})
+
+tape('migrate: setConfig() overrides configs given in constructor', function(t) {
+  t.plan(1)
+  var migrator = new Migrator({client: {config: {migrations: {directory: '/some/dir'}}}})
+
+  var config = migrator.setConfig({directory: './custom/path'})
+
+  t.equal(config.directory, './custom/path')
+})
+


### PR DESCRIPTION
Summary of changes:

- ~~Fix some typos from migrate API docs~~ (someone else was faster)
- Add a mention about `disableTransactions` config option
- Add descriptions for each config option
- Remove mention of config option `database` (couldn't find out where that would be used, hope I got this right?)
- Add basic `tape` tests for the migrator

Proof-reading the config option descriptions is probably a good idea.

The changes to actual code are sort-of cosmetic, just thought to make it easier to find the config default values. Was thinking of asserting for valid values in `setConfig()`, but didn't want to start breaking apps which are potentially feeding in invalid/old config values.