### PR TITLE
Optionally use DEFAULT instead of NULL when translating undefined to SQL value.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1154,10 +1154,32 @@ knex('books').insert({title: 'Slaughterhouse Five'})
 knex('coords').insert([{x: 20}, {y: 30},  {x: 10, y: 20}])
 </pre>
 
-
 <pre class="display">
 // Returns [2] in "mysql", "sqlite"; [2, 3] in "postgresql"
 knex.insert([{title: 'Great Gatsby'}, {title: 'Fahrenheit 451'}], 'id').into('books')
+</pre>
+
+    <p>
+      If one prefers that undefined keys are replaced with <tt>DEFAULT</tt> instead of <tt>NULL</tt>
+      one may give <tt>replaceUndefinedWithDefault</tt> configuration parameter in knex config. Option
+      is supported by all other drivers except <tt>sqlite</tt> and <tt>websql</tt>.
+    </p>
+
+<pre>
+<code class="js">
+var knex = require('knex')({
+  client: 'mysql',
+  connection: {
+    host     : '127.0.0.1',
+    user     : 'your_database_user',
+    password : 'your_database_password',
+    database : 'myapp_test'
+  },
+  replaceUndefinedWithDefault: true
+});
+knex('coords').insert([{x: 20}, {y: 30},  {x: 10, y: 20}])
+// insert into `coords` (`x`, `y`) values (20, DEFAULT), (DEFAULT, 30), (10, 20)
+</code>
 </pre>
 
     <p id="Builder-returning">

--- a/index.html
+++ b/index.html
@@ -1160,9 +1160,8 @@ knex.insert([{title: 'Great Gatsby'}, {title: 'Fahrenheit 451'}], 'id').into('bo
 </pre>
 
     <p>
-      If one prefers that undefined keys are replaced with <tt>DEFAULT</tt> instead of <tt>NULL</tt>
-      one may give <tt>replaceUndefinedWithDefault</tt> configuration parameter in knex config. Option
-      is supported by all other drivers except <tt>sqlite</tt> and <tt>websql</tt>.
+      If one prefers that undefined keys are replaced with <tt>NULL</tt> instead of <tt>DEFAULT</tt>
+      one may give <tt>useNullAsDefault</tt> configuration parameter in knex config.
     </p>
 
 <pre>
@@ -1175,10 +1174,10 @@ var knex = require('knex')({
     password : 'your_database_password',
     database : 'myapp_test'
   },
-  replaceUndefinedWithDefault: true
+  useNullAsDefault: true
 });
 knex('coords').insert([{x: 20}, {y: 30},  {x: 10, y: 20}])
-// insert into `coords` (`x`, `y`) values (20, DEFAULT), (DEFAULT, 30), (10, 20)
+// insert into `coords` (`x`, `y`) values (20, NULL), (NULL, 30), (10, 20)
 </code>
 </pre>
 

--- a/src/client.js
+++ b/src/client.js
@@ -40,9 +40,9 @@ function Client(config = {}) {
       this.initializePool(config)
     }
   }
-  this.valueForUndefined = null
-  if (config.replaceUndefinedWithDefault) {
-    this.valueForUndefined = this.raw('DEFAULT');
+  this.valueForUndefined = this.raw('DEFAULT');
+  if (config.useNullAsDefault) {
+    this.valueForUndefined = null
   }
 }
 inherits(Client, EventEmitter)

--- a/src/client.js
+++ b/src/client.js
@@ -1,4 +1,5 @@
 
+var _              = require('lodash')
 var Promise        = require('./promise')
 var helpers        = require('./helpers')
 
@@ -38,6 +39,10 @@ function Client(config = {}) {
     if (!config.pool || (config.pool && config.pool.max !== 0)) {
       this.initializePool(config)
     }
+  }
+  this.valueForUndefined = null
+  if (config.replaceUndefinedWithDefault) {
+    this.valueForUndefined = this.raw('DEFAULT');
   }
 }
 inherits(Client, EventEmitter)
