### PR TITLE
Don't insert or update columns with undefined values

### DIFF
--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -78,7 +78,6 @@ assign(QueryCompiler.prototype, {
     } else if (typeof insertValues === 'object' && _.isEmpty(insertValues)) {
       return sql + this._emptyInsertValue;
     }
-
     var insertData = this._prepInsert(insertValues);
     if (typeof insertData === 'string') {
       sql += insertData;
@@ -360,6 +359,7 @@ assign(QueryCompiler.prototype, {
     var i = -1;
     while (++i < data.length) {
       if (data[i] == null) break;
+      data[i] = _.omit(data[i], _.isUndefined);
       if (i === 0) columns = Object.keys(data[i]).sort();
       var row = new Array(columns.length);
       var keys = Object.keys(data[i]);
@@ -388,6 +388,7 @@ assign(QueryCompiler.prototype, {
 
   // "Preps" the update.
   _prepUpdate: function _prepUpdate(data) {
+    data = _.omit(data, _.isUndefined);
     var vals = [];
     var sorted = Object.keys(data).sort();
     var i = -1;

--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -359,7 +359,6 @@ assign(QueryCompiler.prototype, {
     var i = -1;
     while (++i < data.length) {
       if (data[i] == null) break;
-      data[i] = _.omit(data[i], _.isUndefined);
       if (i === 0) columns = Object.keys(data[i]).sort();
       var row = new Array(columns.length);
       var keys = Object.keys(data[i]);

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -57,7 +57,7 @@ assign(QueryCompiler.prototype, {
     }
     return _.compact(statements).join(' ');
   },
-  
+
   pluck: function() {
     return {
       sql: this.select(),
@@ -78,13 +78,12 @@ assign(QueryCompiler.prototype, {
     } else if (typeof insertValues === 'object' && _.isEmpty(insertValues)) {
       return sql + this._emptyInsertValue
     }
-
     var insertData = this._prepInsert(insertValues);
     if (typeof insertData === 'string') {
       sql += insertData;
     } else  {
       if (insertData.columns.length) {
-        sql += '(' + this.formatter.columnize(insertData.columns) 
+        sql += '(' + this.formatter.columnize(insertData.columns)
         sql += ') values ('
         var i = -1
         while (++i < insertData.values.length) {
@@ -124,14 +123,14 @@ assign(QueryCompiler.prototype, {
         if (stmt.distinct) distinct = true
         if (stmt.type === 'aggregate') {
           sql.push(this.aggregate(stmt))
-        } 
+        }
         else if (stmt.value && stmt.value.length > 0) {
           sql.push(this.formatter.columnize(stmt.value))
         }
       }
     }
     if (sql.length === 0) sql = ['*'];
-    return 'select ' + (distinct ? 'distinct ' : '') + 
+    return 'select ' + (distinct ? 'distinct ' : '') +
       sql.join(', ') + (this.tableName ? ' from ' + this.tableName : '');
   },
 
@@ -357,7 +356,7 @@ assign(QueryCompiler.prototype, {
     if (statement.not) return 'not ' + str;
     return str;
   },
-  
+
   _prepInsert: function(data) {
     var isRaw = this.formatter.rawOrFn(data);
     if (isRaw) return isRaw;
@@ -367,6 +366,7 @@ assign(QueryCompiler.prototype, {
     var i = -1
     while (++i < data.length) {
       if (data[i] == null) break;
+      data[i] = _.omit(data[i], _.isUndefined)
       if (i === 0) columns = Object.keys(data[i]).sort()
       var row  = new Array(columns.length)
       var keys = Object.keys(data[i])
@@ -395,6 +395,7 @@ assign(QueryCompiler.prototype, {
 
   // "Preps" the update.
   _prepUpdate: function(data) {
+    data = _.omit(data, _.isUndefined)
     var vals   = []
     var sorted = Object.keys(data).sort()
     var i      = -1

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -366,7 +366,6 @@ assign(QueryCompiler.prototype, {
     var i = -1
     while (++i < data.length) {
       if (data[i] == null) break;
-      data[i] = _.omit(data[i], _.isUndefined)
       if (i === 0) columns = Object.keys(data[i]).sort()
       var row  = new Array(columns.length)
       var keys = Object.keys(data[i])

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -1519,6 +1519,19 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it("should not insert with undefined values", function(){
+    testsql(qb().into('users').insert({'email': 'foo', 'name': undefined}), {
+      mysql: {
+        sql: 'insert into `users` (`email`) values (?)',
+        bindings: ['foo']
+      },
+      default: {
+        sql: 'insert into "users" ("email") values (?)',
+        bindings: ['foo']
+      }
+    });
+  });
+
   // it("insert with array with null value and returning is a noop", function() {
   //   testsql(qb().into('users').insert([null], 'id'), {
   //     mysql: {
@@ -1639,6 +1652,19 @@ describe("QueryBuilder", function() {
       default: {
         sql: 'update "users" set "email" = ?, "name" = ? where "id" = ?',
         bindings: ['foo', 'bar', 1]
+      }
+    });
+  });
+
+  it("should not update columns undefined values", function() {
+    testsql(qb().update({'email': 'foo', 'name': undefined}).table('users').where('id', '=', 1), {
+      mysql: {
+        sql: 'update `users` set `email` = ? where `id` = ?',
+        bindings: ['foo', 1]
+      },
+      default: {
+        sql: 'update "users" set "email" = ? where "id" = ?',
+        bindings: ['foo', 1]
       }
     });
   });

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -20,7 +20,7 @@ function qb() {
   return clients.default.queryBuilder()
 }
 
-function raw(sql, bindings) { 
+function raw(sql, bindings) {
   return clients.default.raw(sql, bindings)
 }
 
@@ -30,7 +30,7 @@ function verifySqlResult(dialect, expectedObj, sqlObj) {
       expectedObj[key](sqlObj[key]);
     } else {
       try {
-        expect(sqlObj[key]).to.deep.equal(expectedObj[key]);  
+        expect(sqlObj[key]).to.deep.equal(expectedObj[key]);
       } catch (e) {
         e.stack = dialect + ': ' + e.stack
         throw e
@@ -39,7 +39,7 @@ function verifySqlResult(dialect, expectedObj, sqlObj) {
   });
 }
 
-function testsql(chain, valuesToCheck) {  
+function testsql(chain, valuesToCheck) {
   Object.keys(valuesToCheck).forEach(function(key) {
     var newChain = chain.clone()
         newChain.client = clients[key]
@@ -1518,20 +1518,6 @@ describe("QueryBuilder", function() {
       }
     });
   });
-
-  it("should not insert with undefined values", function(){
-    testsql(qb().into('users').insert({'email': 'foo', 'name': undefined}), {
-      mysql: {
-        sql: 'insert into `users` (`email`) values (?)',
-        bindings: ['foo']
-      },
-      default: {
-        sql: 'insert into "users" ("email") values (?)',
-        bindings: ['foo']
-      }
-    });
-  });
-
   // it("insert with array with null value and returning is a noop", function() {
   //   testsql(qb().into('users').insert([null], 'id'), {
   //     mysql: {
@@ -2390,20 +2376,20 @@ describe("QueryBuilder", function() {
       }
     })
   })
-  
+
   it('has a modify method which accepts a function that can modify the query', function() {
-    // arbitrary number of arguments can be passed to `.modify(queryBuilder, ...)`, 
+    // arbitrary number of arguments can be passed to `.modify(queryBuilder, ...)`,
     // builder is bound to `this`
     var withBars = function(queryBuilder, table, fk) {
       if(!this || this !== queryBuilder) {
         throw 'Expected query builder passed as first argument and bound as `this` context';
       }
-      
+
       this
         .leftJoin('bars', table + '.' + fk, 'bars.id')
         .select('bars.*')
     };
-    
+
     testsql(qb().select('foo_id').from('foos').modify(withBars, 'foos', 'bar_id'), {
       mysql: {
         sql: 'select `foo_id`, `bars`.* from `foos` left join `bars` on `foos`.`bar_id` = `bars`.`id`'


### PR DESCRIPTION
Fixes #961. This is unable to work on bulk inserts. 

Not set up to do integration tests, was able to run through unit tests fine. 