### PR TITLE
Change `exports` to `module.exports` in migration stubs

### DIFF
--- a/lib/migrate/stub/coffee.stub
+++ b/lib/migrate/stub/coffee.stub
@@ -1,5 +1,5 @@
 
-exports.up = (knex, Promise) ->
+module.exports.up = (knex, Promise) ->
   <% if (d.tableName) { %>
   knex.schema.createTable "<%= d.tableName %>", (t) ->
     t.increments()
@@ -7,7 +7,7 @@ exports.up = (knex, Promise) ->
   <% } %>
 
 
-exports.down = (knex, Promise) ->
+module.exports.down = (knex, Promise) ->
   <% if (d.tableName) { %>
   knex.schema.dropTable "<%= d.tableName %>"
   <% } %>

--- a/lib/migrate/stub/js.stub
+++ b/lib/migrate/stub/js.stub
@@ -1,5 +1,5 @@
 
-exports.up = function(knex, Promise) {
+module.exports.up = function(knex, Promise) {
   <% if (d.tableName) { %>
   return knex.schema.createTable("<%= d.tableName %>", function(t) {
     t.increments();
@@ -8,7 +8,7 @@ exports.up = function(knex, Promise) {
   <% } %>
 };
 
-exports.down = function(knex, Promise) {
+module.exports.down = function(knex, Promise) {
   <% if (d.tableName) { %>
   return knex.schema.dropTable("<%= d.tableName %>");
   <% } %>

--- a/lib/migrate/stub/ls.stub
+++ b/lib/migrate/stub/ls.stub
@@ -1,5 +1,5 @@
 
-exports.up = (knex, Promise) ->
+module.exports.up = (knex, Promise) ->
   <% if (d.tableName) { %>
   knex.schema.create-table "<%= d.tableName %>", (t) ->
     t.increments!
@@ -7,7 +7,7 @@ exports.up = (knex, Promise) ->
   <% } %>
 
 
-exports.down = (knex, Promise) ->
+module.exports.down = (knex, Promise) ->
   <% if (d.tableName) { %>
   knex.schema.drop-table "<%= d.tableName %>"
   <% } %>


### PR DESCRIPTION
For 1) consistency and 2) keeping people from doing the wrong thing (eg. refactoring the code and trying to assign an object to `exports`). Less footguns is better :)