### PR TITLE
Allow knexfile to export a function

### DIFF
--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -50,6 +50,10 @@ function initKnex(env) {
   var defaultEnv  = 'development';
   var config      = require(env.configPath);
 
+  if (typeof config === 'function') {
+    config = config(environment || defaultEnv);
+  }
+
   if (!environment && typeof config[defaultEnv] === 'object') {
     environment = defaultEnv;
   }


### PR DESCRIPTION
To avoid configuration duplication i want to programmatically create the knexfile-content depending on the value of `--env`.
I could parse the process.argv in my own knexfile but this seems like a nicer api and doesn't break or change any existing behavior.