### PR TITLE
Clarify documentation for defaults for precision and scale

### DIFF
--- a/index.html
+++ b/index.html
@@ -1756,13 +1756,13 @@ knex.schema.raw("SET sql_mode='TRADITIONAL'")
     <p id="Schema-float">
       <b class="header">float</b><code>table.float(column, [precision], [scale])</code>
       <br />
-      Adds a float column, with optional precision and scale.
+      Adds a float column, with optional precision (defaults to 8) and scale (defaults to 2).
     </p>
 
     <p id="Schema-decimal">
       <b class="header">decimal</b><code>table.decimal(column, [precision], [scale])</code>
       <br />
-      Adds a decimal column, with optional precision and scale.
+      Adds a decimal column, with optional precision (defaults to 8) and scale (defaults to 2).
     </p>
 
     <p id="Schema-boolean">


### PR DESCRIPTION
Had to go digging through the source code to find out how my numeric columns were getting their defaults.  I added a line to the float and decimal columns types' documentation to make it clear.  This is in line with other defaults that are specified in the docs.