### PR TITLE
Make raw bindings backwards compatible

### DIFF
--- a/index.html
+++ b/index.html
@@ -2134,6 +2134,9 @@ knex('users')
   .orWhere(
     knex.raw('accesslevel = ?', 1)
   )
+  .orWhere(
+    knex.raw('updtime = ?', new Date())
+  )
 </pre>
 
     <p>

--- a/index.html
+++ b/index.html
@@ -2124,6 +2124,18 @@ knex('users')
   }))
 </pre>
 
+    <p>For simpler queries where one only has a single binding, <tt>.raw</tt> can accept said binding as its second parameter.</p>
+
+<pre class="display">
+knex('users')
+  .where(
+    knex.raw('LOWER("login") = ?', 'knex')
+  )
+  .orWhere(
+    knex.raw('accesslevel = ?', 1)
+  )
+</pre>
+
     <p>
       To prevent replacement of <tt>?</tt> one can use escape sequence <tt>\\?</tt>.
     </p>

--- a/src/raw.js
+++ b/src/raw.js
@@ -27,7 +27,7 @@ assign(Raw.prototype, {
   set: function(sql, bindings) {    
     this._cached  = undefined
     this.sql      = sql
-    this.bindings = _.isObject(bindings) || _.isUndefined(bindings) ?  bindings : [bindings]
+    this.bindings = (_.isObject(bindings) || _.isUndefined(bindings)) ?  bindings : [bindings]
 
     return this
   },

--- a/src/raw.js
+++ b/src/raw.js
@@ -6,6 +6,7 @@ var EventEmitter  = require('events').EventEmitter
 var assign        = require('lodash/object/assign')
 var reduce        = require('lodash/collection/reduce')
 var isPlainObject = require('lodash/lang/isPlainObject')
+var _             = require('lodash');
 
 function Raw(client) {
   this.client   = client
@@ -26,7 +27,8 @@ assign(Raw.prototype, {
   set: function(sql, bindings) {    
     this._cached  = undefined
     this.sql      = sql
-    this.bindings = bindings
+    this.bindings = _.isObject(bindings) || _.isUndefined(bindings) ?  bindings : [bindings]
+
     return this
   },
 

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -3109,4 +3109,33 @@ describe("QueryBuilder", function() {
       }
     });
   });
+
+  it('#965 - .raw accepts Array and Non-Array bindings', function() {
+    var expected = function(expectedBindings) {
+      return {
+        mysql:   {
+          sql:      'select * from `users` where username = ?',
+          bindings: expectedBindings
+        },
+        mssql:   {
+          sql:      'select * from [users] where username = ?',
+          bindings: expectedBindings
+        },
+        default: {
+          sql:      'select * from "users" where username = ?',
+          bindings: expectedBindings
+        }
+      };
+    };
+
+    //String
+    testsql(qb().select('*').from('users').where(raw('username = ?', 'knex')), expected(['knex']));
+    testsql(qb().select('*').from('users').where(raw('username = ?', ['knex'])), expected(['knex']));
+
+    //Number
+    testsql(qb().select('*').from('users').where(raw('username = ?', 0)), expected([0]));
+    testsql(qb().select('*').from('users').where(raw('username = ?', [1])), expected([1]));
+
+  });
+
 });

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -3111,31 +3111,40 @@ describe("QueryBuilder", function() {
   });
 
   it('#965 - .raw accepts Array and Non-Array bindings', function() {
-    var expected = function(expectedBindings) {
+    var expected = function(fieldName, expectedBindings) {
       return {
         mysql:   {
-          sql:      'select * from `users` where username = ?',
+          sql:      'select * from `users` where ' + fieldName + ' = ?',
           bindings: expectedBindings
         },
         mssql:   {
-          sql:      'select * from [users] where username = ?',
+          sql:      'select * from [users] where ' + fieldName + ' = ?',
           bindings: expectedBindings
         },
         default: {
-          sql:      'select * from "users" where username = ?',
+          sql:      'select * from "users" where ' + fieldName + ' = ?',
           bindings: expectedBindings
         }
       };
     };
 
     //String
-    testsql(qb().select('*').from('users').where(raw('username = ?', 'knex')), expected(['knex']));
-    testsql(qb().select('*').from('users').where(raw('username = ?', ['knex'])), expected(['knex']));
+    testsql(qb().select('*').from('users').where(raw('username = ?', 'knex')), expected('username', ['knex']));
+    testsql(qb().select('*').from('users').where(raw('username = ?', ['knex'])), expected('username', ['knex']));
 
     //Number
-    testsql(qb().select('*').from('users').where(raw('username = ?', 0)), expected([0]));
-    testsql(qb().select('*').from('users').where(raw('username = ?', [1])), expected([1]));
+    testsql(qb().select('*').from('users').where(raw('isadmin = ?', 0)), expected('isadmin', [0]));
+    testsql(qb().select('*').from('users').where(raw('isadmin = ?', [1])), expected('isadmin', [1]));
 
+    //Date
+    var date = new Date(2016, 0, 5, 10, 19, 30, 599);
+    var sqlUpdTime = '2016-01-05 10:19:30.599';
+    testsql(qb().select('*').from('users').where(raw('updtime = ?', date)), expected('updtime', [date]));
+    testsql(qb().select('*').from('users').where(raw('updtime = ?', [date])), expected('updtime', [date]));
+    testquery(qb().select('*').from('users').where(raw('updtime = ?', date)), {
+      mysql: 'select * from `users` where updtime = \'' + sqlUpdTime + '\'',
+      default: 'select * from "users" where updtime = \'' + sqlUpdTime + '\''
+    });
   });
 
 });


### PR DESCRIPTION
I explained this in #965 where the handling of bindings for `.raw` was changed in v0.8+ disallowing the use of for example:

```javascript
knex.raw('username = ?', 'Test');
//generates username = 'T' with 4 bindings ['T', 'e', 's', 't']
```

So in the spirit of not breaking applications upon upgrading knex version, this is my suggested solution. It doesn't make any sense to enforce Array bindings while the rest of the knex interface is very flexible, and it also allows for easier-to-read code.

```javascript
knex.raw('username = ?', 'Test');
//now generates username = 'Test'
```

I added a test case so that this does not break again.


Edit: A good argument to why this should be merged, I am going to quote http://knexjs.org/
>**Upgrading 0.7 -> 0.8**
>
>There should be no major changes breaking the external API. If you encounter issues, please open a ticket.

Yet this broke in 0.8.