### PR TITLE
Fix 'migrate.latest()' when at base migration

### DIFF
--- a/lib/migrate/index.js
+++ b/lib/migrate/index.js
@@ -210,7 +210,7 @@ var Migrator = (function () {
 
   Migrator.prototype._latestBatchNumber = function _latestBatchNumber() {
     return this.knex(this.config.tableName).max('batch as max_batch').then(function (obj) {
-      return obj[0].max_batch || 0;
+      return Array.isArray(obj) ? obj[0].max_batch : 0;
     });
   };
 


### PR DESCRIPTION
Getting `Knex:warning - migrations failed with error: Cannot read property '0' of undefined` when running `knex.migrate.latest(config)` when at the base migration (no records in migrations table)