### PR TITLE
knex.batchInsert

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,14 @@
       <li>- <a href="#Raw-queries-wrapped">Wrapped Queries</a></li>
     </ul>
 
+
+    <a class="toc_title" href="#Utility">
+      Utility
+    </a>
+    <ul class="toc_section">
+      <li>- <a href="#Utility-BatchInsert">Batch Insert</a></li>
+    </ul>
+
     <a class="toc_title" href="#Interfaces">
       Interfaces
     </a>
@@ -2196,6 +2204,35 @@ knex.select('e.lastname', 'e.salary', subcolumn)
   .from('employee as e')
   .whereRaw('dept_no = e.dept_no')
 </pre>
+
+
+    <h2 id="Utility">Utility</h2>
+
+    <p>
+      A collection of utilities that the knex library provides for convenience.
+    </p>
+
+
+    <h3 id="Utility-BatchInsert">Batch Insert</h3>
+
+    <p>The <tt>batchInsert</tt> utility will insert a batch of rows wrapped inside a transaction (which is automatically created), at a given <tt>chunkSize</tt>.</p>
+    <p>It's primarily designed to be used when you have thousands of rows to insert into a table.</p>
+    <p>By default, the <tt>chunkSize</tt> is set to 1.</p>
+
+<pre>
+<code class="js">
+  var rows = [{...}, {...}];
+  var chunkSize = 30;
+  knex.batchInsert('TableName', rows, chunkSize)
+  .then(function() {
+    ...
+  })
+  .catch(function(error) {
+    ...
+  });
+</code>
+</pre>
+
 
     <h2 id="Interfaces">Interfaces</h2>
 

