### PR TITLE
Allows builder instances to be used as scalar values

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -80,6 +80,9 @@ assign(Formatter.prototype, {
     if (typeof value === 'function') {
       return this.outputQuery(this.compileCallback(value), true);
     }
+    if (value instanceof QueryBuilder) {
+      return this.parameterize(value);
+    }
     raw = this.unwrapRaw(value);
     if (raw) return raw;
     if (typeof value === 'number') return value;

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -157,6 +157,15 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it("allows for subqueries to be used inside select", function() {
+    var subquery = qb().select('total').from('pets').as('pet_total');
+    testsql(qb().select(['name', subquery]).from('public.users'), {
+      mysql: 'select `name`, (select `total` from `pets`) as `pet_total` from `public`.`users`',
+      mssql: 'select [name], (select [total] from [pets]) as [pet_total] from [public].[users]',
+      default: 'select "name", (select "total" from "pets") as "pet_total" from "public"."users"'
+    });
+  });
+
   it("basic table wrapping", function() {
     testsql(qb().select('*').from('public.users'), {
       mysql: 'select * from `public`.`users`',
@@ -198,6 +207,14 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it("where subquery", function() {
+    var subquery = qb().select('total').from('pets');
+    testsql(qb().select('*').from('users').where({ total: subquery }), {
+      mysql: 'select * from `users` where `total` = (select `total` from `pets`)',
+      mssql: 'select * from [users] where [total] = (select [total] from [pets])',
+      default: 'select * from "users" where "total" = (select "total" from "pets")'
+    });
+  });
 
   it("where not", function() {
     testsql(qb().select('*').from('users').whereNot('id', '=', 1), {


### PR DESCRIPTION
I'm not sure if it was intentional or not to only allow subqueries using a builder instance in `whereIn` statements but this fix makes it so that they can be used elsewhere. It's quite handy to build instances programmatically rather than have to build up the function in the grouped chain.

I'm not super familiar with the codebase so if this breaks other stuff let me know. Should work similar to the way the `whereIn` compiler works though.

cc #614 