### PR TITLE
Bugfix/acquire new connection when socket closed

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -40,7 +40,7 @@ assign(Runner.prototype, {
       .then(resolver)
       .catch((error) => {
           //TODO: -- Temporary check during test-phase. How to properly check this globally across all dialects?
-          if(error.message.indexOf('socket') !== -1) {
+          if(error.message.toLowerCase().indexOf('this socket is closed') !== -1) {
             //Socket closed, so kill connection and try one more time with a fresh connection.
             runner.connection.__knex__disposed = true;
             runner.client.pool.destroy(runner.connection);

--- a/src/runner.js
+++ b/src/runner.js
@@ -25,22 +25,32 @@ assign(Runner.prototype, {
   // a single connection.
   run: function() {
     var runner = this
-    return Promise.using(this.ensureConnection(), function(connection) {
-      runner.connection = connection;
 
+    return new Promise((resolver, rejecter) => {
       runner.client.emit('start', runner.builder)
       runner.builder.emit('start', runner.builder)
+
       var sql = runner.builder.toSQL();
 
       if (runner.builder._debug) {
         console.log(sql)
       }
 
-      if (_.isArray(sql)) {
-        return runner.queryArray(sql);
-      }
-      return runner.query(sql);
-
+      return runner._execSQL(sql)
+      .then(resolver)
+      .catch((error) => {
+          //TODO: -- Temporary check during test-phase. How to properly check this globally across all dialects?
+          if(error.message.indexOf('socket') !== -1) {
+            //Socket closed, so kill connection and try one more time with a fresh connection.
+            runner.connection.__knex__disposed = true;
+            runner.client.pool.destroy(runner.connection);
+            runner.connection = null; //ensureConneciton will create a new connection
+            return runner._execSQL(sql)
+              .then(resolver)
+              .catch(rejecter)
+          }
+          rejecter(error)
+      })
     })
 
     // If there are any "error" listeners, we fire an error event
@@ -59,6 +69,18 @@ assign(Runner.prototype, {
       runner.builder.emit('end');
     })
 
+  },
+
+  _execSQL: function(sql) {
+    var runner = this
+    return Promise.using(this.ensureConnection(), function(connection) {
+      runner.connection = connection;
+
+      if (_.isArray(sql)) {
+        return runner.queryArray(sql);
+      }
+      return runner.query(sql);
+    })
   },
 
   // Stream the result set, by passing through to the dialect's streaming

--- a/test/integration/misc/index.js
+++ b/test/integration/misc/index.js
@@ -1,0 +1,36 @@
+/*global describe, expect, it*/
+
+'use strict';
+
+module.exports = function(knex) {
+
+	var dialect = knex.client.config.dialect;
+
+	describe('Miscellaneous', function() {
+
+		if(dialect === 'postgres') {
+			it('When Socket is closed by server, acquire a new connection and retry running the query.', function() {
+				return knex.raw('SELECT 1 = 1')
+					.then(function() {
+						var qBuilder = knex.raw('SELECT 1 = 1');
+
+						var Runner = qBuilder.client.runner(qBuilder);
+						Runner.run();
+
+						qBuilder.once('query', function() {
+							//Kill the socket by nullifying the handle
+							Runner.connection.connection.stream._handle = null;
+						});
+
+						return qBuilder;
+					})
+					.catch(function(error) {
+						//TODO: Temporary
+						expect(error).to.deep.equal({});
+					})
+			});
+		}
+
+	});
+
+};

--- a/test/integration/suite.js
+++ b/test/integration/suite.js
@@ -22,6 +22,7 @@ module.exports = function(knex) {
     require('./builder/transaction')(knex);
     require('./builder/deletes')(knex);
     require('./builder/additional')(knex);
+    require('./misc')(knex);
 
     describe('knex.destroy', function() {
       it('should allow destroying the pool with knex.destroy', function() {


### PR DESCRIPTION
@elhigu @woopstar In reference to #1198 this will "retry" a runner's job once it fails due to the socket being closed by the server. A few key notes here that had me going back and forth a bit..

1. The `Runner.run` function seems to be the best place to put this to avoid duplicating code between `Runner.query` and `Runner.queryArray` and to avoid having to move when/where events are being emitted.

2. The error thrown does not contain a code, only a message. In the listed issue, the message for mysql was `This socket has been ended by the other party` while in Postgres it's something like `Socket is closed` -- So I have no clue how to globally distinguish the specific error across all dialects.

3. I avoided recursion here since retrying more than once does not sound like a good idea.

4. I have no clue how to write a test for this since the connections need to be closed by the server. Any ideas?


Test code used

```javascript
knex.raw('SELECT version()')
.then(function() {
debugger; //Manually close connections on the server
return knex.raw('SELECT version()');
})
.then(function(result) {
//Result is present, query success.
}).catch(function(error) {
//Previously 'socket closed' error.
});
```

Code may need some cleanup, putting this up to see if I'm on the right track.