### PR TITLE
[doc] Update Examples of defaultTo in Docs  [closes #699]

### DIFF
--- a/index.html
+++ b/index.html
@@ -1813,8 +1813,8 @@ knex.schema.raw("SET sql_mode='TRADITIONAL'")
       is passed as the second argument.
       <br />
       Note that the method for defaulting to the current datetime varies from one database to another.
-      For example: PostreSQL requires <tt>.defaultTo(knex.raw('now()'))</tt>,
-      but SQLite3 requires <tt>.defaultTo(knex.raw("date('now')"))</tt>.
+      For example: PostreSQL requires <tt>.defaultTo(knex.fn.now())</tt>,
+      but SQLite3 requires <tt>.defaultTo(knex.fn.now())</tt>.
     </p>
 
     <p id="Schema-timestamps">

--- a/index.html
+++ b/index.html
@@ -1812,9 +1812,10 @@ knex.schema.raw("SET sql_mode='TRADITIONAL'")
       Adds a timestamp column, defaults to <tt>timestamptz</tt> in PostgreSQL, unless true
       is passed as the second argument.
       <br />
-      Note that the method for defaulting to the current datetime varies from one database to another.
-      For example: PostreSQL requires <tt>.defaultTo(knex.fn.now())</tt>,
-      but SQLite3 requires <tt>.defaultTo(knex.fn.now())</tt>.
+      For Example:
+      <pre class="display">
+        table.timestamp('created_at').defaultTo(knex.fn.now());
+      </pre>
     </p>
 
     <p id="Schema-timestamps">

--- a/index.html
+++ b/index.html
@@ -1813,9 +1813,9 @@ knex.schema.raw("SET sql_mode='TRADITIONAL'")
       is passed as the second argument.
       <br />
       For Example:
-      <pre class="display">
-        table.timestamp('created_at').defaultTo(knex.fn.now());
-      </pre>
+<pre class="display">
+  table.timestamp('created_at').defaultTo(knex.fn.now());
+</pre>
     </p>
 
     <p id="Schema-timestamps">


### PR DESCRIPTION
Updated the defaultTo examples in the documentation to reflect the new `knex.fn.now()` function

Refrence #699 