### PR TITLE
Ensure /lib is up to date during CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ node_js:
 before_script:
   - psql -c 'create database knex_test;' -U postgres
   - mysql -e 'create database knex_test;'
+  - babel -L -D src/ --out-dir lib/
 
 after_script:
   - npm run-script coveralls


### PR DESCRIPTION
As noted in this [comment](https://github.com/tgriesser/knex/pull/1009#issuecomment-146021024) it looks like Travis doesn't have an `npm run dev` step, so PRs which do not remember to update `/lib` will not be tested against the built source.