### PR TITLE
Issue #1052 patch

### DIFF
--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -53,9 +53,10 @@ function initKnex(env) {
   if (!environment && typeof config[defaultEnv] === 'object') {
     environment = defaultEnv;
   }
+
   if (environment) {
     console.log('Using environment:', chalk.magenta(environment));
-    config = config[environment];
+    config = config[environment] || config;
   }
 
   if (!config) {

--- a/lib/connection/index.js
+++ b/lib/connection/index.js
@@ -1,12 +1,6 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
-var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+exports.__esModule = true;
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
@@ -20,7 +14,7 @@ var Connection = (function (_EventEmitter) {
   function Connection(connection) {
     _classCallCheck(this, Connection);
 
-    _get(Object.getPrototypeOf(Connection.prototype), 'constructor', this).call(this);
+    _EventEmitter.call(this);
     this.connection = connection;
 
     // Flag indicating whether the connection is "managed",
@@ -28,12 +22,9 @@ var Connection = (function (_EventEmitter) {
     this.managed = false;
   }
 
-  _createClass(Connection, [{
-    key: 'execute',
-    value: function execute() {
-      return this._execute();
-    }
-  }]);
+  Connection.prototype.execute = function execute() {
+    return this._execute();
+  };
 
   return Connection;
 })(_events.EventEmitter);

--- a/lib/dialects/websql/transaction.js
+++ b/lib/dialects/websql/transaction.js
@@ -9,7 +9,7 @@ var EventEmitter = require('events').EventEmitter;
 function Transaction_WebSQL(client, container) {
   helpers.warn('WebSQL transactions will run queries, but do not commit or rollback');
   var trx = this;
-  this._promise = Promise['try'](function () {
+  this._promise0 = Promise['try'](function () {
     container(makeKnex(makeClient(trx, client)));
   });
 }
@@ -38,7 +38,7 @@ var promiseInterface = ['then', 'bind', 'catch', 'finally', 'asCallback', 'sprea
 // "then" method on the current `Target`
 promiseInterface.forEach(function (method) {
   Transaction_WebSQL.prototype[method] = function () {
-    return this._promise = this._promise[method].apply(this._promise, arguments);
+    return this._promise0 = this._promise0[method].apply(this._promise0, arguments);
   };
 });
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -26,7 +26,7 @@ function Transaction(client, container, config, outerTx) {
 
   debug('%s: Starting %s transaction', txid, outerTx ? 'nested' : 'top level');
 
-  this._promise = Promise.using(this.acquireConnection(client, config, txid), function (connection) {
+  this._promise0 = Promise.using(this.acquireConnection(client, config, txid), function (connection) {
 
     var trxClient = _this.trxClient = makeTxClient(_this, client, connection);
     var init = client.transacting ? _this.savepoint(connection) : _this.begin(connection);
@@ -80,8 +80,12 @@ function Transaction(client, container, config, outerTx) {
     }
 
     // Push the current promise onto the queue of promises.
-    outerTx._childQueue.push(this._promise);
+    outerTx._childQueue.push(this._promise0);
   }
+
+  this._then = function _then() {
+    return this._promise0._then.apply(this._promise0, arguments);
+  };
 }
 inherits(Transaction, EventEmitter);
 
@@ -253,7 +257,7 @@ var promiseInterface = ['then', 'bind', 'catch', 'finally', 'asCallback', 'sprea
 // "then" method on the current `Target`
 promiseInterface.forEach(function (method) {
   Transaction.prototype[method] = function () {
-    return this._promise = this._promise[method].apply(this._promise, arguments);
+    return this._promise0 = this._promise0[method].apply(this._promise0, arguments);
   };
 });
 

--- a/lib/util/parse-connection.js
+++ b/lib/util/parse-connection.js
@@ -1,8 +1,6 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
+exports.__esModule = true;
 exports['default'] = parseConnectionString;
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
@@ -32,7 +30,7 @@ function parseConnectionString(str) {
   }
   return {
     client: protocol,
-    connection: protocol === 'postgres' ? (0, _pgConnectionString.parse)(str) : connectionObject(parsed)
+    connection: protocol === 'postgres' ? _pgConnectionString.parse(str) : connectionObject(parsed)
   };
 }
 

--- a/src/dialects/websql/transaction.js
+++ b/src/dialects/websql/transaction.js
@@ -8,7 +8,7 @@ var EventEmitter = require('events').EventEmitter
 function Transaction_WebSQL(client, container) {
   helpers.warn('WebSQL transactions will run queries, but do not commit or rollback')
   var trx = this
-  this._promise = Promise.try(function() {
+  this._promise0 = Promise.try(function() {
     container(makeKnex(makeClient(trx, client)))
   })
 }
@@ -41,7 +41,7 @@ var promiseInterface = [
 // "then" method on the current `Target`
 promiseInterface.forEach(function(method) {
   Transaction_WebSQL.prototype[method] = function() {
-    return (this._promise = this._promise[method].apply(this._promise, arguments))
+    return (this._promise0 = this._promise0[method].apply(this._promise0, arguments))
   }
 })
 

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -23,7 +23,7 @@ function Transaction(client, container, config, outerTx) {
 
   debug('%s: Starting %s transaction', txid, outerTx ? 'nested' : 'top level')
 
-  this._promise = Promise.using(this.acquireConnection(client, config, txid), (connection) => {
+  this._promise0 = Promise.using(this.acquireConnection(client, config, txid), (connection) => {
     
     var trxClient = this.trxClient = makeTxClient(this, client, connection)
     var init      = client.transacting ? this.savepoint(connection) : this.begin(connection)
@@ -80,8 +80,12 @@ function Transaction(client, container, config, outerTx) {
     }
 
     // Push the current promise onto the queue of promises.
-    outerTx._childQueue.push(this._promise)
+    outerTx._childQueue.push(this._promise0)
   }
+
+  this._then = function _then() {
+    return this._promise0._then.apply(this._promise0, arguments);
+  };
 
 }
 inherits(Transaction, EventEmitter)
@@ -260,7 +264,7 @@ var promiseInterface = [
 // "then" method on the current `Target`
 promiseInterface.forEach(function(method) {
   Transaction.prototype[method] = function() {
-    return (this._promise = this._promise[method].apply(this._promise, arguments))
+    return (this._promise0 = this._promise0[method].apply(this._promise0, arguments))
   }
 })
 

--- a/test/integration/builder/transaction.js
+++ b/test/integration/builder/transaction.js
@@ -277,6 +277,24 @@ module.exports = function(knex) {
 
     });
 
+    it('#1052 - transaction promise mutating', function() {
+        var transactionReturning = knex.transaction(function(trx) {
+        return trx.insert({
+            first_name: 'foo',
+            last_name: 'baz',
+            email:'fbaz@example.com',
+            logins: 1,
+            about: 'Lorem ipsum Dolore labore incididunt enim.',
+            created_at: new Date(),
+            updated_at: new Date()
+        }).into('accounts');
+        });
+        return Promise.all([transactionReturning, transactionReturning])
+        .spread(function (ret1, ret2) {
+            expect(ret1).to.equal(ret2);
+        });
+    });
+
   });
 
 };


### PR DESCRIPTION
This patch fixes issue #1052 

This patches makes the `Transaction` class compatible with Bluebird's inner functions, notably `Promise.all`, where an iterable of `Promise` objects is expected or an object that responds to the `Promise` interface (like `Transaction`). to do so, two changes were made:
1. The `Transaction._promise` property was renamed to `Transaction._promise0`, in order to comply with [Bluebird](https://github.com/petkaantonov/bluebird/blob/v2.9.24/src/thenables.js)
2. An new instance method `Transaction._then` was defined as well for the same reasons above but for [this line](https://github.com/petkaantonov/bluebird/blob/v2.9.24/src/thenables.js#L16)

An alternate solution is to make `Transaction` inherit from `Promise`, this way it will make it a Promise instance, but that may lead to unexpected behavior given how `Transaction` is proxying function calls to the inner promise object. Maybe a refactor is due to make `Transaction` a `Promise` first, and then provide an interface to make SQL calls on it?
