### PR TITLE
Fixes inTable(undefined) silently fails bug from Issue #1220

### DIFF
--- a/src/schema/tablebuilder.js
+++ b/src/schema/tablebuilder.js
@@ -190,8 +190,8 @@ TableBuilder.prototype.foreign = function(column) {
         foreignData.references = pieces ? pieces[0] : tableColumn;
         return {
           on: function(tableName) {
-            if (typeof tableName === 'undefined') {
-              throw new Error("table name is of type 'undefined'. Please pass in a valid table name");
+            if (typeof tableName !== 'string') {
+              throw new TypeError(`Expected tableName to be a string, got: ${typeof tableName}`);
             }
             foreignData.inTable = tableName;
             return returnObj;

--- a/src/schema/tablebuilder.js
+++ b/src/schema/tablebuilder.js
@@ -190,6 +190,9 @@ TableBuilder.prototype.foreign = function(column) {
         foreignData.references = pieces ? pieces[0] : tableColumn;
         return {
           on: function(tableName) {
+            if (typeof tableName === 'undefined') {
+              throw new Error("table name is of type 'undefined'. Please pass in a valid table name");
+            }
             foreignData.inTable = tableName;
             return returnObj;
           },

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -41,7 +41,7 @@ module.exports = function(knex) {
             .dropTableIfExists('rename_column_foreign_test')
             .dropTableIfExists('rename_column_test')
             .dropTableIfExists('should_not_be_run')
-            .dropTableIfExists('foreign_key_empty_inTable_test_parameter')
+            .dropTableIfExists('invalid_inTable_param_test')
         ]);
       });
 
@@ -166,7 +166,7 @@ module.exports = function(knex) {
       });
 
       it('rejects setting foreign key where tableName is not typeof === string', function() {
-        return knex.schema.createTable('foreign_key_empty_inTable_test_parameter', function(table) {
+        return knex.schema.createTable('invalid_inTable_param_test', function(table) {
           var createInvalidUndefinedInTableSchema = function() {
             table.increments('id').references('id').inTable()
           };

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -164,6 +164,15 @@ module.exports = function(knex) {
         });
       });
 
+      it('fails when setting foreign keys on incorrect table name', function() {
+        return knex.schema.createTable('undefined_inTable_parameter', function(table) {
+          var createInvalidInTableSchema = function() {
+            table.increments('id').references('id').inTable()
+          };
+          expect(createInvalidInTableSchema).to.throw(Error);
+        })
+      });
+
       it('allows for composite keys', function() {
         return knex.schema
           .createTable('composite_key_test', function(table) {

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -41,6 +41,7 @@ module.exports = function(knex) {
             .dropTableIfExists('rename_column_foreign_test')
             .dropTableIfExists('rename_column_test')
             .dropTableIfExists('should_not_be_run')
+            .dropTableIfExists('foreign_key_empty_inTable_test_parameter')
         ]);
       });
 
@@ -164,14 +165,19 @@ module.exports = function(knex) {
         });
       });
 
-      it('fails when setting foreign keys on incorrect table name', function() {
-        return knex.schema.createTable('undefined_inTable_parameter', function(table) {
-          var createInvalidInTableSchema = function() {
+      it('rejects setting foreign key where tableName is not typeof === string', function() {
+        return knex.schema.createTable('foreign_key_empty_inTable_test_parameter', function(table) {
+          var createInvalidUndefinedInTableSchema = function() {
             table.increments('id').references('id').inTable()
           };
-          expect(createInvalidInTableSchema).to.throw(Error);
+          var createInvalidObjectInTableSchema = function () {
+            table.integer('another_id').references('id').inTable({tableName: 'this_should_fail'})
+          };
+          expect(createInvalidUndefinedInTableSchema).to.throw(TypeError);
+          expect(createInvalidObjectInTableSchema).to.throw(TypeError);
         })
       });
+
 
       it('allows for composite keys', function() {
         return knex.schema


### PR DESCRIPTION
Fixes #1220, https://github.com/tgriesser/knex/issues/1220, inTable(undefined) fails silently error by making sure it throws an error if the user passes an undefined table name.