### PR TITLE
removed comma from seed js.stub

### DIFF
--- a/src/seed/stub/js.stub
+++ b/src/seed/stub/js.stub
@@ -7,6 +7,6 @@ exports.seed = function(knex, Promise) {
     // Inserts seed entries
     knex('table_name').insert({id: 1, colName: 'rowValue'}),
     knex('table_name').insert({id: 2, colName: 'rowValue2'}),
-    knex('table_name').insert({id: 3, colName: 'rowValue3'}),
+    knex('table_name').insert({id: 3, colName: 'rowValue3'})
   );
 };


### PR DESCRIPTION
Comma removed after third sample entry inside the join statement. While the stub itself is meant to be altered before running, the extra comma suggests to the user improper syntax for a join statement. If the comma is left in by the user, knex seed:run will throw 'unexpected token )' error. 

return statement on js.stub was previously 

```
  return Promise.join(
    // Deletes ALL existing entries
    knex('table_name').del(), 

    // Inserts seed entries
    knex('table_name').insert({id: 1, colName: 'rowValue'}),
    knex('table_name').insert({id: 2, colName: 'rowValue2'}),
    knex('table_name').insert({id: 3, colName: 'rowValue3'}),
  );
```

is now
```
return Promise.join(
    // Deletes ALL existing entries
    knex('table_name').del(), 

    // Inserts seed entries
    knex('table_name').insert({id: 1, colName: 'rowValue'}),
    knex('table_name').insert({id: 2, colName: 'rowValue2'}),
    knex('table_name').insert({id: 3, colName: 'rowValue3'})
  );
```