### PR TITLE
Fixed nested transactions

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -63,7 +63,7 @@ function Transaction(client, container, config, outerTx) {
   this._childQueue = []
 
   // The queue is a noop unless we have child promises.
-  this._queue = this._queue || Promise.resolve(true)
+  this._queue = Promise.resolve(true)
 
   // If there's a wrapping transaction, we need to see if there are 
   // any current children in the pending queue.
@@ -74,9 +74,7 @@ function Transaction(client, container, config, outerTx) {
     if (outerTx._childQueue.length > 0) {
 
       var previousSibling = outerTx._childQueue[outerTx._childQueue.length - 1]
-      this._queue = this._queue.then(function() {
-        return Promise.settle([previousSibling])
-      })
+      this._queue = Promise.settle([previousSibling])
 
     }
 

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -73,8 +73,9 @@ function Transaction(client, container, config, outerTx) {
     // settles (commit or rollback) and then we can continue.
     if (outerTx._childQueue.length > 0) {
 
+      var previousSibling = outerTx._childQueue[outerTx._childQueue.length - 1]
       this._queue = this._queue.then(function() {
-        return Promise.settle(outerTx._childQueue[outerTx._childQueue.length - 1])
+        return Promise.settle([previousSibling])
       })
 
     }

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -60,8 +60,6 @@ function Transaction(client, container, config, outerTx) {
 
   // If there is more than one child transaction,
   // we queue them, executing each when the previous completes.
-  this._childQueue = []
-
   // The queue is a noop unless we have child promises.
   this._queue = Promise.resolve(true)
 
@@ -71,15 +69,10 @@ function Transaction(client, container, config, outerTx) {
 
     // If there are other promises pending, we just wait until that one
     // settles (commit or rollback) and then we can continue.
-    if (outerTx._childQueue.length > 0) {
-
-      var previousSibling = outerTx._childQueue[outerTx._childQueue.length - 1]
-      this._queue = Promise.settle([previousSibling])
-
-    }
+    if (outerTx._lastChild) this._queue = Promise.settle([outerTx._lastChild])
 
     // Push the current promise onto the queue of promises.
-    outerTx._childQueue.push(this._promise)
+    outerTx._lastChild = this._promise
   }
 
 }

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -58,23 +58,15 @@ function Transaction(client, container, config, outerTx) {
 
   this._completed  = false
 
-  // If there is more than one child transaction,
-  // we queue them, executing each when the previous completes.
-  // The queue is a noop unless we have child promises.
-  this._queue = Promise.resolve(true)
-
-  // If there's a wrapping transaction, we need to see if there are 
-  // any current children in the pending queue.
+  // If there's a wrapping transaction, we need to wait for any older sibling
+  // transactions to settle (commit or rollback) before we can start, and we
+  // need to register ourselves with the parent transaction so any younger
+  // siblings can wait for us to complete before they can start.
+  this._previousSibling = Promise.resolve(true);
   if (outerTx) {
-
-    // If there are other promises pending, we just wait until that one
-    // settles (commit or rollback) and then we can continue.
-    if (outerTx._lastChild) this._queue = Promise.settle([outerTx._lastChild])
-
-    // Push the current promise onto the queue of promises.
-    outerTx._lastChild = this._promise
+    if (outerTx._lastChild) this._previousSibling = outerTx._lastChild;
+    outerTx._lastChild = this._promise;
   }
-
 }
 inherits(Transaction, EventEmitter)
 
@@ -230,7 +222,7 @@ function makeTxClient(trx, client, connection) {
     })
   }
   trxClient.acquireConnection = function() {
-    return trx._queue.then(function() {
+    return Promise.settle([trx._previousSibling]).then(function () {
       return connection
     })
   }


### PR DESCRIPTION
The original code for handling nested transactions did not work correctly when you had sibling nested transactions, i.e. two or more transactions all living inside the same parent transaction and latter ones getting started after their predecessor sibling completes (rolls back or commits). In such cases, knex would hang on any DB operation attempted using a non-initial sibling transaction.

Basic cause was in knex _accidentally_ waiting for that same transaction to complete before allowing someone else to access the transaction's database connection. :smiling_imp:

Basic bug fixed in d0836b8f880373836b153e922f401496e2914466.

Detailed tests added for handling sibling tested transactions in 675c684d3bd6b55ed63e4a6d3035754d2964cf8d. You can run those tests to reproduce the hang if you run them without the fix applied.

The three later commits (e0e77dfaf8dd13719bbebe1279d4a6d601595be2, f38f901bd5745399e129635febf2db35bfcae2f3, 675c684d3bd6b55ed63e4a6d3035754d2964cf8d) then just clean up the related code. And in the end the code is simplified enough that the original fix becomes unnecessary to begin with. :smile:

Hope this helps.

Best regards,
  Jurko Gospodnetić