### PR TITLE
Add option to timestamps to be not null and default to the current timestamp

### DIFF
--- a/index.html
+++ b/index.html
@@ -1875,6 +1875,12 @@ knex.schema.raw("SET sql_mode='TRADITIONAL'")
       <br />
       Adds a <tt>created_at</tt> and <tt>updated_at</tt> column on the database,
       setting these each to <a href="#Schema-dateTime">dateTime</a> types.
+      <br />
+      When true is passed as the first argument a <tt>timestamp</tt> type is used.
+      <br />
+      Both colums default to being not null and the current timestamp when true
+      is passed as the second argument.
+      <br />
     </p>
 
     <p id="Schema-binary">

--- a/src/schema/tablebuilder.js
+++ b/src/schema/tablebuilder.js
@@ -144,12 +144,13 @@ _.each(columnTypes, function(type) {
     // The "timestamps" call is really a compound call to set the
     // `created_at` and `updated_at` columns.
     if (type === 'timestamps') {
-      if (args[0] === true) {
-        this.timestamp('created_at');
-        this.timestamp('updated_at');
-      } else {
-        this.datetime('created_at');
-        this.datetime('updated_at');
+      var col = (args[0] === true) ? 'timestamp' : 'datetime';
+      var createdAt = this[col]('created_at');
+      var updatedAt = this[col]('updated_at');
+      if (args[1] === true) {
+        var now = this.client.raw('CURRENT_TIMESTAMP');
+        createdAt.notNullable().defaultTo(now);
+        updatedAt.notNullable().defaultTo(now);
       }
       return;
     }

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -442,6 +442,14 @@ describe("PostgreSQL SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table "users" add column "created_at" timestamptz, add column "updated_at" timestamptz');
   });
 
+  it("adding timestamps with defaults", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.timestamps(false, true);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "created_at" timestamptz not null default CURRENT_TIMESTAMP, add column "updated_at" timestamptz not null default CURRENT_TIMESTAMP');
+  });
+
   it("adding binary", function() {
     tableSql = client.schemaBuilder().table('users', function(table) {
       table.binary('foo');


### PR DESCRIPTION
This closes #547. I've added a third parameter to `timestamps` so it will be backwards compatible.