### PR TITLE
Allow disabling transaction per migration

### DIFF
--- a/index.html
+++ b/index.html
@@ -2484,6 +2484,26 @@ $ knex seed:run
       <tt>directory</tt>, <tt>extension</tt>, and <tt>tableName</tt> for the migrations.
     </p>
 
+    <h4 id="Migrations-API-transactions">Transactions in migrations</h4>
+
+    <p>
+      By default, each migration is run inside a transaction. Whenever needed, one can disable transactions for all migrations via the common migration config option <tt>config.disableTransactions</tt> or per-migration, via exposing a boolean property <tt>config.transaction</tt> from a migration file:
+    </p>
+
+<pre>
+<code class="js">
+exports.up = function(knex, Promise) { /* ... */ };
+exports.down = function(knex, Promise) { /* ... */ };
+exports.config {
+  transaction: false
+};
+</code>
+</pre>
+
+    <p>
+      The same config property can be used for enabling transaction per-migration in case the common configuration has <tt>disableTransactions: true</tt>.
+    </p>
+
     <p id="Migrations-make">
       <b class="header">make</b><code>knex.migrate.make(name, [config])</code>
       <br />

--- a/lib/connection/index.js
+++ b/lib/connection/index.js
@@ -1,12 +1,6 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
-var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+exports.__esModule = true;
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
@@ -20,7 +14,7 @@ var Connection = (function (_EventEmitter) {
   function Connection(connection) {
     _classCallCheck(this, Connection);
 
-    _get(Object.getPrototypeOf(Connection.prototype), 'constructor', this).call(this);
+    _EventEmitter.call(this);
     this.connection = connection;
 
     // Flag indicating whether the connection is "managed",
@@ -28,12 +22,9 @@ var Connection = (function (_EventEmitter) {
     this.managed = false;
   }
 
-  _createClass(Connection, [{
-    key: 'execute',
-    value: function execute() {
-      return this._execute();
-    }
-  }]);
+  Connection.prototype.execute = function execute() {
+    return this._execute();
+  };
 
   return Connection;
 })(_events.EventEmitter);

--- a/lib/migrate/index.js
+++ b/lib/migrate/index.js
@@ -2,11 +2,7 @@
 // -------
 "use strict";
 
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+exports.__esModule = true;
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
@@ -34,273 +30,262 @@ var Migrator = (function () {
 
   // Migrators to the latest configuration.
 
-  _createClass(Migrator, [{
-    key: 'latest',
-    value: function latest(config) {
-      var _this = this;
+  Migrator.prototype.latest = function latest(config) {
+    var _this = this;
 
-      this.config = this.setConfig(config);
-      return this._migrationData().tap(validateMigrationList).spread(function (all, completed) {
-        return _this._runBatch(_.difference(all, completed), 'up');
-      });
-    }
+    this.config = this.setConfig(config);
+    return this._migrationData().tap(validateMigrationList).spread(function (all, completed) {
+      return _this._runBatch(_.difference(all, completed), 'up');
+    });
+  };
 
-    // Rollback the last "batch" of migrations that were run.
-  }, {
-    key: 'rollback',
-    value: function rollback(config) {
-      var _this2 = this;
+  // Rollback the last "batch" of migrations that were run.
 
-      return Promise['try'](function () {
-        _this2.config = _this2.setConfig(config);
-        return _this2._migrationData().tap(validateMigrationList).then(function (val) {
-          return _this2._getLastBatch(val);
-        }).then(function (migrations) {
-          return _this2._runBatch(_.pluck(migrations, 'name'), 'down');
-        });
-      });
-    }
+  Migrator.prototype.rollback = function rollback(config) {
+    var _this2 = this;
 
-    // Retrieves and returns the current migration version
-    // we're on, as a promise. If there aren't any migrations run yet,
-    // return "none" as the value for the `currentVersion`.
-  }, {
-    key: 'currentVersion',
-    value: function currentVersion(config) {
-      this.config = this.setConfig(config);
-      return this._listCompleted(config).then(function (completed) {
-        var val = _.chain(completed).map(function (value) {
-          return value.split('_')[0];
-        }).max().value();
-        return val === -Infinity ? 'none' : val;
-      });
-    }
-
-    // Creates a new migration, with a given name.
-  }, {
-    key: 'make',
-    value: function make(name, config) {
-      var _this3 = this;
-
-      this.config = this.setConfig(config);
-      if (!name) Promise.rejected(new Error('A name must be specified for the generated migration'));
-      return this._ensureFolder(config).then(function (val) {
-        return _this3._generateStubTemplate(val);
-      }).then(function (val) {
-        return _this3._writeNewMigration(name, val);
-      });
-    }
-
-    // Lists all available migration versions, as a sorted array.
-  }, {
-    key: '_listAll',
-    value: function _listAll(config) {
-      this.config = this.setConfig(config);
-      return Promise.promisify(fs.readdir, fs)(this._absoluteConfigDir()).then(function (migrations) {
-        return _.filter(migrations, function (value) {
-          var extension = path.extname(value);
-          return _.contains(['.co', '.coffee', '.eg', '.iced', '.js', '.litcoffee', '.ls'], extension);
-        }).sort();
-      });
-    }
-
-    // Ensures a folder for the migrations exist, dependent on the
-    // migration config settings.
-  }, {
-    key: '_ensureFolder',
-    value: function _ensureFolder() {
-      var dir = this._absoluteConfigDir();
-      return Promise.promisify(fs.stat, fs)(dir)['catch'](function () {
-        return Promise.promisify(mkdirp)(dir);
-      });
-    }
-
-    // Ensures that the proper table has been created,
-    // dependent on the migration config settings.
-  }, {
-    key: '_ensureTable',
-    value: function _ensureTable() {
-      var _this4 = this;
-
-      var table = this.config.tableName;
-      return this.knex.schema.hasTable(table).then(function (exists) {
-        if (!exists) return _this4._createMigrationTable(table);
-      });
-    }
-
-    // Create the migration table, if it doesn't already exist.
-  }, {
-    key: '_createMigrationTable',
-    value: function _createMigrationTable(tableName) {
-      return this.knex.schema.createTable(tableName, function (t) {
-        t.increments();
-        t.string('name');
-        t.integer('batch');
-        t.timestamp('migration_time');
-      });
-    }
-
-    // Run a batch of current migrations, in sequence.
-  }, {
-    key: '_runBatch',
-    value: function _runBatch(migrations, direction) {
-      var _this5 = this;
-
-      return Promise.all(_.map(migrations, this._validateMigrationStructure, this)).then(function () {
-        return _this5._latestBatchNumber();
-      }).then(function (batchNo) {
-        if (direction === 'up') batchNo++;
-        return batchNo;
-      }).then(function (batchNo) {
-        return _this5._waterfallBatch(batchNo, migrations, direction);
-      })['catch'](function (error) {
-        helpers.warn('migrations failed with error: ' + error.message);
-        throw error;
-      });
-    }
-
-    // Validates some migrations by requiring and checking for an `up` and `down` function.
-  }, {
-    key: '_validateMigrationStructure',
-    value: function _validateMigrationStructure(name) {
-      var migration = require(path.join(this._absoluteConfigDir(), name));
-      if (typeof migration.up !== 'function' || typeof migration.down !== 'function') {
-        throw new Error('Invalid migration: ' + name + ' must have both an up and down function');
-      }
-      return name;
-    }
-
-    // Lists all migrations that have been completed for the current db, as an array.
-  }, {
-    key: '_listCompleted',
-    value: function _listCompleted() {
-      var _this6 = this;
-
-      var tableName = this.config.tableName;
-      return this._ensureTable(tableName).then(function () {
-        return _this6.knex(tableName).orderBy('id').select('name');
+    return Promise['try'](function () {
+      _this2.config = _this2.setConfig(config);
+      return _this2._migrationData().tap(validateMigrationList).then(function (val) {
+        return _this2._getLastBatch(val);
       }).then(function (migrations) {
-        return _.pluck(migrations, 'name');
+        return _this2._runBatch(_.pluck(migrations, 'name'), 'down');
       });
+    });
+  };
+
+  // Retrieves and returns the current migration version
+  // we're on, as a promise. If there aren't any migrations run yet,
+  // return "none" as the value for the `currentVersion`.
+
+  Migrator.prototype.currentVersion = function currentVersion(config) {
+    this.config = this.setConfig(config);
+    return this._listCompleted(config).then(function (completed) {
+      var val = _.chain(completed).map(function (value) {
+        return value.split('_')[0];
+      }).max().value();
+      return val === -Infinity ? 'none' : val;
+    });
+  };
+
+  // Creates a new migration, with a given name.
+
+  Migrator.prototype.make = function make(name, config) {
+    var _this3 = this;
+
+    this.config = this.setConfig(config);
+    if (!name) Promise.rejected(new Error('A name must be specified for the generated migration'));
+    return this._ensureFolder(config).then(function (val) {
+      return _this3._generateStubTemplate(val);
+    }).then(function (val) {
+      return _this3._writeNewMigration(name, val);
+    });
+  };
+
+  // Lists all available migration versions, as a sorted array.
+
+  Migrator.prototype._listAll = function _listAll(config) {
+    this.config = this.setConfig(config);
+    return Promise.promisify(fs.readdir, fs)(this._absoluteConfigDir()).then(function (migrations) {
+      return _.filter(migrations, function (value) {
+        var extension = path.extname(value);
+        return _.contains(['.co', '.coffee', '.eg', '.iced', '.js', '.litcoffee', '.ls'], extension);
+      }).sort();
+    });
+  };
+
+  // Ensures a folder for the migrations exist, dependent on the
+  // migration config settings.
+
+  Migrator.prototype._ensureFolder = function _ensureFolder() {
+    var dir = this._absoluteConfigDir();
+    return Promise.promisify(fs.stat, fs)(dir)['catch'](function () {
+      return Promise.promisify(mkdirp)(dir);
+    });
+  };
+
+  // Ensures that the proper table has been created,
+  // dependent on the migration config settings.
+
+  Migrator.prototype._ensureTable = function _ensureTable() {
+    var _this4 = this;
+
+    var table = this.config.tableName;
+    return this.knex.schema.hasTable(table).then(function (exists) {
+      if (!exists) return _this4._createMigrationTable(table);
+    });
+  };
+
+  // Create the migration table, if it doesn't already exist.
+
+  Migrator.prototype._createMigrationTable = function _createMigrationTable(tableName) {
+    return this.knex.schema.createTable(tableName, function (t) {
+      t.increments();
+      t.string('name');
+      t.integer('batch');
+      t.timestamp('migration_time');
+    });
+  };
+
+  // Run a batch of current migrations, in sequence.
+
+  Migrator.prototype._runBatch = function _runBatch(migrations, direction) {
+    var _this5 = this;
+
+    return Promise.all(_.map(migrations, this._validateMigrationStructure, this)).then(function () {
+      return _this5._latestBatchNumber();
+    }).then(function (batchNo) {
+      if (direction === 'up') batchNo++;
+      return batchNo;
+    }).then(function (batchNo) {
+      return _this5._waterfallBatch(batchNo, migrations, direction);
+    })['catch'](function (error) {
+      helpers.warn('migrations failed with error: ' + error.message);
+      throw error;
+    });
+  };
+
+  // Validates some migrations by requiring and checking for an `up` and `down` function.
+
+  Migrator.prototype._validateMigrationStructure = function _validateMigrationStructure(name) {
+    var migration = require(path.join(this._absoluteConfigDir(), name));
+    if (typeof migration.up !== 'function' || typeof migration.down !== 'function') {
+      throw new Error('Invalid migration: ' + name + ' must have both an up and down function');
     }
+    return name;
+  };
 
-    // Gets the migration list from the specified migration directory,
-    // as well as the list of completed migrations to check what
-    // should be run.
-  }, {
-    key: '_migrationData',
-    value: function _migrationData() {
-      return Promise.all([this._listAll(), this._listCompleted()]);
-    }
+  // Lists all migrations that have been completed for the current db, as an array.
 
-    // Generates the stub template for the current migration, returning a compiled template.
-  }, {
-    key: '_generateStubTemplate',
-    value: function _generateStubTemplate() {
-      var stubPath = this.config.stub || path.join(__dirname, 'stub', this.config.extension + '.stub');
-      return Promise.promisify(fs.readFile, fs)(stubPath).then(function (stub) {
-        return _.template(stub.toString(), null, { variable: 'd' });
-      });
-    }
+  Migrator.prototype._listCompleted = function _listCompleted() {
+    var _this6 = this;
 
-    // Write a new migration to disk, using the config and generated filename,
-    // passing any `variables` given in the config to the template.
-  }, {
-    key: '_writeNewMigration',
-    value: function _writeNewMigration(name, tmpl) {
-      var config = this.config;
-      var dir = this._absoluteConfigDir();
-      if (name[0] === '-') name = name.slice(1);
-      var filename = yyyymmddhhmmss() + '_' + name + '.' + config.extension;
-      return Promise.promisify(fs.writeFile, fs)(path.join(dir, filename), tmpl(config.variables || {}))['return'](path.join(dir, filename));
-    }
+    var tableName = this.config.tableName;
+    return this._ensureTable(tableName).then(function () {
+      return _this6.knex(tableName).orderBy('id').select('name');
+    }).then(function (migrations) {
+      return _.pluck(migrations, 'name');
+    });
+  };
 
-    // Get the last batch of migrations, by name, ordered by insert id
-    // in reverse order.
-  }, {
-    key: '_getLastBatch',
-    value: function _getLastBatch() {
-      var tableName = this.config.tableName;
-      return this.knex(tableName).where('batch', function (qb) {
-        qb.max('batch').from(tableName);
-      }).orderBy('id', 'desc');
-    }
+  // Gets the migration list from the specified migration directory,
+  // as well as the list of completed migrations to check what
+  // should be run.
 
-    // Returns the latest batch number.
-  }, {
-    key: '_latestBatchNumber',
-    value: function _latestBatchNumber() {
-      return this.knex(this.config.tableName).max('batch as max_batch').then(function (obj) {
-        return obj[0].max_batch || 0;
-      });
-    }
+  Migrator.prototype._migrationData = function _migrationData() {
+    return Promise.all([this._listAll(), this._listCompleted()]);
+  };
 
-    // Runs a batch of `migrations` in a specified `direction`,
-    // saving the appropriate database information as the migrations are run.
-  }, {
-    key: '_waterfallBatch',
-    value: function _waterfallBatch(batchNo, migrations, direction) {
-      var _this7 = this;
+  // Generates the stub template for the current migration, returning a compiled template.
 
-      var knex = this.knex;
-      var _config = this.config;
-      var tableName = _config.tableName;
-      var disableTransactions = _config.disableTransactions;
+  Migrator.prototype._generateStubTemplate = function _generateStubTemplate() {
+    var stubPath = this.config.stub || path.join(__dirname, 'stub', this.config.extension + '.stub');
+    return Promise.promisify(fs.readFile, fs)(stubPath).then(function (stub) {
+      return _.template(stub.toString(), null, { variable: 'd' });
+    });
+  };
 
-      var directory = this._absoluteConfigDir();
-      var current = Promise.bind({ failed: false, failedOn: 0 });
-      var log = [];
-      _.each(migrations, function (migration) {
-        var name = migration;
-        migration = require(directory + '/' + name);
+  // Write a new migration to disk, using the config and generated filename,
+  // passing any `variables` given in the config to the template.
 
-        // We're going to run each of the migrations in the current "up"
-        current = current.then(function () {
-          if (disableTransactions) {
-            return warnPromise(migration[direction](knex, Promise), name);
-          }
+  Migrator.prototype._writeNewMigration = function _writeNewMigration(name, tmpl) {
+    var config = this.config;
+    var dir = this._absoluteConfigDir();
+    if (name[0] === '-') name = name.slice(1);
+    var filename = yyyymmddhhmmss() + '_' + name + '.' + config.extension;
+    return Promise.promisify(fs.writeFile, fs)(path.join(dir, filename), tmpl(config.variables || {}))['return'](path.join(dir, filename));
+  };
+
+  // Get the last batch of migrations, by name, ordered by insert id
+  // in reverse order.
+
+  Migrator.prototype._getLastBatch = function _getLastBatch() {
+    var tableName = this.config.tableName;
+    return this.knex(tableName).where('batch', function (qb) {
+      qb.max('batch').from(tableName);
+    }).orderBy('id', 'desc');
+  };
+
+  // Returns the latest batch number.
+
+  Migrator.prototype._latestBatchNumber = function _latestBatchNumber() {
+    return this.knex(this.config.tableName).max('batch as max_batch').then(function (obj) {
+      return obj[0].max_batch || 0;
+    });
+  };
+
+  // If transaction conf for a single migration is defined, use that.
+  // Otherwise, rely on the common config. This allows enabling/disabling
+  // transaction for a single migration by will, regardless of the common
+  // config.
+
+  Migrator.prototype._useTransaction = function _useTransaction(migration, allTransactionsDisabled) {
+    var singleTransactionValue = _.get(migration, 'config.transaction');
+
+    return _.isBoolean(singleTransactionValue) ? singleTransactionValue : !allTransactionsDisabled;
+  };
+
+  // Runs a batch of `migrations` in a specified `direction`,
+  // saving the appropriate database information as the migrations are run.
+
+  Migrator.prototype._waterfallBatch = function _waterfallBatch(batchNo, migrations, direction) {
+    var _this7 = this;
+
+    var knex = this.knex;
+    var _config = this.config;
+    var tableName = _config.tableName;
+    var disableTransactions = _config.disableTransactions;
+
+    var directory = this._absoluteConfigDir();
+    var current = Promise.bind({ failed: false, failedOn: 0 });
+    var log = [];
+    _.each(migrations, function (migration) {
+      var name = migration;
+      migration = require(directory + '/' + name);
+
+      // We're going to run each of the migrations in the current "up"
+      current = current.then(function () {
+        if (_this7._useTransaction(migration, disableTransactions)) {
           return _this7._transaction(migration, direction, name);
-        }).then(function () {
-          log.push(path.join(directory, name));
-          if (direction === 'up') {
-            return knex(tableName).insert({
-              name: name,
-              batch: batchNo,
-              migration_time: new Date()
-            });
-          }
-          if (direction === 'down') {
-            return knex(tableName).where({ name: name }).del();
-          }
-        });
+        }
+        return warnPromise(migration[direction](knex, Promise), name);
+      }).then(function () {
+        log.push(path.join(directory, name));
+        if (direction === 'up') {
+          return knex(tableName).insert({
+            name: name,
+            batch: batchNo,
+            migration_time: new Date()
+          });
+        }
+        if (direction === 'down') {
+          return knex(tableName).where({ name: name }).del();
+        }
       });
+    });
 
-      return current.thenReturn([batchNo, log]);
-    }
-  }, {
-    key: '_transaction',
-    value: function _transaction(migration, direction, name) {
-      return this.knex.transaction(function (trx) {
-        return warnPromise(migration[direction](trx, Promise), name, function () {
-          trx.commit();
-        });
+    return current.thenReturn([batchNo, log]);
+  };
+
+  Migrator.prototype._transaction = function _transaction(migration, direction, name) {
+    return this.knex.transaction(function (trx) {
+      return warnPromise(migration[direction](trx, Promise), name, function () {
+        trx.commit();
       });
-    }
-  }, {
-    key: '_absoluteConfigDir',
-    value: function _absoluteConfigDir() {
-      return path.resolve(process.cwd(), this.config.directory);
-    }
-  }, {
-    key: 'setConfig',
-    value: function setConfig(config) {
-      return assign({
-        extension: 'js',
-        tableName: 'knex_migrations',
-        directory: './migrations'
-      }, this.config || {}, config);
-    }
-  }]);
+    });
+  };
+
+  Migrator.prototype._absoluteConfigDir = function _absoluteConfigDir() {
+    return path.resolve(process.cwd(), this.config.directory);
+  };
+
+  Migrator.prototype.setConfig = function setConfig(config) {
+    return assign({
+      extension: 'js',
+      tableName: 'knex_migrations',
+      directory: './migrations'
+    }, this.config || {}, config);
+  };
 
   return Migrator;
 })();

--- a/lib/util/parse-connection.js
+++ b/lib/util/parse-connection.js
@@ -1,8 +1,6 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
+exports.__esModule = true;
 exports['default'] = parseConnectionString;
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
@@ -32,7 +30,7 @@ function parseConnectionString(str) {
   }
   return {
     client: protocol,
-    connection: protocol === 'postgres' ? (0, _pgConnectionString.parse)(str) : connectionObject(parsed)
+    connection: protocol === 'postgres' ? _pgConnectionString.parse(str) : connectionObject(parsed)
   };
 }
 

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -76,7 +76,7 @@ module.exports = function(knex) {
       });
 
       it('should not create column for invalid migration', function() {
-        knex.schema.hasColumn('migration_test_1', 'transaction').then(function(exists) {
+        return knex.schema.hasColumn('migration_test_1', 'transaction').then(function(exists) {
           // MySQL / Oracle commit transactions implicit for most common
           // migration statements (e.g. CREATE TABLE, ALTER TABLE, DROP TABLE),
           // so we need to check for dialect

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -120,4 +120,28 @@ module.exports = function(knex) {
 
   });
 
+  describe('knex.migrate (transactions disabled)', function () {
+
+    describe('knex.migrate.latest (all transactions disabled)', function() {
+
+      before(function() {
+        return knex.migrate.latest({directory: 'test/integration/migrate/test', disableTransactions: true}).catch(function() {});
+      });
+
+      // Same test as before, but this time, because
+      // transactions are off, the column gets created for all dialects always.
+      it('should create column even in invalid migration', function() {
+        return knex.schema.hasColumn('migration_test_1', 'transaction').then(function(exists) {
+          expect(exists).to.equal(true);
+        });
+      });
+
+      after(function() {
+        return knex.migrate.rollback({directory: 'test/integration/migrate/test'});
+      });
+
+    });
+
+  });
+
 };

--- a/test/integration/migrate/test_per_migration_trx_disabled/20131019235242_migration_1.js
+++ b/test/integration/migrate/test_per_migration_trx_disabled/20131019235242_migration_1.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('migration_test_trx_1', function(t) {
+      t.increments();
+      t.string('name');
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('migration_test_trx_1');
+};

--- a/test/integration/migrate/test_per_migration_trx_disabled/20150109002832_invalid_migration.js
+++ b/test/integration/migrate/test_per_migration_trx_disabled/20150109002832_invalid_migration.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = function(knex) {
+  return knex.schema.table('migration_test_trx_1', function (table) {
+      table.string('transaction');
+    }).raw('SELECT foo FROM unknown_table');
+};
+
+exports.down = function() {
+
+};
+
+exports.config = {
+  transaction: false
+};

--- a/test/integration/migrate/test_per_migration_trx_disabled/20150109095253_migration_after_invalid.js
+++ b/test/integration/migrate/test_per_migration_trx_disabled/20150109095253_migration_after_invalid.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('should_not_be_run', function(t) {
+      t.increments();
+      t.string('name');
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('should_not_be_run');
+};

--- a/test/integration/migrate/test_per_migration_trx_enabled/20131019235242_migration_1.js
+++ b/test/integration/migrate/test_per_migration_trx_enabled/20131019235242_migration_1.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('migration_test_trx_1', function(t) {
+      t.increments();
+      t.string('name');
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('migration_test_trx_1');
+};

--- a/test/integration/migrate/test_per_migration_trx_enabled/20150109002832_invalid_migration.js
+++ b/test/integration/migrate/test_per_migration_trx_enabled/20150109002832_invalid_migration.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = function(knex) {
+  return knex.schema.table('migration_test_trx_1', function (table) {
+      table.string('transaction');
+    }).raw('SELECT foo FROM unknown_table');
+};
+
+exports.down = function() {
+
+};
+
+exports.config = {
+  transaction: true
+};

--- a/test/integration/migrate/test_per_migration_trx_enabled/20150109095253_migration_after_invalid.js
+++ b/test/integration/migrate/test_per_migration_trx_enabled/20150109095253_migration_after_invalid.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('should_not_be_run', function(t) {
+      t.increments();
+      t.string('name');
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('should_not_be_run');
+};


### PR DESCRIPTION
Hi,

As discussed in #848 and #834, there's cases where one needs to disable transactions on per-migration basis. Ran into a such case myself, and thus ended up taking my chances with this feature.

I couldn't find any hints whether this feature or migration-specific configs in general would be in the works, thus jumped right in to suggest something. If there's some activity around this already, happy to modify this PR accordingly.

The change in the code seemed straightforward, was wondering a bit how to set the actual configs in migration files. The end result below - the reason I didn't go with the current `config.disableTransactions` approach is that I wanted to get rid of that negation there. If you, however, feel that being consistent here would be better, I can change `config.transaction` -> `config.disableTransaction`, for example.

Tests became maybe a bit messy since had to create multiple sets of test migration files, but not much alternatives afaics.
