### PR TITLE
Fix small link bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
 
       <li><b><a href="#Builder-wheres">Where Methods:</a></b></li>
       <li>&nbsp;&nbsp;- <a href="#Builder-where">where</a></li>
-      <li>&nbsp;&nbsp;- <a href="#Builder-where">whereNot</a></li>
+      <li>&nbsp;&nbsp;- <a href="#Builder-whereNot">whereNot</a></li>
       <li>&nbsp;&nbsp;- <a href="#Builder-whereIn">whereIn</a></li>
       <li>&nbsp;&nbsp;- <a href="#Builder-whereNotIn">whereNotIn</a></li>
       <li>&nbsp;&nbsp;- <a href="#Builder-whereNull">whereNull</a></li>


### PR DESCRIPTION
The link for "whereNot" was directed to "where".