### PR TITLE
Fix transaction callback throw handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1709,6 +1709,12 @@ knex.transaction(function(trx) {
 </pre>
 
   <p>
+    Throwing an error directly from the transaction handler function
+    automatically rolls back the transaction, same as returning a rejected
+    promise.
+  </p>
+
+  <p>
     Notice that if a promise is not returned within the handler, it is up to you to ensure <tt>trx.commit</tt>, or
     <tt>trx.rollback</tt> are called, otherwise the transaction connection will hang.
   </p>

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -32,10 +32,15 @@ function Transaction(client, container, config, outerTx) {
       return makeTransactor(this, connection, trxClient)
     })
     .then((transactor) => {
-      var result = container(transactor)
-
       // If we've returned a "thenable" from the transaction container, assume
       // the rollback and commit are chained to this object's success / failure.
+      // Directly thrown errors are treated as automatic rollbacks.
+      var result
+      try {
+        result = container(transactor)
+      } catch (err) {
+        result = Promise.reject(err)
+      }
       if (result && result.then && typeof result.then === 'function') {
         result.then((val) => {
           transactor.commit(val)

--- a/test/integration/builder/transaction.js
+++ b/test/integration/builder/transaction.js
@@ -146,12 +146,11 @@ module.exports = function(knex) {
         expect(__knexUid).to.equal(obj.__knexUid);
       })
       .catch(function(msg) {
-        if (knex.client.dialect === 'oracle' || knex.client.dialect === 'mssql') {
-          // oracle start transaction /rollback are no queries
-          expect(count).to.equal(2);
-        } else {
-          expect(count).to.equal(4);
-        }
+        // oracle & mssql: BEGIN & ROLLBACK not reported as queries
+        var expectedCount =
+          knex.client.dialect === 'oracle' ||
+          knex.client.dialect === 'mssql' ? 2 : 4;
+        expect(count).to.equal(expectedCount);
         expect(msg).to.equal(err);
         return knex('accounts').where('id', id).select('first_name');
       })

--- a/test/tape/transactions.js
+++ b/test/tape/transactions.js
@@ -31,51 +31,146 @@ module.exports = function(knex) {
     })
   })
 
-  test('transaction rollback', function(t) {
-    return knex.transaction(function(trx) {
-      return trx.insert({id: 1, name: 'A'}).into('test_table').then(function() {
-        throw new Error('Not inserting')
+  test('transaction rollback on returned rejected promise', function (t) {
+    var testError = new Error('Not inserting')
+    var trxQueryCount = 0
+    var trxRejected
+    return knex.transaction(function (trx) {
+      return trx.insert({id: 1, name: 'A'}).into('test_table').then(function () {
+        throw testError
       })
     })
-    .catch(function() {})
-    .finally(function() {
-      return knex.select('*').from('test_table').then(function(results) {
-        t.equal(results.length, 0, 'No rows were inserted')
+    .on('query', function () {
+      ++trxQueryCount
+    })
+    .catch(function (err) {
+      t.equal(err, testError, 'Expected error reported')
+      trxRejected = true
+    })
+    .finally(function () {
+      // BEGIN, INSERT, ROLLBACK
+      // oracle & mssql: BEGIN & ROLLBACK not reported as queries
+      var expectedQueryCount =
+        knex.client.dialect === 'oracle' ||
+        knex.client.dialect === 'mssql' ? 1 : 3
+      t.equal(trxQueryCount, expectedQueryCount, 'Expected number of transaction SQL queries executed')
+      t.equal(trxRejected, true, 'Transaction promise rejected')
+      return knex.select('*').from('test_table').then(function (results) {
+        t.equal(results.length, 0, 'No rows inserted')
       })
     })
   })
 
-  test('transaction savepoint', function(t) {
-    
-    return knex.transaction(function(trx) {
-      
-      return trx.insert({id: 1, name: 'A'}).into('test_table').then(function() {
-        
-        // Nested transaction (savepoint)
-        return trx.transaction(function(trx2) {
-          
-          // Insert and then roll back the savepoint
-          return trx2.table('test_table').insert({id: 2, name: 'B'}).then(function() {
-            return trx2('test_table').then(function(results) {
-              t.equal(results.length, 2, 'Two Rows inserted')
-            })
-            .throw(new Error('Rolling Back Savepoint'))
-          })
-
-        })
-
-      }).catch(function(err) {
-        t.equal(err.message, 'Rolling Back Savepoint')
-      })
-
+  test('transaction rollback on error throw', function (t) {
+    var testError = new Error('Boo!!!')
+    var trxQueryCount = 0
+    var trxRejected
+    return knex.transaction(function () {
+      throw testError
     })
-    .catch(function() {})
-    .finally(function() {
-      return knex.select('*').from('test_table').then(function(results) {
+    .on('query', function () {
+      ++trxQueryCount
+    })
+    .catch(function (err) {
+      t.equal(err, testError, 'Expected error reported')
+      trxRejected = true;
+    })
+    .finally(function () {
+      // BEGIN, ROLLBACK
+      // oracle & mssql: BEGIN & ROLLBACK not reported as queries
+      var expectedQueryCount =
+        knex.client.dialect === 'oracle' ||
+        knex.client.dialect === 'mssql' ? 0 : 2
+      t.equal(trxQueryCount, expectedQueryCount, 'Expected number of transaction SQL queries executed')
+      t.equal(trxRejected, true, 'Transaction promise rejected')
+    })
+  })
+
+  test('transaction savepoint rollback on returned rejected promise', function (t) {
+    var testError = new Error('Rolling Back Savepoint')
+    var trx1QueryCount = 0
+    var trx2QueryCount = 0
+    var trx2Rejected
+    return knex.transaction(function (trx1) {
+      return trx1.insert({id: 1, name: 'A'}).into('test_table').then(function () {
+        // Nested transaction (savepoint)
+        return trx1.transaction(function (trx2) {
+          // Insert and then roll back to savepoint
+          return trx2.table('test_table').insert({id: 2, name: 'B'}).then(function () {
+            return trx2('test_table').then(function (results) {
+              t.equal(results.length, 2, 'Two rows inserted')
+            })
+            .throw(testError)
+          })
+        })
+        .on('query', function () {
+          ++trx2QueryCount
+        })
+      }).catch(function (err) {
+        t.equal(err, testError, 'Expected error reported')
+        trx2Rejected = true
+      })
+    })
+    .on('query', function () {
+      ++trx1QueryCount
+    })
+    .finally(function () {
+      // trx1: BEGIN, INSERT, ROLLBACK
+      // trx2: SAVEPOINT, INSERT, SELECT, ROLLBACK TO SAVEPOINT
+      // oracle & mssql: BEGIN & ROLLBACK not reported as queries
+      var expectedTrx1QueryCount =
+        knex.client.dialect === 'oracle' ||
+        knex.client.dialect === 'mssql' ? 1 : 3
+      var expectedTrx2QueryCount = 4
+      expectedTrx1QueryCount += expectedTrx2QueryCount
+      t.equal(trx1QueryCount, expectedTrx1QueryCount, 'Expected number of parent transaction SQL queries executed')
+      t.equal(trx2QueryCount, expectedTrx2QueryCount, 'Expected number of nested transaction SQL queries executed')
+      t.equal(trx2Rejected, true, 'Nested transaction promise rejected')
+      return knex.select('*').from('test_table').then(function (results) {
         t.equal(results.length, 1, 'One row inserted')
       })
     })
-  
+  })
+
+  test('transaction savepoint rollback on error throw', function (t) {
+    var testError = new Error('Rolling Back Savepoint')
+    var trx1QueryCount = 0
+    var trx2QueryCount = 0
+    var trx2Rejected
+    return knex.transaction(function (trx1) {
+      return trx1.insert({id: 1, name: 'A'}).into('test_table').then(function () {
+        // Nested transaction (savepoint)
+        return trx1.transaction(function () {  // trx2
+          // Roll back to savepoint
+          throw testError
+        })
+        .on('query', function () {
+          ++trx2QueryCount
+        })
+      }).catch(function (err) {
+        t.equal(err, testError, 'Expected error reported')
+        trx2Rejected = true
+      })
+    })
+    .on('query', function () {
+      ++trx1QueryCount
+    })
+    .finally(function () {
+      // trx1: BEGIN, INSERT, ROLLBACK
+      // trx2: SAVEPOINT, ROLLBACK TO SAVEPOINT
+      // oracle & mssql: BEGIN & ROLLBACK not reported as queries
+      var expectedTrx1QueryCount =
+        knex.client.dialect === 'oracle' ||
+        knex.client.dialect === 'mssql' ? 1 : 3
+      var expectedTrx2QueryCount = 2
+      expectedTrx1QueryCount += expectedTrx2QueryCount
+      t.equal(trx1QueryCount, expectedTrx1QueryCount, 'Expected number of parent transaction SQL queries executed')
+      t.equal(trx2QueryCount, expectedTrx2QueryCount, 'Expected number of nested transaction SQL queries executed')
+      t.equal(trx2Rejected, true, 'Nested transaction promise rejected')
+      return knex.select('*').from('test_table').then(function (results) {
+        t.equal(results.length, 1, 'One row inserted')
+      })
+    })
   })
 
   test('sibling nested transactions - second created after first one commits', function (t) {

--- a/test/tape/transactions.js
+++ b/test/tape/transactions.js
@@ -26,7 +26,7 @@ module.exports = function(knex) {
     })
     .then(function() {
       return knex.select('*').from('test_table').then(function(results) {
-        t.equal(results.length, 1)
+        t.equal(results.length, 1, 'One row inserted')
       })
     })
   })
@@ -310,14 +310,14 @@ module.exports = function(knex) {
       queryCount++
     })
     .catch(function(err) {
-      t.equal(err.message, 'Rolled back')
+      t.equal(err.message, 'Rolled back', 'Transaction promise rejected with expected error')
     })
     .finally(function() {
       // oracle & mssql: BEGIN & ROLLBACK not reported as queries
       var expectedQueryCount =
         knex.client.dialect === 'oracle' ||
         knex.client.dialect === 'mssql' ? 1 : 3
-      t.equal(queryCount, expectedQueryCount)
+      t.equal(queryCount, expectedQueryCount, 'Expected number of transaction SQL queries executed')
     })
 
   })
@@ -340,7 +340,7 @@ module.exports = function(knex) {
     return knex.transaction(function() {
       throw new Error('Some Error')
     }).catch(function(e) {
-      t.equal(e.message, 'Some Error')
+      t.equal(e.message, 'Some Error', 'Transaction promise rejected with expected error')
     })
   })
 

--- a/test/tape/transactions.js
+++ b/test/tape/transactions.js
@@ -431,14 +431,6 @@ module.exports = function(knex) {
     });    
   });
 
-  test('#832 - exceptions in transaction container', function(t) {
-    return knex.transaction(function() {
-      throw new Error('Some Error')
-    }).catch(function(e) {
-      t.equal(e.message, 'Some Error', 'Transaction promise rejected with expected error')
-    })
-  })
-
   if (knex.client.driverName === 'pg') {
     tape('allows postgres ? operator in knex.raw() if no bindings given #519 and #888', function (t) {
       t.plan(1)

--- a/test/tape/transactions.js
+++ b/test/tape/transactions.js
@@ -313,7 +313,11 @@ module.exports = function(knex) {
       t.equal(err.message, 'Rolled back')
     })
     .finally(function() {
-      t.equal(queryCount, knex.client.dialect === 'oracle' || knex.client.dialect === 'mssql' ? 1 : 3)
+      // oracle & mssql: BEGIN & ROLLBACK not reported as queries
+      var expectedQueryCount =
+        knex.client.dialect === 'oracle' ||
+        knex.client.dialect === 'mssql' ? 1 : 3
+      t.equal(queryCount, expectedQueryCount)
     })
 
   })


### PR DESCRIPTION
Originally if a transaction callback threw an error, `knex`'s & database's transaction tracking got out of sync:
- `knex` considered the transaction completed & rejected its transaction promise
- DB was not told to roll back its transaction so the used database connection got returned to the connection pool without its transaction actually getting rolled back

Effect would be random database deadlocks and/or operations failures later on due to application code running under a transaction when it does not expect to be, e.g. it can cause that transaction to start holding database locks and thus block other regular transactions, and all of it at random depending on the order in which connections get grabbed from the `knex` connection pool.

This changes the behaviour by treating such thrown exceptions the same as if a rejected promise had been returned from them and rolls back the underlying database transaction.

The pull request also does some minor code cleanup to keep the code directly touched by it in sync with the rest of the code.

Initial cleanup:
- 85b780d4fa7c376717b2933d76f7a9c68c12e989 sync test comments about oracle & mssql not reporting BEGIN/ROLLBACK
- 3d8131b5eb5bde8744a169c66ee6135018202a83 add missing tape assertion descriptions

Actual fix:
- 84f85beb73edd040afdc5511e5a6cc939c4cd46f sync knex & DB transaction state on trx callback error throw

Test suite updates:
- 3225ab45bcf5d8ba11b97c9b64b8441ac26cb14a test transaction callback throwing an error
- 96bd74e0c12c3b99831100beb4e0cf1b94c20d55 remove now redundant test case

Doc updates:
- 20843aa8d6cba84d091be0b16ba90364d8cfc67f document handling errors thrown from an exception handler function