### PR TITLE
Add some CI badge to README (npm version, dep status)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # .travis.yml
-sudo: false
-
 language: node_js
+sudo: false
 
 node_js:
   - '0.10'

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-# [knex.js](http://knexjs.org) [![Build Status](https://travis-ci.org/tgriesser/knex.svg?branch=master)](https://travis-ci.org/tgriesser/knex) [![Coverage Status](https://coveralls.io/repos/tgriesser/knex/badge.svg?branch=master)](https://coveralls.io/r/tgriesser/knex?branch=master)
+# [knex.js](http://knexjs.org)
 
-Gitter chat
-[![Gitter chat](https://badges.gitter.im/tgriesser/knex.svg)](https://gitter.im/tgriesser/knex "Gitter chat")
+[![npm version](http://img.shields.io/npm/v/knex.svg)](https://npmjs.org/package/knex)
+[![Build Status](https://travis-ci.org/tgriesser/knex.svg?branch=master)](https://travis-ci.org/tgriesser/knex)
+[![Coverage Status](https://coveralls.io/repos/tgriesser/knex/badge.svg?branch=master)](https://coveralls.io/r/tgriesser/knex?branch=master)
+[![Dependencies Status](https://david-dm.org/tgriesser/knex.svg)](https://david-dm.org/tgriesser/knex)
+[![Gitter chat](https://badges.gitter.im/tgriesser/knex.svg)](https://gitter.im/tgriesser/knex)
 
-A SQL query builder that is flexible, portable, and fun to use!
+> **A SQL query builder that is _flexible_, _portable_, and _fun_ to use!**
 
 A batteries-included, multi-dialect (MySQL, PostgreSQL, SQLite3, WebSQL, Oracle) query builder for
 Node.js and the Browser, featuring:
@@ -17,7 +20,7 @@ Node.js and the Browser, featuring:
 
 [Read the full documentation to get started!](http://knexjs.org)
 
-For support and questions, join the #bookshelf channel on freenode IRC
+For support and questions, join the `#bookshelf` channel on freenode IRC
 
 For an Object Relational Mapper, see: http://bookshelfjs.org
 


### PR DESCRIPTION
as title and commit says :)

This highlight some outdated dependancies:

so far, incompatible changes spotted:
- upgrade to babel 6. (non easy)
- bluebird (test failing when upgrading)