### PR TITLE
Fix calling process.exit with "ok" exit code

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -40,7 +40,7 @@ var helpers = {
 
   exit: function(msg) {
     console.log(chalk.red(msg))
-    process.exit()
+    process.exit(1)
   }
 
 };


### PR DESCRIPTION
We have a helper to log an error message to the console and exit the process. It looks like the only place we use this helper is when we try and fail to [initialize the driver](https://github.com/tgriesser/knex/blob/5a94bc9b178d399e23a80ff396a0fc7ec01ecc9b/src/client.js#L159).

Unfortunately, when we call `process.exit()` without an exit code, it [exits with a `0` exit code](https://nodejs.org/api/process.html#process_process_exit_code) -- which means success.

This is especially a problem when running tests in a CI environment, as it results in a false positive: tests not only do not pass, but they probably didn't even run.