### PR TITLE
Fix CLI failing with TypeError if knex installation missing

### DIFF
--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -112,8 +112,9 @@ function invoke(env) {
     .description('       Create a named migration file.')
     .option('-x [' + filetypes.join('|') + ']', 'Specify the stub extension (default js)')
     .action(function(name) {
+      var instance = initKnex(env);
       var ext = (argv.x || env.configPath.split('.').pop()).toLowerCase();
-      pending = initKnex(env).migrate.make(name, {extension: ext}).then(function(name) {
+      pending = instance.migrate.make(name, {extension: ext}).then(function(name) {
         success(chalk.green('Created Migration: ' + name));
       }).catch(exit);
     });
@@ -156,8 +157,9 @@ function invoke(env) {
     .description('       Create a named seed file.')
     .option('-x [' + filetypes.join('|') + ']', 'Specify the stub extension (default js)')
     .action(function(name) {
+      var instance = initKnex(env);
       var ext = (argv.x || env.configPath.split('.').pop()).toLowerCase();
-      pending = initKnex(env).seed.make(name, {extension: ext}).then(function(name) {
+      pending = instance.seed.make(name, {extension: ext}).then(function(name) {
         success(chalk.green('Created seed file: ' + name));
       }).catch(exit);
     });


### PR DESCRIPTION
When run without local knex installation CLI currently fails with a nice error message in some cases and with TypeError with other cases (migrate:make, seed:make). This changes aligns the behavior to always show the expected error message.