@@ -132,6 +137,12 @@ assign(Client.prototype, {
     this.emit('query', assign({__knexUid: connection.__knexUid}, obj))
     debugQuery(obj.sql)
     return this._stream.call(this, connection, obj, stream, options)
+  },
+
+  prepBindings: function(bindings) {
+    return _.map(bindings, function(binding) {
+      return binding === undefined ? this.valueForUndefined : binding
+    }, this);
   },
 
   wrapIdentifier: function(value) {

--- a/src/dialects/oracle/index.js
+++ b/src/dialects/oracle/index.js
@@ -64,6 +64,9 @@ assign(Client_Oracle.prototype, {
       else if (Buffer.isBuffer(value)) {
         return SqlString.bufferToString(value)
       }
+      else if (value === undefined) {
+        return this.valueForUndefined
+      }
       return value
     }, this)
   },

--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -54,8 +54,8 @@ assign(Client_PG.prototype, {
   // Prep the bindings as needed by PostgreSQL.
   prepBindings: function(bindings, tz) {
     return _.map(bindings, function(binding) {
-      return utils.prepareValue(binding, tz)
-    });
+      return utils.prepareValue(binding, tz, this.valueForUndefined)
+    }, this);
   },
 
   // Get a raw connection, called by the `pool` whenever a new

--- a/src/dialects/postgres/utils.js
+++ b/src/dialects/postgres/utils.js
@@ -34,7 +34,7 @@ var arrayString;
 // to their 'raw' counterparts for use as a postgres parameter
 // note: you can override this function to provide your own conversion mechanism
 // for complex types, etc...
-var prepareValue = function (val, seen) {
+var prepareValue = function (val, seen, valueForUndefined) {
   if (val instanceof Buffer) {
     return val;
   }
@@ -44,8 +44,11 @@ var prepareValue = function (val, seen) {
   if (Array.isArray(val)) {
     return arrayString(val);
   }
-  if (val === null || val === undefined) {
+  if (val === null) {
     return null;
+  }
+  if (val === undefined) {
+    return valueForUndefined;
   }
   if (typeof val === 'object') {
     return prepareObject(val, seen);

--- a/src/dialects/sqlite3/index.js
+++ b/src/dialects/sqlite3/index.js
@@ -18,6 +18,9 @@ var SQLite3_DDL    = require('./schema/ddl')
 
 function Client_SQLite3(config) {
   Client.call(this, config)
+  if (config.replaceUndefinedWithDefault) {
+    throw new Error('replaceUndefinedWithDefault not supported by sqlite3')
+  }
 }
 inherits(Client_SQLite3, Client)
 

--- a/src/dialects/sqlite3/index.js
+++ b/src/dialects/sqlite3/index.js
@@ -1,6 +1,7 @@
 
 // SQLite3
 // -------
+var _              = require('lodash')
 var Promise        = require('../../promise')
 
 var inherits       = require('inherits')
@@ -18,8 +19,8 @@ var SQLite3_DDL    = require('./schema/ddl')
 
 function Client_SQLite3(config) {
   Client.call(this, config)
-  if (config.replaceUndefinedWithDefault) {
-    throw new Error('replaceUndefinedWithDefault not supported by sqlite3')
+  if (!config.useNullAsDefault) {
+    helpers.warn('sqlite does not support inserting default values. Set the `useNullAsDefault` flag to hide this warning. (see docs http://knexjs.org/#Builder-insert).');
   }
 }
 inherits(Client_SQLite3, Client)
@@ -109,6 +110,16 @@ assign(Client_SQLite3.prototype, {
         stream.end()
       })
     })
+  },
+
+  prepBindings: function(bindings) {
+    return _.map(bindings, function(binding) {
+      if (binding === undefined && this.valueForUndefined !== null) {
+        throw new TypeError("`sqlite` does not support inserting default values. Specify values explicitly or use the `useNullAsDefault` config flag. (see docs http://knexjs.org/#Builder-insert).");
+      } else {
+        return binding
+      }
+    }, this);
   },
 
   // Ensures the response is returned in the same format as other clients.

--- a/src/query/string.js
+++ b/src/query/string.js
@@ -4,7 +4,11 @@ var SqlString = exports;
 var helpers   = require('../helpers')
 
 SqlString.escape = function(val, timeZone) {
-  if (val == null) {
+  // Cant do require on top of file beacuse Raw is not yet initialized when this file is
+  // executed for the first time
+  var Raw = require('../raw')
+
+  if (val === null || val === undefined) {
     return 'NULL';
   }
 
@@ -23,6 +27,10 @@ SqlString.escape = function(val, timeZone) {
 
   if (Array.isArray(val)) {
     return SqlString.arrayToList(val, timeZone);
+  }
+
+  if (val instanceof Raw) {
+    return val;
   }
 
   if (typeof val === 'object') {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -16,6 +16,14 @@ var clients = {
   default:  new Client({})
 }
 
+var undefinedWithDefaultTrueConfig = { replaceUndefinedWithDefault: true };
+var clientsWithReplaceUndefinedWithDefaultTrue = {
+  mysql:    new MySQL_Client(undefinedWithDefaultTrueConfig),
+  postgres: new PG_Client(undefinedWithDefaultTrueConfig),
+  oracle:   new Oracle_Client(undefinedWithDefaultTrueConfig),
+  default:  new Client(undefinedWithDefaultTrueConfig)
+}
+
 function qb() {
   return clients.default.queryBuilder()
 }
@@ -39,10 +47,11 @@ function verifySqlResult(dialect, expectedObj, sqlObj) {
   });
 }
 
-function testsql(chain, valuesToCheck) {  
+function testsql(chain, valuesToCheck, selectedClients) {
+  selectedClients = selectedClients || clients;
   Object.keys(valuesToCheck).forEach(function(key) {
     var newChain = chain.clone()
-        newChain.client = clients[key]
+        newChain.client = selectedClients[key]
     var sqlAndBindings = newChain.toSQL()
 
     var checkValue = valuesToCheck[key]
@@ -54,10 +63,11 @@ function testsql(chain, valuesToCheck) {
   })
 }
 
-function testquery(chain, valuesToCheck) {
+function testquery(chain, valuesToCheck, selectedClients) {
+  selectedClients = selectedClients || clients;
   Object.keys(valuesToCheck).forEach(function(key) {
     var newChain = chain.clone()
-        newChain.client = clients[key]
+        newChain.client = selectedClients[key]
     var sqlString  = newChain.toQuery()
     var checkValue = valuesToCheck[key]
     expect(checkValue).to.equal(sqlString)
@@ -1396,6 +1406,23 @@ describe("QueryBuilder", function() {
         bindings: ['foo', 'taylor', 'bar', 'dayle']
       }
     });
+  });
+
+  it("multiple inserts with partly undefined keys", function() {
+    testquery(qb().from('users').insert([{email: 'foo', name: 'taylor'}, {name: 'dayle'}]), {
+      mysql: "insert into `users` (`email`, `name`) values ('foo', 'taylor'), (NULL, 'dayle')",
+      sqlite3: 'insert into "users" ("email", "name") select \'foo\' as "email", \'taylor\' as "name" union all select NULL as "email", \'dayle\' as "name"',
+      oracle: 'begin execute immediate \'insert into "users" ("email", "name") values (:1, :2)\' using \'foo\', \'taylor\'; execute immediate \'insert into "users" ("email", "name") values (:1, :2)\' using NULL, \'dayle\';end;',
+      default: 'insert into "users" ("email", "name") values (\'foo\', \'taylor\'), (NULL, \'dayle\')'
+    });
+  });
+
+  it("multiple inserts with partly undefined keys and replaceUndefinedWithDefault: true", function() {
+    testquery(qb().from('users').insert([{email: 'foo', name: 'taylor'}, {name: 'dayle'}]), {
+      mysql: "insert into `users` (`email`, `name`) values ('foo', 'taylor'), (DEFAULT, 'dayle')",
+      oracle: 'begin execute immediate \'insert into "users" ("email", "name") values (:1, :2)\' using \'foo\', \'taylor\'; execute immediate \'insert into "users" ("email", "name") values (:1, :2)\' using DEFAULT, \'dayle\';end;',
+      default: 'insert into "users" ("email", "name") values (\'foo\', \'taylor\'), (DEFAULT, \'dayle\')'
+    }, clientsWithReplaceUndefinedWithDefaultTrue);
   });
 
   it("multiple inserts with returning", function() {


### PR DESCRIPTION
Fixes #662 by adding new configuration option `replaceUndefinedWithDefault` which can be given to all other clients except `sqlite`which does not support `DEFAULT`. 

Change is backwards compatible, since default behavior is not changed, so it should be possible to add to 0.9.1. 