### PR TITLE
Query event in Transaction should be proxied to the main client

### DIFF
--- a/lib/dialects/websql/transaction.js
+++ b/lib/dialects/websql/transaction.js
@@ -24,6 +24,7 @@ function makeClient(trx, client) {
 
   trxClient.on('query', function (arg) {
     trx.emit('query', arg);
+    client.emit('query', arg);
   });
   trxClient.commit = function () {};
   trxClient.rollback = function () {};

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -208,6 +208,7 @@ function makeTxClient(trx, client, connection) {
 
   trxClient.on('query', function (arg) {
     trx.emit('query', arg);
+    client.emit('query', arg);
   });
 
   var _query = trxClient.query;

--- a/src/dialects/websql/transaction.js
+++ b/src/dialects/websql/transaction.js
@@ -23,6 +23,7 @@ function makeClient(trx, client) {
   
   trxClient.on('query', function(arg) {
     trx.emit('query', arg)
+    client.emit('query', arg)
   })
   trxClient.commit = function() {}
   trxClient.rollback = function() {}

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -211,6 +211,7 @@ function makeTxClient(trx, client, connection) {
   
   trxClient.on('query', function(arg) {
     trx.emit('query', arg)
+    client.emit('query', arg)
   })
 
   var _query = trxClient.query;

--- a/test/integration/builder/transaction.js
+++ b/test/integration/builder/transaction.js
@@ -253,6 +253,27 @@ module.exports = function(knex) {
       })
     })
 
+    it('#855 - Query Event should trigger on Transaction Client AND main Client', function(done) {
+      var queryEventTriggered = false;
+
+      knex.once('query', function(queryData) {
+        queryEventTriggered = true;
+        return queryData;
+      });
+
+      function expectQueryEventToHaveBeenTriggered() {
+        expect(queryEventTriggered).to.equal(true);
+        done();
+      }
+
+      knex.transaction(function(trx) {
+        trx.select('*').from('accounts').then(tr.commit).catch(tr.rollback);
+      })
+          .then(expectQueryEventToHaveBeenTriggered)
+          .catch(expectQueryEventToHaveBeenTriggered);
+
+    });
+
   });
 
 };

--- a/test/integration/builder/transaction.js
+++ b/test/integration/builder/transaction.js
@@ -267,7 +267,7 @@ module.exports = function(knex) {
       }
 
       knex.transaction(function(trx) {
-        trx.select('*').from('accounts').then(tr.commit).catch(tr.rollback);
+        trx.select('*').from('accounts').then(trx.commit).catch(trx.rollback);
       })
           .then(expectQueryEventToHaveBeenTriggered)
           .catch(expectQueryEventToHaveBeenTriggered);


### PR DESCRIPTION
As discussed with @tgriesser in #855 the query event is no longer triggered onto the main client when in a transaction. It was simply a miss during the transaction overhaul, according to tgriessers's comments.

Example code:
```
dbClient.on('query', function(obj) {
	console.log('onQuery'); //Works in knex < 8.0.0, fails in >= 8.0.0
	return obj;
});

dbClient.transaction(function(tr) {
	return tr.raw('SELECT version()').then(tr.commit).catch(tr.rollback);
}).then(_.noop).catch(_.noop);
```

There may be better ways of fixing this, I don't know.