### PR TITLE
Don't attempt to release resources that have been disposed of already

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -135,6 +135,7 @@ assign(Runner.prototype, {
     return Promise['try'](function () {
       return runner.connection || runner.client.acquireConnection();
     }).disposer(function () {
+      if (runner.connection.__knex__disposed) return;
       runner.client.releaseConnection(runner.connection);
     });
   }

--- a/src/runner.js
+++ b/src/runner.js
@@ -139,6 +139,7 @@ assign(Runner.prototype, {
     return Promise.try(function() {
       return runner.connection || runner.client.acquireConnection()
     }).disposer(function() {
+      if (runner.connection.__knex__disposed) return
       runner.client.releaseConnection(runner.connection)
     })
   }


### PR DESCRIPTION
I tried using 'npm build' to generate the PR but a lot of things changed, possibly due to changes in webpack. It's a bit weird to check in both versions of the source -- perhaps a post-install hook to build from source or something like that would be more appropriate?

Tests are still too convoluted for me to have any idea how to go about testing this; just to generate the error to run this down I had to wrap native node.js modules: https://github.com/myndzi/pool2/issues/12#issuecomment-139792551

It's a simple enough fix, though, that I think it's okay to merge and probably release. This will hopefully take care of various random network errors producing error messages from knex that can be safely ignored.