### PR TITLE
Add .timeout to raw, and attempt to fix the timeout test

### DIFF
--- a/src/raw.js
+++ b/src/raw.js
@@ -7,6 +7,7 @@ var assign        = require('lodash/object/assign')
 var reduce        = require('lodash/collection/reduce')
 var isPlainObject = require('lodash/lang/isPlainObject')
 var _             = require('lodash');
+var isNumber      = require('lodash/lang/isNumber');
 
 function Raw(client) {
   this.client   = client
@@ -30,6 +31,13 @@ assign(Raw.prototype, {
     this.bindings = (_.isObject(bindings) || _.isUndefined(bindings)) ?  bindings : [bindings]
 
     return this
+  },
+
+  timeout: function(ms) {
+    if(isNumber(ms) && ms > 0) {
+      this._timeout = ms;
+    }
+    return this;
   },
 
   // Wraps the current sql with `before` and `after`.
@@ -66,6 +74,9 @@ assign(Raw.prototype, {
       this._cached.sql = this._cached.sql + this._wrappedAfter
     }
     this._cached.options = reduce(this._options, assign, {})
+    if(this._timeout) {
+      this._cached.timeout = this._timeout;
+    }
     return this._cached
   }
 


### PR DESCRIPTION
It seems that when `.timeout` was added to query builder, it was not added to instances of `.raw`, that's my bad. This will add the same timeout functionality also for running `.raw` as non-bindings.

```javascript
knex.raw('SELECT something')
.timeout(1000)
.then(_.noop);
//Previously did not work. Now works as expected.
```

Also attempting to fix the timeout test in this PR as its previous implementation was very unreliable.