### PR TITLE
Support connections to EnterpriseDB Postgres databases.

### DIFF
--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -94,7 +94,7 @@ assign(Client_PG.prototype, {
     return new Promise(function(resolver, rejecter) {
       connection.query('select version();', function(err, resp) {
         if (err) return rejecter(err);
-        resolver(/^PostgreSQL (.*?) /.exec(resp.rows[0].version)[1]);
+        resolver(/^(PostgreSQL|EnterpriseDB) (.*?) /.exec(resp.rows[0].version)[1]);
       });
     });
   },

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -86,6 +86,10 @@ assign(Formatter.prototype, {
     return this._wrapString(value + '');
   },
 
+  wrapAsIdentifier: function wrapAsIdentifier(value) {
+    return this.client.wrapIdentifier((value || '').trim());
+  },
+
   alias: function(first, second) {
     return first + ' as ' + second;
   },
@@ -141,7 +145,7 @@ assign(Formatter.prototype, {
     if (asIndex !== -1) {
       var first  = value.slice(0, asIndex)
       var second = value.slice(asIndex + 4)
-      return this.alias(this.wrap(first), this.wrap(second))
+      return this.alias(this.wrap(first), this.wrapAsIdentifier(second))
     }
     var i = -1, wrapped = [];
     segments = value.split('.');

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -148,6 +148,15 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it("allows alias with dots in the identifier name", function() {
+    testsql(qb().select('foo as bar.baz').from('users'), {
+      mysql: 'select `foo` as `bar.baz` from `users`',
+      oracle: 'select "foo" "bar.baz" from "users"',
+      mssql: 'select [foo] as [bar.baz] from [users]',
+      default: 'select "foo" as "bar.baz" from "users"'
+    });
+  });
+
   it("basic table wrapping", function() {
     testsql(qb().select('*').from('public.users'), {
       mysql: 'select * from `public`.`users`',


### PR DESCRIPTION
[EnterpriseDB](http://www.enterprisedb.com/) is a distribution of Postgres. Knex should be compatible with EnterpriseDB as-is, but because it's looking for the string `Postgres` in the result of `SELECT version();`, connections to EnterpriseDB databases currently fail.