### PR TITLE
Fix valuesForUndefined actual query being executed. Fixes #1268

### DIFF
--- a/src/dialects/mssql/index.js
+++ b/src/dialects/mssql/index.js
@@ -101,7 +101,6 @@ assign(Client_MSSQL.prototype, {
     if (!obj || typeof obj === 'string') obj = {sql: obj}
     // convert ? params into positional bindings (@p1)
     obj.sql = this.positionBindings(obj.sql);
-    obj.bindings = this.prepBindings(obj.bindings) || [];
     return new Promise(function(resolver, rejecter) {
       stream.on('error', rejecter);
       stream.on('end', resolver);
@@ -128,7 +127,6 @@ assign(Client_MSSQL.prototype, {
     if (!obj || typeof obj === 'string') obj = {sql: obj}
     // convert ? params into positional bindings (@p1)
     obj.sql = this.positionBindings(obj.sql);
-    obj.bindings = this.prepBindings(obj.bindings) || [];
     return new Promise(function(resolver, rejecter) {
       var sql = obj.sql
       if (!sql) return resolver()

--- a/src/dialects/oracle/index.js
+++ b/src/dialects/oracle/index.js
@@ -125,8 +125,6 @@ assign(Client_Oracle.prototype, {
     // convert ? params into positional bindings (:1)
     obj.sql = this.positionBindings(obj.sql);
 
-    obj.bindings = this.prepBindings(obj.bindings) || [];
-
     if (!obj.sql) throw new Error('The query is empty');
 
     return connection.executeAsync(obj.sql, obj.bindings).then(function(response) {

--- a/src/interface.js
+++ b/src/interface.js
@@ -5,7 +5,7 @@ import {isArray, map, clone, each} from 'lodash'
 module.exports = function(Target) {
 
   Target.prototype.toQuery = function(tz) {
-    var data = this.toSQL(this._method);
+    var data = this.toSQL(this._method, tz);
     if (!isArray(data)) data = [data];
     return map(data, (statement) => {
       return this._formatQuery(statement.sql, statement.bindings, tz);

--- a/src/interface.js
+++ b/src/interface.js
@@ -14,9 +14,6 @@ module.exports = function(Target) {
 
   // Format the query as sql, prepping bindings as necessary.
   Target.prototype._formatQuery = function(sql, bindings, tz) {
-    if (this.client && this.client.prepBindings) {
-      bindings = this.client.prepBindings(bindings, tz);
-    }
     return this.client.SqlString.format(sql, bindings, tz);
   };
 

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -34,8 +34,8 @@ assign(Builder.prototype, {
   },
 
   // Convert the current query "toSQL"
-  toSQL: function(method) {
-    return this.client.queryCompiler(this).toSQL(method || this._method);
+  toSQL: function(method, tz) {
+    return this.client.queryCompiler(this).toSQL(method || this._method, tz);
   },
 
   // Create a shallow clone of the current query builder.

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -44,6 +44,11 @@ assign(QueryCompiler.prototype, {
     if (method === 'select' && this.single.as) {
       defaults.as = this.single.as;
     }
+
+    if(this.client && this.client.prepBindings) {
+      defaults.bindings = this.client.prepBindings(defaults.bindings);
+    }
+
     return assign(defaults, val);
   },
 

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -45,9 +45,7 @@ assign(QueryCompiler.prototype, {
       defaults.as = this.single.as;
     }
 
-    if(this.client && this.client.prepBindings) {
-      defaults.bindings = this.client.prepBindings(defaults.bindings);
-    }
+    defaults.bindings = this.client.prepBindings(defaults.bindings || []);
 
     return assign(defaults, val);
   },

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -29,7 +29,7 @@ assign(QueryCompiler.prototype, {
   _emptyInsertValue: 'default values',
 
   // Collapse the builder into a single object
-  toSQL: function(method) {
+  toSQL: function(method, tz) {
     method = method || this.method
     var val = this[method]()
     var defaults = {
@@ -45,7 +45,7 @@ assign(QueryCompiler.prototype, {
       defaults.as = this.single.as;
     }
 
-    defaults.bindings = this.client.prepBindings(defaults.bindings || []);
+    defaults.bindings = this.client.prepBindings(defaults.bindings || [], tz);
 
     return assign(defaults, val);
   },

--- a/src/raw.js
+++ b/src/raw.js
@@ -61,7 +61,7 @@ assign(Raw.prototype, {
       this._cached = {
         method: 'raw',
         sql: this.sql,
-        bindings: this.bindings
+        bindings: _.isUndefined(this.bindings) ? void 0 : [this.bindings]
       }
     }
     if (this._wrappedBefore) {
@@ -74,6 +74,7 @@ assign(Raw.prototype, {
     if(this._timeout) {
       this._cached.timeout = this._timeout;
     }
+    this._cached.bindings = this.client.prepBindings(this._cached.bindings || []);
     return this._cached
   }
 

--- a/src/raw.js
+++ b/src/raw.js
@@ -74,7 +74,9 @@ assign(Raw.prototype, {
     if(this._timeout) {
       this._cached.timeout = this._timeout;
     }
-    this._cached.bindings = this.client.prepBindings(this._cached.bindings || []);
+    if(this.client && this.client.prepBindings) {
+      this._cached.bindings = this.client.prepBindings(this._cached.bindings || []);
+    }
     return this._cached
   }
 

--- a/src/raw.js
+++ b/src/raw.js
@@ -51,7 +51,7 @@ assign(Raw.prototype, {
   },
 
   // Returns the raw sql for the query.
-  toSQL: function() {
+  toSQL: function(method, tz) {
     if (this._cached) return this._cached
     if (Array.isArray(this.bindings)) {
       this._cached = replaceRawArrBindings(this)
@@ -61,7 +61,7 @@ assign(Raw.prototype, {
       this._cached = {
         method: 'raw',
         sql: this.sql,
-        bindings: _.isUndefined(this.bindings) ? void 0 : [this.bindings]
+        bindings: isUndefined(this.bindings) ? void 0 : [this.bindings]
       }
     }
     if (this._wrappedBefore) {
@@ -75,7 +75,7 @@ assign(Raw.prototype, {
       this._cached.timeout = this._timeout;
     }
     if(this.client && this.client.prepBindings) {
-      this._cached.bindings = this.client.prepBindings(this._cached.bindings || []);
+      this._cached.bindings = this.client.prepBindings(this._cached.bindings || [], tz);
     }
     return this._cached
   }

--- a/test/integration/builder/selects.js
+++ b/test/integration/builder/selects.js
@@ -694,8 +694,13 @@ module.exports = function(knex) {
     it('Retains array bindings, #228', function() {
       var raw  = knex.raw('select * from table t where t.id = ANY( ?::int[] )', [[1, 2, 3]]);
       var raw2 = knex.raw('select "stored_procedure"(?, ?, ?)', [1, 2, ['a', 'b', 'c']]);
-      expect(raw.toSQL().bindings).to.eql([[1, 2, 3]]);
-      expect(raw2.toSQL().bindings).to.eql([1, 2, ['a', 'b', 'c']]);
+      var expected1 = [[1, 2, 3]];
+      var expected2 = [1, 2, ['a', 'b', 'c']];
+      expect(raw.toSQL().bindings).to.eql(knex.client.prepBindings(expected1));
+      expect(raw2.toSQL().bindings).to.eql(knex.client.prepBindings(expected2));
+      //Also expect raw's bindings to not have been modified by calling .toSQL() (preserving original bindings)
+      expect(raw.bindings).to.eql(expected1);
+      expect(raw2.bindings).to.eql(expected2);
     });
 
     it('always returns the response object from raw', function() {

--- a/test/tape/raw.js
+++ b/test/tape/raw.js
@@ -92,3 +92,9 @@ test('raw bindings are optional, #853', function(t) {
   t.deepEqual(sql.bindings, [4])
 
 })
+
+test('raw with no client should still be able to run', function(t) {
+  t.plan(1)
+
+  t.equal(new Raw().set('select * from ?', [raw('table')]).toSQL().sql, 'select * from table')
+});

--- a/test/tape/raw.js
+++ b/test/tape/raw.js
@@ -67,7 +67,7 @@ test('allows for options in raw queries, #605', function(t) {
     sql: "select 'foo', 'bar';",
     options: {rowMode: "array"},
     method: 'raw',
-    bindings: undefined
+    bindings: []
   })
 })
 


### PR DESCRIPTION
This was a doosey and a half.. The main issue was that `prepBindings` was not being called in the `QueryCompiler`.

Interestingly however, some `prepBindings` that weren't being called also resulted in invalid tests, specifically for postgres. Reason for this is that the `pg` module and knex's own `prepBindings` -> `prepareValue` converts `Numbers` to `Strings` prior to executing the query. I'm mentioning this so you know why I had to change a few tests.

I also had to do a hacky-fix to one of the tests that involved `undefined` values for sqlite3 to prevent the `TypeError` being thrown. Since it does not support `valueForUndefined`, the entire test crashed after applying `prepBindings`, which was to be expected.

cc @rhys-vdw @elhigu @chrisfrancis27