### PR TITLE
Bugfix/or where with object should be and

### DIFF
--- a/index.html
+++ b/index.html
@@ -694,6 +694,12 @@ var subquery = knex('users').where('votes', '>', 100).andWhere('status', 'active
 knex('accounts').where('id', 'in', subquery)
 </pre>
 
+<p class="title">.orWhere with an object automatically wraps the statement and creates an <tt>or (and - and - and)</tt> clause</p>
+
+<pre class="display">
+knex('users').where('id', 1).orWhere({votes: 100, user: 'knex'})
+</pre>
+
 
 
     <p id="Builder-whereNot">

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -225,8 +225,17 @@ assign(Builder.prototype, {
     return this;
   },
   // Adds an `or where` clause to the query.
-  orWhere: function() {
-    return this._bool('or').where.apply(this, arguments);
+  orWhere: function orWhere() {
+    this._bool('or');
+    var obj = arguments[0];
+    if(_.isObject(obj) && !_.isFunction(obj) && !(obj instanceof Raw)) {
+      return this.whereWrapped(function() {
+        for(let key in obj) {
+          this.andWhere(key, obj[key]);
+        }
+      });
+    }
+    return this.where.apply(this, arguments);
   },
 
   // Adds an `not where` clause to the query.

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -3169,4 +3169,23 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it("#1118 orWhere({..}) generates or (and - and - and)", function() {
+    testsql(qb().select('*').from('users').where('id', '=', 1).orWhere({
+      email: 'foo',
+      id: 2
+    }), {
+      mysql: {
+        sql: 'select * from `users` where `id` = ? or (`email` = ? and `id` = ?)',
+        bindings: [1, 'foo', 2]
+      },
+      mssql: {
+        sql: 'select * from [users] where [id] = ? or ([email] = ? and [id] = ?)',
+        bindings: [1, 'foo', 2]
+      },
+      default: {
+        sql: 'select * from "users" where "id" = ? or ("email" = ? and "id" = ?)',
+        bindings: [1, 'foo', 2]
+      }
+    });
+  });
 });


### PR DESCRIPTION
This is a PR for #1118. There may be better ways of solving this..

Previously, `orWhere({...})` would generate *or-or-or*, it will now generate a wrapped *and-and-and* instead.