### PR TITLE
fixes bug when using dot in as identifier

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -86,6 +86,10 @@ assign(Formatter.prototype, {
     return this._wrapString(value + '');
   },
 
+  wrapAsIdentifier: function wrapAsIdentifier(value) {
+    return this.client.wrapIdentifier((value || '').trim());
+  },
+
   alias: function(first, second) {
     return first + ' as ' + second;
   },
@@ -141,7 +145,7 @@ assign(Formatter.prototype, {
     if (asIndex !== -1) {
       var first  = value.slice(0, asIndex)
       var second = value.slice(asIndex + 4)
-      return this.alias(this.wrap(first), this.wrap(second))
+      return this.alias(this.wrap(first), this.wrapAsIdentifier(second))
     }
     var i = -1, wrapped = [];
     segments = value.split('.');

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -148,6 +148,15 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it("allows alias with dots in the identifier name", function() {
+    testsql(qb().select('foo as bar.baz').from('users'), {
+      mysql: 'select `foo` as `bar.baz` from `users`',
+      oracle: 'select "foo" "bar.baz" from "users"',
+      mssql: 'select [foo] as [bar.baz] from [users]',
+      default: 'select "foo" as "bar.baz" from "users"'
+    });
+  });
+
   it("basic table wrapping", function() {
     testsql(qb().select('*').from('public.users'), {
       mysql: 'select * from `public`.`users`',


### PR DESCRIPTION
I've encountered what I think is a bug on the formatting of SQL statements. Take the following example:
```js
var knex = require('knex')(config);
console.log(knex.select('id as foo.bar').from('users').toSQL());
```
This would print
```
{ method: 'select',
  options: {},
  bindings: [],
  sql: 'select "id" as "foo"."bar" from "users"' }
```
like trying to access a field in the alias but instead should be formatted as
```
{ method: 'select',
  options: {},
  bindings: [],
  sql: 'select "id" as "foo.bar" from "users"' }
```