### PR TITLE
NPM test script improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 ## How to contribute to Knex.js
 
-* Make changes in the `/src` directory and run `npm run dev` to
-update the files in `/lib`
+* Make changes in the `/src` directory and run `npm run babel` (runs once and
+  then quits) or `npm run dev` (runs once and then watches for changes) to
+  update the files in `/lib`. `npm test` will also do this.
 
 * Before sending a pull request for a feature or bug fix, be sure to have
 [tests](https://github.com/tgriesser/knex/tree/master/test).

--- a/package.json
+++ b/package.json
@@ -45,9 +45,10 @@
   },
   "scripts": {
     "dev": "babel -L -D -w src/ --out-dir lib/",
+    "babel": "babel -L -D src/ --out-dir lib/",
     "build": "./scripts/build.sh",
     "tape": "node test/tape/index.js | tap-spec",
-    "test": "npm run jshint && istanbul --config=test/.istanbul.yml cover _mocha -- --check-leaks -t 5000 -b -R spec test/index.js && npm run tape",
+    "test": "npm run babel && npm run jshint && istanbul --config=test/.istanbul.yml cover node_modules/mocha/bin/_mocha -- --check-leaks -t 5000 -b -R spec test/index.js && npm run tape",
     "plaintest": "mocha --check-leaks -t 10000 -b -R spec test/index.js && npm run tape",
     "coveralls": "cat ./test/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "jshint": "jshint --exclude=test/coverage/. test/. src/."


### PR DESCRIPTION
  - Add `npm run babel` command and run it on `npm test` (supersedes PR #1011 - Ensure /lib is up to date during CI tests)
  - Fix `npm test` command not working on Windows due to Istanbul config issue (see https://github.com/gotwarlost/istanbul/issues/90)
  - Update `CONTRIBUTING.md`