### PR TITLE
Add .filter() to resultsets

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,6 +224,7 @@
       <li>&nbsp;&nbsp;– <a href="#Promises-reduce">reduce</a></li>
       <li>&nbsp;&nbsp;– <a href="#Promises-bind">bind</a></li>
       <li>&nbsp;&nbsp;– <a href="#Promises-return">return</a></li>
+      <li>&nbsp;&nbsp;– <a href="#Promises-filter">filter</a></li>
       <li><b><a href="#Interfaces-Callbacks">Callbacks</a></b></li>
       <li>&nbsp;&nbsp;– <a href="#Interfaces-asCallback">asCallback</a></li>
       <li><b><a href="#Interfaces-Streams">Streams</a></b></li>
@@ -2356,6 +2357,28 @@ knex.insert(values).into('users')
   });
 
 knex.insert(values).into('users').return({inserted: true});
+</code>
+</pre>
+
+
+    <p id="Promises-filter">
+      <b class="header">filter</b><code>.filter(fn)</code>
+      <br />
+      A passthrough to <a href="http://bluebirdjs.com/docs/api/promise.filter.html">Bluebird's filter implementation</a> with the result set.
+    </p>
+
+
+<pre>
+<code class="js">
+  knex
+  .select()
+  .from('users')
+  .filter(function(row) {
+    return row.Id > 10;
+  })
+  .then(function(rows) {
+
+  });
 </code>
 </pre>
 

--- a/src/interface.js
+++ b/src/interface.js
@@ -72,8 +72,9 @@ module.exports = function(Target) {
   // Creates a method which "coerces" to a promise, by calling a
   // "then" method on the current `Target`
   _.each(['bind', 'catch', 'finally', 'asCallback',
-    'spread', 'map', 'reduce', 'tap', 'thenReturn',
-    'return', 'yield', 'ensure', 'nodeify', 'exec'], function(method) {
+    'spread', 'map', 'reduce', 'tap', 'filter',
+    'thenReturn', 'return', 'yield', 'ensure',
+    'nodeify', 'exec'], function(method) {
     Target.prototype[method] = function() {
       var then = this.then();
       then = then[method].apply(then, arguments);


### PR DESCRIPTION
This is for issue #1000 .

Example:

```javascript
knex('test')
.select()
.filter(function(item) {
	return item.test > 10;
})
.then(function(items) {
})
.catch(function(error) {
});
```

Not entirely sure on the use cases of this since there's `.where` and whatnot, but who am I to judge. :)