### PR TITLE
Fix a few hyperlinks in the changelog

### DIFF
--- a/index.html
+++ b/index.html
@@ -3021,10 +3021,10 @@ $ npm test
       <li>
         Add <a href="#Builder-countDistinct"><tt>countDistinct</tt></a>,
         <a href="#Builder-avgDistinct"><tt>avgDistinct</tt></a> and
-        <a href="Builder-sumDistinct"><tt>sumDistinct</tt></a>. #1046
+        <a href="#Builder-sumDistinct"><tt>sumDistinct</tt></a>. #1046
       </li>
       <li>
-        Add <a href="Schema-jsonb"><tt>schema.jsonb</tt></a>. Deprecated <tt>schema.json(column, true)</tt>. #991
+        Add <a href="#Schema-jsonb"><tt>schema.jsonb</tt></a>. Deprecated <tt>schema.json(column, true)</tt>. #991
       </li>
       <li>Support binding identifiers with `??`. #1103</li>
       <li>Restore `query` event when triggered by transactions. #855</li>


### PR DESCRIPTION
The hash (#) was missing for two hyperlinks. This fixes that.