### PR TITLE
Checking for plain object instead object on raw queries

### DIFF
--- a/lib/raw.js
+++ b/lib/raw.js
@@ -7,6 +7,7 @@ var inherits = require('inherits');
 var EventEmitter = require('events').EventEmitter;
 var assign = require('lodash/object/assign');
 var reduce = require('lodash/collection/reduce');
+var isPlainObject = require('lodash/lang/isPlainObject');
 
 function Raw(client) {
   this.client = client;
@@ -49,7 +50,7 @@ assign(Raw.prototype, {
     if (this._cached) return this._cached;
     if (Array.isArray(this.bindings)) {
       this._cached = replaceRawArrBindings(this);
-    } else if (this.bindings && typeof this.bindings === 'object') {
+    } else if (this.bindings && isPlainObject(this.bindings)) {
       this._cached = replaceKeyBindings(this);
     } else {
       this._cached = {

--- a/src/raw.js
+++ b/src/raw.js
@@ -1,10 +1,11 @@
 
 // Raw
 // -------
-var inherits     = require('inherits')
-var EventEmitter = require('events').EventEmitter
-var assign       = require('lodash/object/assign')
-var reduce       = require('lodash/collection/reduce')
+var inherits      = require('inherits')
+var EventEmitter  = require('events').EventEmitter
+var assign        = require('lodash/object/assign')
+var reduce        = require('lodash/collection/reduce')
+var isPlainObject = require('lodash/lang/isPlainObject')
 
 function Raw(client) {
   this.client   = client
@@ -47,7 +48,7 @@ assign(Raw.prototype, {
     if (this._cached) return this._cached
     if (Array.isArray(this.bindings)) {
       this._cached = replaceRawArrBindings(this) 
-    } else if (this.bindings && typeof this.bindings === 'object') {
+    } else if (this.bindings && isPlainObject(this.bindings)) {
       this._cached = replaceKeyBindings(this)
     } else {
       this._cached = {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -2417,4 +2417,31 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it("where with date object", function () {
+    var date = new Date();
+    testsql(qb().select('*').from('users').where("birthday", ">=", date), {
+      mysql: {
+        sql: 'select * from `users` where `birthday` >= ?',
+        bindings: [date]
+      },
+      default: {
+        sql: 'select * from "users" where "birthday" >= ?',
+        bindings: [date]
+      }
+    });
+  });
+
+  it("raw where with date object", function() {
+    var date = new Date();
+    testsql(qb().select('*').from('users').whereRaw("birthday >= ?", date), {
+      mysql: {
+        sql: 'select * from `users` where birthday >= ?',
+        bindings: [date]
+      },
+      default: {
+        sql: 'select * from "users" where birthday >= ?',
+        bindings: [date]
+      }
+    });
+  });
 });


### PR DESCRIPTION
The query builder checks if the bindings are objects in the following form:

    if (this.bindings && typeof this.bindings === 'object') {

This would result in an unexpected behavior if passed an object other than a plain object. For example, if passing a `Date` object, the workaround would be to pass the `Date` object in an array, but that's not very intuitive, given that the `where` function you can pass the `Date` object directly.

This patch uses lodash's `isPlainObject` to do the above check, now we can pass a Date object directly on a raw clause in the same fashion as in the `where` method.