### PR TITLE
Add all supported Mysql2 dialect options

### DIFF
--- a/src/dialects/mysql2/index.js
+++ b/src/dialects/mysql2/index.js
@@ -10,8 +10,37 @@ var pluck        = require('lodash/collection/pluck')
 var assign       = require('lodash/object/assign');
 var Transaction  = require('./transaction')
 
-var configOptions = ['user', 'database', 'host', 'password',
-  'port', 'ssl', 'connection', 'compress', 'stream'];
+var configOptions = [
+  'isServer',
+  'stream',
+  'host',
+  'port',
+  'localAddress',
+  'socketPath',
+  'user',
+  'password',
+  'passwordSha1',
+  'database',
+  'connectTimeout',
+  'insecureAuth',
+  'supportBigNumbers',
+  'bigNumberStrings',
+  'decimalNumbers',
+  'dateStrings',
+  'debug',
+  'trace',
+  'stringifyObjects',
+  'timezone',
+  'flags',
+  'queryFormat',
+  'pool',
+  'ssl',
+  'multipleStatements',
+  'namedPlaceholders',
+  'typeCast',
+  'charsetNumber',
+  'compress'
+];
 
 // Always initialize with the "QueryBuilder" and "QueryCompiler"
 // objects, which extend the base 'lib/query/builder' and


### PR DESCRIPTION
You are missing a bunch of support options and one that is coming soon to make decimals numbers. I added them all though I am not sure why we filter them at all. We should just pass them along but didn't want to make a breaking change like that.

**_Had to remove charset as it is different then the Pool2 library's charset._**