### PR TITLE
Add TypeError if missing callback in Schema .createTable/.table

### DIFF
--- a/src/schema/tablebuilder.js
+++ b/src/schema/tablebuilder.js
@@ -18,6 +18,10 @@ function TableBuilder(client, method, tableName, fn) {
   this._tableName  = tableName;
   this._statements = [];
   this._single     = {};
+
+  if(!_.isFunction(this._fn)) {
+    throw new TypeError('A callback function must be supplied to calls against `.createTable` and `.table`')
+  }
 }
 
 TableBuilder.prototype.setSchema = function(schemaName) {

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -55,7 +55,7 @@ module.exports = function(knex) {
         })
         .to.throw(TypeError);
         expect(function() {
-          knex.schema.createTable('callback_must_be_supplied', function(table){}).toString();
+          knex.schema.createTable('callback_must_be_supplied', function(){}).toString();
         })
         .to.not.throw(TypeError);
       });
@@ -276,7 +276,7 @@ module.exports = function(knex) {
         })
           .to.throw(TypeError);
         expect(function() {
-          knex.schema.createTable('callback_must_be_supplied', function(table){}).toString();
+          knex.schema.createTable('callback_must_be_supplied', function(){}).toString();
         })
           .to.not.throw(TypeError);
       });

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -49,6 +49,17 @@ module.exports = function(knex) {
 
     describe('createTable', function() {
 
+      it('Callback function must be supplied', function() {
+        expect(function() {
+          knex.schema.createTable('callback_must_be_supplied').toString()
+        })
+        .to.throw(TypeError);
+        expect(function() {
+          knex.schema.createTable('callback_must_be_supplied', function(table){}).toString();
+        })
+        .to.not.throw(TypeError);
+      });
+
       it('is possible to chain .catch', function() {
         return knex.schema
           .createTable('catch_test', function(t) {
@@ -258,6 +269,17 @@ module.exports = function(knex) {
     });
 
     describe('table', function() {
+
+      it('Callback function must be supplied', function() {
+        expect(function() {
+          knex.schema.createTable('callback_must_be_supplied').toString()
+        })
+          .to.throw(TypeError);
+        expect(function() {
+          knex.schema.createTable('callback_must_be_supplied', function(table){}).toString();
+        })
+          .to.not.throw(TypeError);
+      });
 
       it('allows adding a field', function () {
         return knex.schema.table('test_table_two', function(t) {


### PR DESCRIPTION
Seen quite a few issues caused by missing a callback function, and the stack generated isn't very specific. The documentation states a callback is to be supplied, and while it's easy to forget, this will at least ease up the confusion.

See example #1256 