### PR TITLE
Array values supported on object passed to where functions

### DIFF
--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -239,7 +239,7 @@ assign(Builder.prototype, {
     var boolVal = this._bool();
     var notVal = this._not() ? 'Not' : '';
     for (var key in obj) {
-      this[boolVal + 'Where' + notVal](key, obj[key]);
+      this[boolVal + 'Where' + notVal].apply(this, [key].concat(obj[key]));
     }
     return this;
   },

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -2417,4 +2417,15 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it('where object with keys containing array values', function() {
+    testsql(qb().select('name').from('players').where({team: ['=', 'foo'], score: ['>=', 500]}), {
+      mysql: {
+        sql: 'select `name` from `players` where `team` = ? and `score` >= ?'
+      },
+      default: {
+        sql: 'select "name" from "players" where "team" = ? and "score" >= ?'
+      }
+    });
+  });
+
 });


### PR DESCRIPTION
This PR adds support for passing objects containing array values to the `where` function. This allows for shorter and more concise syntax when querying for anything else than `=`. Example:

Previously:

`Player.where('team', 'foo').andWhere('score_record', '>=', 500).fetchAll();`

Now with this change:

`Player.where({
  team: 'foo',
  score_record: ['>=', 500]
}).fetchAll();
`