### PR TITLE
Change pool initialization to be asynchronous

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -157,7 +157,6 @@ assign(Client.prototype, {
         }
       }).then(function () {
         client.pool = new client.Pool(assign(client.poolDefaults(config.pool || {}), config.pool));
-        client.pool.setMaxListeners(0); // Suppress warnings about too many event listeners
         client.pool.on('error', function (err) {
           helpers.error('Pool2 - ' + err);
         });
@@ -235,20 +234,10 @@ assign(Client.prototype, {
   // A callback may also be used instead of a promise.
   releaseConnection: function releaseConnection(connection, callback) {
     var pool = this.pool;
-    var promise = new Promise(function (resolver, rejecter) {
-      var errorHandler, successHandler;
+    var promise = new Promise(function (resolver) {
       debug('releasing connection to pool: %s', connection.__knexUid);
-      errorHandler = function (err) {
-        pool.removeListener('drain', successHandler);
-        rejecter(err);
-      };
-      successHandler = function () {
-        pool.removeListener('error', errorHandler);
-        resolver();
-      };
-      pool.once('error', errorHandler);
-      pool.once('drain', successHandler);
       pool.release(connection);
+      resolver();
     });
     // Allow either a callback or promise interface for releasing connections.
     if (typeof callback === 'function') {

--- a/lib/client.js
+++ b/lib/client.js
@@ -38,9 +38,6 @@ function Client() {
   this.connectionSettings = cloneDeep(config.connection || {});
   if (this.driverName && config.connection) {
     this.initializeDriver();
-    if (!config.pool || config.pool && config.pool.max !== 0) {
-      this.initializePool(config);
-    }
   }
 }
 inherits(Client, EventEmitter);
@@ -151,15 +148,30 @@ assign(Client.prototype, {
 
   Pool: Pool2,
 
-  initializePool: function initializePool(config) {
-    if (this.pool) this.destroy();
-    this.pool = new this.Pool(assign(this.poolDefaults(config.pool || {}), config.pool));
-    this.pool.on('error', function (err) {
-      helpers.error('Pool2 - ' + err);
+  initializePool: function initializePool(config, callback) {
+    var client = this;
+    var promise = new Promise(function (resolver, rejecter) {
+      return Promise['try'](function () {
+        if (client.pool) {
+          return client.destroy();
+        }
+      }).then(function () {
+        client.pool = new client.Pool(assign(client.poolDefaults(config.pool || {}), config.pool));
+        client.pool.on('error', function (err) {
+          helpers.error('Pool2 - ' + err);
+        });
+        client.pool.on('warn', function (msg) {
+          helpers.warn('Pool2 - ' + msg);
+        });
+        resolver();
+      })['catch'](rejecter);
     });
-    this.pool.on('warn', function (msg) {
-      helpers.warn('Pool2 - ' + msg);
-    });
+    // Allow either a callback or promise interface for initialization.
+    if (typeof callback === 'function') {
+      promise.nodeify(callback);
+    } else {
+      return promise;
+    }
   },
 
   poolDefaults: function poolDefaults(poolConfig) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -150,21 +150,21 @@ assign(Client.prototype, {
 
   initializePool: function initializePool(config, callback) {
     var client = this;
-    var promise = new Promise(function (resolver, rejecter) {
+    var promise = Promise['try'](function () {
       return Promise['try'](function () {
         if (client.pool) {
           return client.destroy();
         }
       }).then(function () {
         client.pool = new client.Pool(assign(client.poolDefaults(config.pool || {}), config.pool));
+        client.pool.setMaxListeners(0); // Suppress warnings about too many event listeners
         client.pool.on('error', function (err) {
           helpers.error('Pool2 - ' + err);
         });
         client.pool.on('warn', function (msg) {
           helpers.warn('Pool2 - ' + msg);
         });
-        resolver();
-      })['catch'](rejecter);
+      });
     });
     // Allow either a callback or promise interface for initialization.
     if (typeof callback === 'function') {
@@ -207,39 +207,66 @@ assign(Client.prototype, {
   },
 
   // Acquire a connection from the pool.
-  acquireConnection: function acquireConnection() {
+  acquireConnection: function acquireConnection(callback) {
     var client = this;
-    return new Promise(function (resolver, rejecter) {
+    var promise = Promise['try'](function () {
       if (!client.pool) {
-        return rejecter(new Error('There is no pool defined on the current client'));
+        if (!client.config.pool || client.config.pool && client.config.pool.max !== 0) {
+          return client.initializePool(client.config);
+        }
+        throw new Error('There is no pool defined on the current client');
       }
-      client.pool.acquire(function (err, connection) {
-        if (err) return rejecter(err);
+    }).then(function () {
+      return Promise.fromNode(client.pool.acquire.bind(client.pool)).then(function (connection) {
         debug('acquiring connection from pool: %s', connection.__knexUid);
-        resolver(connection);
+        return connection;
       });
     });
+    // Allow either a callback or promise interface for initialization.
+    if (typeof callback === 'function') {
+      promise.nodeify(callback);
+    } else {
+      return promise;
+    }
   },
 
   // Releases a connection back to the connection pool,
   // returning a promise resolved when the connection is released.
-  releaseConnection: function releaseConnection(connection) {
+  // A callback may also be used instead of a promise.
+  releaseConnection: function releaseConnection(connection, callback) {
     var pool = this.pool;
-    return new Promise(function (resolver) {
+    var promise = new Promise(function (resolver, rejecter) {
+      var errorHandler, successHandler;
       debug('releasing connection to pool: %s', connection.__knexUid);
+      errorHandler = function (err) {
+        pool.removeListener('drain', successHandler);
+        rejecter(err);
+      };
+      successHandler = function () {
+        pool.removeListener('error', errorHandler);
+        resolver();
+      };
+      pool.once('error', errorHandler);
+      pool.once('drain', successHandler);
       pool.release(connection);
-      resolver();
     });
+    // Allow either a callback or promise interface for releasing connections.
+    if (typeof callback === 'function') {
+      promise.nodeify(callback);
+    } else {
+      return promise;
+    }
   },
 
   // Destroy the current connection pool for the client.
   destroy: function destroy(callback) {
     var client = this;
-    var promise = new Promise(function (resolver) {
-      if (!client.pool) return resolver();
-      client.pool.end(function () {
+    var promise = Promise['try'](function () {
+      if (!client.pool) {
+        return;
+      }
+      return Promise.fromNode(client.pool.end.bind(client.pool)).then(function () {
         client.pool = undefined;
-        resolver();
       });
     });
     // Allow either a callback or promise interface for destruction.

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -39,9 +39,8 @@ module.exports = function makeKnex(client) {
       return client.transaction(container, config);
     },
 
-    // Initializes the pool for a knex client. Must be called before submitting
-    // queries to the database. Returns a promise, and may optionally be called
-    // with a callback.
+    // Initializes the pool for a knex client. Not normally required. Returns a
+    // promise, and may optionally be called with a callback.
     initialize: function initialize(config, callback) {
       return client.initializePool(config, callback);
     },

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -39,12 +39,15 @@ module.exports = function makeKnex(client) {
       return client.transaction(container, config);
     },
 
-    // Typically never needed, initializes the pool for a knex client.
-    initialize: function initialize(config) {
-      return client.initialize(config);
+    // Initializes the pool for a knex client. Must be called before submitting
+    // queries to the database. Returns a promise, and may optionally be called
+    // with a callback.
+    initialize: function initialize(config, callback) {
+      return client.initializePool(config, callback);
     },
 
-    // Convenience method for tearing down the pool.
+    // Convenience method for tearing down the pool. Returns a promise, and may
+    // optionally be called with a callback.
     destroy: function destroy(callback) {
       return client.destroy(callback);
     }

--- a/src/client.js
+++ b/src/client.js
@@ -155,7 +155,6 @@ assign(Client.prototype, {
       })
       .then(function() {
         client.pool = new client.Pool(assign(client.poolDefaults(config.pool || {}), config.pool))
-        client.pool.setMaxListeners(0) // Suppress warnings about too many event listeners
         client.pool.on('error', function(err) {
           helpers.error('Pool2 - ' + err)
         })
@@ -236,20 +235,10 @@ assign(Client.prototype, {
   // A callback may also be used instead of a promise.
   releaseConnection: function(connection, callback) {
     var pool = this.pool
-    var promise = new Promise(function(resolver, rejecter) {
-      var errorHandler, successHandler
+    var promise = new Promise(function(resolver) {
       debug('releasing connection to pool: %s', connection.__knexUid)
-      errorHandler = function(err) {
-        pool.removeListener('drain', successHandler)
-        rejecter(err)
-      }
-      successHandler = function() {
-        pool.removeListener('error', errorHandler)
-        resolver()
-      }
-      pool.once('error', errorHandler)
-      pool.once('drain', successHandler)
       pool.release(connection)
+      resolver()
     })
     // Allow either a callback or promise interface for releasing connections.
     if (typeof callback === 'function') {

--- a/src/util/make-knex.js
+++ b/src/util/make-knex.js
@@ -20,7 +20,7 @@ module.exports = function makeKnex(client) {
   }
 
   assign(knex, {
-    
+
     Promise: require('../promise'),
 
     // A new query builder instance
@@ -38,12 +38,15 @@ module.exports = function makeKnex(client) {
       return client.transaction(container, config)
     },
 
-    // Typically never needed, initializes the pool for a knex client.
-    initialize: function(config) {
-      return client.initialize(config)
+    // Initializes the pool for a knex client. Must be called before submitting
+    // queries to the database. Returns a promise, and may optionally be called
+    // with a callback.
+    initialize: function(config, callback) {
+      return client.initializePool(config, callback)
     },
 
-    // Convenience method for tearing down the pool.
+    // Convenience method for tearing down the pool. Returns a promise, and may
+    // optionally be called with a callback.
     destroy: function(callback) {
       return client.destroy(callback)
     }
@@ -68,7 +71,7 @@ module.exports = function makeKnex(client) {
       return builder[method].apply(builder, arguments)
     }
   })
-  
+
   knex.client = client
 
   Object.defineProperties(knex, {
@@ -103,7 +106,7 @@ module.exports = function makeKnex(client) {
   client.on('start', function(obj) {
     knex.emit('start', obj)
   })
-  
+
   client.on('query', function(obj) {
     knex.emit('query', obj)
   })

--- a/src/util/make-knex.js
+++ b/src/util/make-knex.js
@@ -38,9 +38,8 @@ module.exports = function makeKnex(client) {
       return client.transaction(container, config)
     },
 
-    // Initializes the pool for a knex client. Must be called before submitting
-    // queries to the database. Returns a promise, and may optionally be called
-    // with a callback.
+    // Initializes the pool for a knex client. Not normally required. Returns a
+    // promise, and may optionally be called with a callback.
     initialize: function(config, callback) {
       return client.initializePool(config, callback)
     },

--- a/test/integration/suite.js
+++ b/test/integration/suite.js
@@ -4,11 +4,16 @@
 
 module.exports = function(knex) {
   var sinon = require('sinon');
+  var Pool2 = require('pool2');
 
   describe(knex.client.dialect + ' | ' + knex.client.driverName, function() {
 
     this.dialect    = knex.client.dialect;
     this.driverName = knex.client.driverName;
+
+    before(function () {
+      return knex.initialize(knex.client.config)
+    });
 
     require('./schema')(knex);
     require('./migrate')(knex);
@@ -22,6 +27,17 @@ module.exports = function(knex) {
     require('./builder/transaction')(knex);
     require('./builder/deletes')(knex);
     require('./builder/additional')(knex);
+
+    describe('knex.initialize', function() {
+      it('should allow reinitializing the pool with knex.initialize', function() {
+        var spy = sinon.spy(knex.client.pool, 'end');
+        return knex.initialize(knex.client.config)
+        .then(function () {
+          expect(knex.client.pool).to.be.an.instanceof(Pool2);
+          expect(spy).to.have.callCount(1);
+        });
+      });
+    });
 
     describe('knex.destroy', function() {
       it('should allow destroying the pool with knex.destroy', function() {

--- a/test/tape/index.js
+++ b/test/tape/index.js
@@ -5,7 +5,7 @@ var makeKnex = require('../../knex')
 var knexfile = require('../knexfile')
 
 Object.keys(knexfile).forEach(function(key) {
-  
+
   require('./parse-connection')
   require('./raw')
   require('./query-builder')
@@ -14,15 +14,20 @@ Object.keys(knexfile).forEach(function(key) {
   require('./knex')
 
   var knex = makeKnex(knexfile[key])
-  
-  require('./transactions')(knex)
-  require('./stream')(knex)
-  
-  // Tear down the knex connection
-  tape(knex.client.driverName + ' - transactions: after', function(t) {
-    knex.destroy().then(function() {
-      t.end()
+
+  knex.initialize(knex.client.config, function () {
+
+    require('./transactions')(knex)
+    require('./stream')(knex)
+
+    // Tear down the knex connection
+    tape(knex.client.driverName + ' - transactions: after', function(t) {
+      knex.destroy(function() {
+        t.end()
+      })
     })
+
+
   })
 
 })

--- a/test/tape/index.js
+++ b/test/tape/index.js
@@ -15,19 +15,14 @@ Object.keys(knexfile).forEach(function(key) {
 
   var knex = makeKnex(knexfile[key])
 
-  knex.initialize(knex.client.config, function () {
+  require('./transactions')(knex)
+  require('./stream')(knex)
 
-    require('./transactions')(knex)
-    require('./stream')(knex)
-
-    // Tear down the knex connection
-    tape(knex.client.driverName + ' - transactions: after', function(t) {
-      knex.destroy(function() {
-        t.end()
-      })
+  // Tear down the knex connection
+  tape(knex.client.driverName + ' - transactions: after', function(t) {
+    knex.destroy(function(err) {
+      t.end(err)
     })
-
-
   })
 
 })

--- a/test/tape/pool.js
+++ b/test/tape/pool.js
@@ -10,18 +10,39 @@ test('instantiating the client should not create pool implicitly', function(t) {
 
   t.equal(client.pool, undefined, 'client.pool should be undefined')
 
-  client.destroy(function() {
-      t.end()
+  client.destroy(function(err) {
+    t.end(err)
   })
 
 })
 
-test('pool must be created explicitly, after instantiating the client', function(t) {
+test('pool may be created explicitly, after instantiating the client', function(t) {
   var client = new Client({connection: {filename: ':memory:'}, pool: {max: 1}})
-  client.initializePool(client.config, function() {
+  client.initializePool(client.config, function(err) {
+    if (err) {
+      t.end(err)
+    }
     t.ok(client.pool instanceof Pool2, 'client.pool should be an instance of Pool2')
-    client.destroy(function() {
-      t.end()
+    client.destroy(function(err) {
+      t.end(err)
+    })
+  })
+})
+
+test('pool will be created implicitly, if necessary, upon attempting to acquire the first connection', function(t) {
+  var client = new Client({connection: {filename: ':memory:'}, pool: {max: 1}})
+  client.acquireConnection(function(err, connection) {
+    if (err) {
+      t.end(err)
+    }
+    t.ok(client.pool instanceof Pool2, 'client.pool should be an instance of Pool2')
+    client.releaseConnection(connection, function(err) {
+      if (err) {
+        t.end(err)
+      }
+      client.destroy(function(err) {
+        t.end(err)
+      })
     })
   })
 })

--- a/test/tape/pool.js
+++ b/test/tape/pool.js
@@ -4,26 +4,24 @@ var test   = require('tape')
 var Client = require('../../lib/dialects/sqlite3');
 var Pool2  = require('pool2')
 
-test('#822, pool config, max: 0 should skip pool construction', function(t) {
-  
-  var client = new Client({connection: {filename: ':memory:'}, pool: {max: 0}})
+test('instantiating the client should not create pool implicitly', function(t) {
 
-  t.equal(client.pool, undefined)
+  var client = new Client({connection: {filename: ':memory:'}, pool: {max: 1}})
 
-  client.destroy()
+  t.equal(client.pool, undefined, 'client.pool should be undefined')
 
-  t.end()
+  client.destroy(function() {
+      t.end()
+  })
 
 })
 
-test('#823, should not skip pool construction pool config is not defined', function(t) {
-  
-  var client = new Client({connection: {filename: ':memory:'}})
-
-  t.ok(client.pool instanceof Pool2)
-
-  client.destroy()
-
-  t.end()
-
+test('pool must be created explicitly, after instantiating the client', function(t) {
+  var client = new Client({connection: {filename: ':memory:'}, pool: {max: 1}})
+  client.initializePool(client.config, function() {
+    t.ok(client.pool instanceof Pool2, 'client.pool should be an instance of Pool2')
+    client.destroy(function() {
+      t.end()
+    })
+  })
 })


### PR DESCRIPTION
### Summary:

Pool initialization is no longer done implicitly when instantiating Knex or a Knex client. Pool initialization ~~must~~ may be performed explicitly, by calling either `knex#initialize` or `client#initializePool`. These are both now asynchronous methods that can either take a callback or return a promise. *Edit:* If the pool is not initialized explicitly, it will be initialized upon the first database connection being acquired.

### Rationale:

Pool initialization should always be performed asynchronously, because pool destruction (which may occur during pool initialization if a pool was previously created) occurs asynchronously. Additionally, constructors should not cause side effects and should always run synchronously.

**NOTE:** ~~This is a breaking API change in that users who were relying on implicit pool initialization will have to change their code to explicitly initialize the pool.~~ This should be backwards-compatible, as pool initialization will be done implicitly upon the first connection being acquired.

Supersedes PR #1009 (Fix reference to undefined `client.initialize` method)