### PR TITLE
Returning doc update

### DIFF
--- a/index.html
+++ b/index.html
@@ -1246,6 +1246,11 @@ knex('coords').insert([{x: 20}, {y: 30},  {x: 10, y: 20}])
       <br />
       Only utilized by PostgreSQL databases, the returning method specifies which column should be returned
       by the <a href="#Builder-insert">insert</a> and <a href="#Builder-update">update</a> methods.
+      <br />
+	  Passed <tt>column</tt> parameter may be a string or an array of strings. When passed in a string,
+	  makes the SQL result be reported as an array of values from the specified column. When passed in an
+	  array of strings, makes the SQL result be reported as an array of objects, each containing a single
+	  property for each of the specified columns.
     </p>
 
 <pre class="display">

--- a/index.html
+++ b/index.html
@@ -1244,7 +1244,7 @@ knex('coords').insert([{x: 20}, {y: 30},  {x: 10, y: 20}])
     <p id="Builder-returning">
       <b class="header">returning</b><code>.returning(column)</code>
       <br />
-      Only utilitzed by PostgreSQL databases, the returning method specifies which column should be returned
+      Only utilized by PostgreSQL databases, the returning method specifies which column should be returned
       by the <a href="#Builder-insert">insert</a> and <a href="#Builder-update">update</a> methods.
     </p>
 


### PR DESCRIPTION
`returning()` docs did not explain the parameter structure passed to this API.

It accepts a single parameter which can be either a string or a list of strings and depending on which you send, the final query result is either a list of column values or a list of objects containing column values as properties.