### PR TITLE
Support question mark escaping for knex rendered queries

### DIFF
--- a/index.html
+++ b/index.html
@@ -2053,11 +2053,6 @@ knex.schema.createTable('accounts', function() {
       Sometimes you may need to use a raw expression in a query. Raw query object may be injected pretty much
       anywhere you want, and using proper bindings can ensure your values are escaped properly, preventing SQL-injection attacks.
     </p>
-    <p>
-      With PostgreSQL <tt>?</tt> replacements are converted to <tt>$1..$n</tt> variables in prepared statements.
-      To prevent replacement one can use escape sequence <tt>\\?</tt> to use JSON operators or in string literals
-      e.g. <tt>knex.raw("(json_column->'json_field')::jsonb \\?& array['keyOne', 'keyWithQuestion\\?']")</tt>.
-    </p>
 
     <h3 id="Raw-Bindings">Raw Parameter Binding:</h3>
 
@@ -2087,6 +2082,14 @@ knex('users')
     thisGuy: 'Bob',
     otherGuy: 'Jay'
   }))
+</pre>
+
+    <p>
+      To prevent replacement of <tt>?</tt> one can use escape sequence <tt>\\?</tt>.
+    </p>
+
+<pre class="display">
+knex.select('*').from('users').where('id', '=', 1).whereRaw('?? \\? ?', ['jsonColumn', 'jsonKey'])
 </pre>
 
     <h3 id="Raw-Expressions">Raw Expressions:</h3>

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -54,6 +54,7 @@ assign(Formatter.prototype, {
       return this.outputQuery(query, isParameter);
     }
     if (value instanceof Raw) {
+      value.client = this.client;
       query = value.toSQL()
       if (query.bindings) {
         this.bindings = this.bindings.concat(query.bindings);

--- a/src/query/string.js
+++ b/src/query/string.js
@@ -34,7 +34,7 @@ SqlString.escape = function(val, timeZone) {
     }
   }
 
-  val = val.replace(/[\0\n\r\b\t\\\'\"\x1a]/g, function(s) {
+  val = val.replace(/(\\\?)|[\0\n\r\b\t\\\'\"\x1a]/g, function(s) {
     switch(s) {
       case "\0": return "\\0";
       case "\n": return "\\n";
@@ -42,6 +42,7 @@ SqlString.escape = function(val, timeZone) {
       case "\b": return "\\b";
       case "\t": return "\\t";
       case "\x1a": return "\\Z";
+      case "\\?": return "?";
       default: return "\\"+s;
     }
   });
@@ -58,13 +59,14 @@ SqlString.arrayToList = function(array, timeZone) {
 SqlString.format = function(sql, values, timeZone) {
   values = values == null ? [] : [].concat(values);
   var index = 0;
-  return sql.replace(/\?/g, function(match) {
+  return sql.replace(/\\?\?/g, function(match) {
+    if (match === '\\?') return match;
     if (index === values.length) {
       return match;
     }
     var value = values[index++];
     return SqlString.escape(value, timeZone)
-  });
+  }).replace('\\?', '?');
 };
 
 SqlString.dateToString = function(date, timeZone) {

--- a/src/raw.js
+++ b/src/raw.js
@@ -75,8 +75,12 @@ function replaceRawArrBindings(raw) {
   var client           = raw.client
   var index            = 0;
   var bindings         = []
-  
-  var sql = raw.sql.replace(/\?\??/g, function(match) {
+
+  var sql = raw.sql.replace(/\\?\?\??/g, function(match) {
+    if (match === '\\?') {
+      return match
+    }
+
     var value = values[index++]
     
     if (value && typeof value.toSQL === 'function') {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -66,6 +66,23 @@ function testquery(chain, valuesToCheck) {
 
 describe("QueryBuilder", function() {
 
+  it("query \\\\? escaping", function() {
+    function createBuilder() {
+      return qb().select('*').from('users').where('id', '=', 1)
+        .whereRaw('?? \\? ?', ['jsonColumn', 'jsonKey\\?']);
+    }
+
+    // need to test each platform separately because QueryBuilder.clone does only shallow copy
+    // and cached raw query strings are not re-evaluated when query builder client is changed
+    testquery(createBuilder(), {
+      mysql: 'select * from `users` where `id` = 1 and `jsonColumn` ? \'jsonKey?\''
+    });
+
+    testquery(createBuilder(), {
+      default: 'select * from "users" where "id" = 1 and "jsonColumn" ? \'jsonKey?\''
+    });
+  });
+
   it("basic select", function() {
     testsql(qb().select('*').from('users'), {
       mysql: 'select * from `users`',


### PR DESCRIPTION
Fixes bug in #519 by adding more complete support for `\?` escape sequence