--- a/src/util/make-knex.js
+++ b/src/util/make-knex.js
@@ -37,8 +37,7 @@ module.exports = function makeKnex(client) {
     batchInsert: function(table, batch, chunkSize) {
       chunkSize = _.isNumber(chunkSize) ? chunkSize : 1;
 
-      return new Promise((resolver, rejecter) => {
-        this.transaction((tr) => {
+      return this.transaction((tr) => {
 
           //Avoid unnecessary call
           if(chunkSize !== 1) {
@@ -50,11 +49,7 @@ module.exports = function makeKnex(client) {
           }))
           .then(tr.commit)
           .catch(tr.rollback)
-
         })
-        .then(resolver)
-        .catch(rejecter)
-      })
     },
 
     // Runs a new transaction, taking a container and returning a promise

--- a/src/util/make-knex.js
+++ b/src/util/make-knex.js
@@ -7,6 +7,8 @@ var Seeder         = require('../seed')
 var FunctionHelper = require('../functionhelper')
 var QueryInterface = require('../query/methods')
 var helpers        = require('../helpers')
+var Promise        = require('../promise')
+var _              = require('lodash')
 
 module.exports = function makeKnex(client) {
 
@@ -30,6 +32,29 @@ module.exports = function makeKnex(client) {
 
     raw: function() {
       return client.raw.apply(client, arguments)
+    },
+
+    batchInsert: function(table, batch, chunkSize) {
+      chunkSize = _.isNumber(chunkSize) ? chunkSize : 1;
+
+      return new Promise((resolver, rejecter) => {
+        this.transaction((tr) => {
+
+          //Avoid unnecessary call
+          if(chunkSize !== 1) {
+            batch = _.chunk(batch, chunkSize)
+          }
+
+          Promise.all(batch.map((items) => {
+            return tr(table).insert(items)
+          }))
+          .then(tr.commit)
+          .catch(tr.rollback)
+
+        })
+        .then(resolver)
+        .catch(rejecter)
+      })
     },
 
     // Runs a new transaction, taking a container and returning a promise

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -647,6 +647,37 @@ module.exports = function(knex) {
       });
     });
 
+
+    it('#757 - knex.batchInsert(tableName, bulk, chunkSize)', function (done) {
+      this.timeout(20000);
+      var fiftyLengthString = 'rO8F8YrFS6uoivuRiVnwrO8F8YrFS6uoivuRiVnwuoivuRiVnw';
+      knex.schema.dropTableIfExists('BatchInsert')
+          .then(function () {
+            return knex.schema.createTable('BatchInsert', function (table) {
+              for(var i = 0; i < 65; i++) {
+                table.string('Col' + i, 50);
+              }
+            })
+          })
+          .then(function () {
+            var items = [];
+
+            for(var i = 0; i < 5000; i++) {
+              var item = {};
+              for(var x = 0; x < 65; x++) {
+                item['Col' + x] = fiftyLengthString;
+              }
+              items.push(item);
+            }
+
+            return knex.batchInsert('BatchInsert', items, 1);
+          })
+          .then(function() {
+            done();
+          })
+          .catch(done);
+    });
+
   });
 
 };

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -674,10 +674,10 @@ module.exports = function(knex) {
             return knex.batchInsert('BatchInsert', items, 30);
           })
           .then(function () {
-            return knex('BatchInsert').count();
+            return knex('BatchInsert').select();
           })
           .then(function (result) {
-            var count = parseInt(_.first(result).count, 10);
+            var count = result.length;
             expect(count).to.equal(amountOfItems);
           })
     });

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -654,7 +654,7 @@ module.exports = function(knex) {
       knex.schema.dropTableIfExists('BatchInsert')
           .then(function () {
             return knex.schema.createTable('BatchInsert', function (table) {
-              for(var i = 0; i < 65; i++) {
+              for(var i = 0; i < 30; i++) {
                 table.string('Col' + i, 50);
               }
             })
@@ -662,9 +662,9 @@ module.exports = function(knex) {
           .then(function () {
             var items = [];
 
-            for(var i = 0; i < 5000; i++) {
+            for(var i = 0; i < 2500; i++) {
               var item = {};
-              for(var x = 0; x < 65; x++) {
+              for(var x = 0; x < 30; x++) {
                 item['Col' + x] = fiftyLengthString;
               }
               items.push(item);

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -648,34 +648,38 @@ module.exports = function(knex) {
     });
 
 
-    it('#757 - knex.batchInsert(tableName, bulk, chunkSize)', function (done) {
-      this.timeout(20000);
+    it('#757 - knex.batchInsert(tableName, bulk, chunkSize)', function () {
       var fiftyLengthString = 'rO8F8YrFS6uoivuRiVnwrO8F8YrFS6uoivuRiVnwuoivuRiVnw';
-      knex.schema.dropTableIfExists('BatchInsert')
+      var items             = [];
+      var amountOfItems     = 100;
+      var amountOfColumns   = 30;
+
+      for (var i = 0; i < amountOfItems; i++) {
+        var item = {};
+        for (var x = 0; x < amountOfColumns; x++) {
+          item['Col' + x] = fiftyLengthString;
+        }
+        items.push(item);
+      }
+
+      return knex.schema.dropTableIfExists('BatchInsert')
           .then(function () {
             return knex.schema.createTable('BatchInsert', function (table) {
-              for(var i = 0; i < 30; i++) {
+              for (var i = 0; i < amountOfColumns; i++) {
                 table.string('Col' + i, 50);
               }
             })
           })
           .then(function () {
-            var items = [];
-
-            for(var i = 0; i < 2500; i++) {
-              var item = {};
-              for(var x = 0; x < 30; x++) {
-                item['Col' + x] = fiftyLengthString;
-              }
-              items.push(item);
-            }
-
-            return knex.batchInsert('BatchInsert', items, 1);
+            return knex.batchInsert('BatchInsert', items, 30);
           })
-          .then(function() {
-            done();
+          .then(function () {
+            return knex('BatchInsert').count();
           })
-          .catch(done);
+          .then(function (result) {
+            var count = parseInt(_.first(result).count, 10);
+            expect(count).to.equal(amountOfItems);
+          })
     });
 
   });


### PR DESCRIPTION
This was discussed in #757. Couldn't see Tim's code in that issue so not sure how he originally implemented this, but hopefully I'm not too far of.

Ideas for performance improvements is more than welcome. It still takes a bit to insert 5k+ rows.

In short it will create a transaction and insert all the rows within that transaction.

```javascript
knex.batchInsert(tableName, rows, chunkSize = 1)
```