### PR TITLE
Add .timeout(ms) to QueryBuilder

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
     </a>
     <ul class="toc_section">
       <li>– <a href="#Builder-main"><b>constructor</b></a></li>
+      <li>– <a href="#Builder-timeout">timeout</a></li>
       <li>– <a href="#Builder-select">select</a></li>
       <li>– <a href="#Builder-as">as</a></li>
       <li>– <a href="#Builder-column">column</a></li>
@@ -582,6 +583,15 @@ pg('table').insert({a: 'b'}).returning('*').toString();
       <a href="#Interfaces">interface methods</a>, to either convert toString, or execute the
       query with a <a href="#Interfaces-Promises">promise</a>, <a href="#Interfaces-Callbacks">callback</a>, or <a href="#Interfaces-Streams">stream</a>.
     </p>
+
+    <p id="Builder-timeout">
+      <b class="header">timeout</b><code>.timeout(ms)</code>
+      <br />
+      Sets a timeout for the query and will throw a <tt>TimeoutError</tt> if the timeout is exceeded.
+      The error contains information about the query, bindings, and the timeout that was set.
+      Useful for complex queries that you want to make sure are not taking too long to execute.
+    </p>
+
 
     <p id="Builder-select">
       <b class="header">select</b><code>.select([*columns])</code>

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -6,12 +6,13 @@ var assert       = require('assert')
 var inherits     = require('inherits')
 var EventEmitter = require('events').EventEmitter
 
-var Raw          = require('../raw')
-var helpers      = require('../helpers')
-var JoinClause   = require('./joinclause')
-var clone        = require('lodash/lang/clone');
-var isUndefined  = require('lodash/lang/isUndefined');
-var assign       = require('lodash/object/assign');
+var Raw         = require('../raw')
+var helpers     = require('../helpers')
+var JoinClause  = require('./joinclause')
+var clone       = require('lodash/lang/clone');
+var isUndefined = require('lodash/lang/isUndefined');
+var isNumber    = require('lodash/lang/isNumber');
+var assign      = require('lodash/object/assign');
 
 // Typically called from `knex.builder`,
 // start a new query building chain.
@@ -55,6 +56,13 @@ assign(Builder.prototype, {
     }
 
     return cloned;
+  },
+
+  timeout: function(ms) {
+    if(isNumber(ms) && ms > 0) {
+      this._timeout = ms;
+    }
+    return this;
   },
 
   // Select

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -11,12 +11,13 @@ var reduce  = require('lodash/collection/reduce');
 // have been gathered in the "QueryBuilder" and turns them into a
 // properly formatted / bound query string.
 function QueryCompiler(client, builder) {
-  this.client      = client
-  this.method      = builder._method || 'select';
-  this.options     = builder._options;
-  this.single      = builder._single;
-  this.grouped     = _.groupBy(builder._statements, 'grouping');
-  this.formatter   = client.formatter()
+  this.client    = client
+  this.method    = builder._method || 'select';
+  this.options   = builder._options;
+  this.single    = builder._single;
+  this.timeout   = builder._timeout || false;
+  this.grouped   = _.groupBy(builder._statements, 'grouping');
+  this.formatter = client.formatter()
 }
 
 var components = [
@@ -36,6 +37,7 @@ assign(QueryCompiler.prototype, {
     var defaults = {
       method: method,
       options: reduce(this.options, assign, {}),
+      timeout: this.timeout,
       bindings: this.formatter.bindings
     };
     if (_.isString(val)) {


### PR DESCRIPTION
A feature suggestion that adds timecontrol over queries to the querybuilder that is being run in an application, similarly to how you can now control the Timeout for acquiring a new conection in 0.10.

Probably not often that this would have a use case, but in complex queries where you have tons of joins and tons of data, this could prove useful. If not for anything else, it can be used for finding queries that are slowing down an app.

This is not a requested feature or anything that I am personally in need of, just something extra.