### PR TITLE
Update regex for named bindings

### DIFF
--- a/index.html
+++ b/index.html
@@ -2224,18 +2224,27 @@ knex('users')
   .orWhere(knex.raw('status <> ?', [1]))
   .groupBy('status')
 </pre>
+
+    <p>
+      Positional bindings <tt>?</tt> are interpreted as values and <tt>??</tt> are interpreted as identifiers.
+    </p>
+
 <pre class="display">
-// positional bindings ? is interpret as value and ?? as identifier
 knex('users').where(knex.raw('?? = ?', ['user.name', 1]))
 </pre>
 
+    <p>
+      Named bindings such as <tt>:name</tt> are interpreted as values and <tt>:name:</tt> interpreted as identifiers.
+      Named bindings are processed so long as the value is anything other than <tt>undefined</tt>.
+    </p>
+
 <pre class="display">
-// named bindings :name is interpret as value and :name: as identifier
 knex('users')
-  .where(knex.raw(':name: = :thisGuy or :name: = :otherGuy', {
+  .where(knex.raw(':name: = :thisGuy or :name: = :otherGuy or :name: = :undefinedBinding', {
     name: 'users.name',
     thisGuy: 'Bob',
-    otherGuy: 'Jay'
+    otherGuy: 'Jay',
+    undefinedBinding: undefined
   }))
 </pre>
 

--- a/src/raw.js
+++ b/src/raw.js
@@ -127,7 +127,7 @@ function replaceKeyBindings(raw) {
   var client   = raw.client
   var sql      = raw.sql, bindings = []
 
-  var regex = new RegExp('(^|\\s)(\\:\\w+\\:?)', 'g')
+  var regex = new RegExp('(\\:\\w+\\:?)', 'g')
   sql = raw.sql.replace(regex, function(full) {
     var key = full.trim();
     var isIdentifier = key[key.length - 1] === ':'

--- a/src/raw.js
+++ b/src/raw.js
@@ -128,11 +128,15 @@ function replaceKeyBindings(raw) {
   var sql      = raw.sql, bindings = []
 
   var regex = new RegExp('(\\:\\w+\\:?)', 'g')
+  var emptyBindings = [];
   sql = raw.sql.replace(regex, function(full) {
     var key = full.trim();
     var isIdentifier = key[key.length - 1] === ':'
     var value = isIdentifier ? values[key.slice(1, -1)] : values[key.slice(1)]
-    if (value === undefined) return ''
+    if (value === undefined) {
+      emptyBindings.push(full);
+      return full;
+    }
     if (value && typeof value.toSQL === 'function') {
       var bindingSQL = value.toSQL()
       if (bindingSQL.bindings !== undefined) {
@@ -146,6 +150,10 @@ function replaceKeyBindings(raw) {
     bindings.push(value)
     return full.replace(key, '?')
   })
+
+  emptyBindings.map(function(binding) {
+    sql = sql.replace(new RegExp(` ${binding}|${binding} |${binding}`, 'g'), '');
+  });
 
   return {
     method: 'raw',

--- a/src/raw.js
+++ b/src/raw.js
@@ -128,13 +128,11 @@ function replaceKeyBindings(raw) {
   var sql      = raw.sql, bindings = []
 
   var regex = new RegExp('(\\:\\w+\\:?)', 'g')
-  var emptyBindings = [];
   sql = raw.sql.replace(regex, function(full) {
     var key = full.trim();
     var isIdentifier = key[key.length - 1] === ':'
     var value = isIdentifier ? values[key.slice(1, -1)] : values[key.slice(1)]
     if (value === undefined) {
-      emptyBindings.push(full);
       return full;
     }
     if (value && typeof value.toSQL === 'function') {
@@ -150,10 +148,6 @@ function replaceKeyBindings(raw) {
     bindings.push(value)
     return full.replace(key, '?')
   })
-
-  emptyBindings.map(function(binding) {
-    sql = sql.replace(new RegExp(` ${binding}|${binding} |${binding}`, 'g'), '');
-  });
 
   return {
     method: 'raw',

--- a/test/tape/raw.js
+++ b/test/tape/raw.js
@@ -71,18 +71,18 @@ test('allows for options in raw queries, #605', function(t) {
   })
 })
 
-test('raw query strings with keys replace values', function(t) {
-
+test('undefined named bindings are ignored', function(t) {
+  
   t.plan(2)
+  
+  t.equal(raw('select :item from :place', {}).toSQL().sql, 'select :item from :place')
 
-  t.equal(raw('select :item from :place', {}).toSQL().sql, 'select from')
-
-  t.equal(raw('select :item :cool 2 from :place', {}).toSQL().sql, 'select 2 from')
+  t.equal(raw('select :item :cool 2 from :place', {item: 'col1'}).toSQL().sql, 'select ? :cool 2 from :place')
 
 })
 
 test('raw bindings are optional, #853', function(t) {
-
+  
   t.plan(2)
 
   var sql = raw('select * from ? where id=?', [raw('foo'), 4]).toSQL()


### PR DESCRIPTION
Fixes #1228  . I'm unsure why the first condition of the regular expression was there, as it shouldn't matter at all?

It should now properly match named bindings, and will not require a space before the binding *(see related issue)*.

I also added a test for this based on examples in documentation.

See http://regexr.com/3cv16

------------------------
**TODO**
- [x] Change regular expression so that spaces are not mandatory for named bindings
- [x] If a binding value is undefined, leave the binding in the sql untouched
- [x] Update docs explaining these changes in detail.