### PR TITLE
Fix error with CLI trying to select environment config for "basic configuration"

### DIFF
--- a/index.html
+++ b/index.html
@@ -2519,12 +2519,15 @@ $ knex migrate:latest
 </pre>
 
     <p>
-      You can also pass the <tt>--env</tt> flag to select an alternative
-      environment:
+      You can also pass the <tt>--env</tt> flag or set <tt>NODE_ENV</tt> to select an alternative environment:
     </p>
 
 <pre>
 $ knex migrate:latest --env production
+
+# or
+
+$ NODE_ENV=production knex migrate:latest
 </pre>
 
     <h2 id="Seeds">Seed files</h2>

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -53,9 +53,10 @@ function initKnex(env) {
   if (!environment && typeof config[defaultEnv] === 'object') {
     environment = defaultEnv;
   }
+
   if (environment) {
     console.log('Using environment:', chalk.magenta(environment));
-    config = config[environment];
+    config = config[environment] || config;
   }
 
   if (!config) {


### PR DESCRIPTION
## Issue

Per the docs for **CLI knexfile.js**, the following configuration should be supported:
> Basic configuration:
> 
```javascript
module.exports = {
  client: 'pg',
  connection: process.env.DATABASE_URL || {
    user: 'me',
    database: 'my_app'
  }
};
```

Per the following conditional block in [`/src/bin/cli.js#L56-L59`](https://github.com/tgriesser/knex/blob/master/src/bin/cli.js#L56-L59) (introduced in #527) there is no check to make sure `config[environment]` exists.
```javascript
  if (environment) {
    console.log('Using environment:', chalk.magenta(environment));
    config = config[environment];
  }
```
**This results in an undefined config when using the basic configuration**.

## Pull Request Details

This pull request includes:

- `config` assignment defaults to itself when `config[environment]` does not exist
- update to the docs indicating that `NODE_ENV` is also used to set the environment in Knex CLI<br>_(this was my issue originally…I did not know the CLI environment defaults to `NODE_ENV`)_


_NOTE: I branched off `master`, but after following the CONTRIBUTING guidelines other files in `lib` showed changes after building that my code would not have affected. My assumption is that the latest build in `master` was dirty so I have only included src changes in this PR._