### PR TITLE
update liftoff dependency so that coffeescript knexfiles and configurations are supported again.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "debug": "^2.1.3",
     "inherits": "~2.0.1",
     "interpret": "^0.6.5",
-    "liftoff": "~2.0.0",
+    "liftoff": "~2.2.0",
     "lodash": "^4.6.0",
     "minimist": "~1.1.0",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION


I suggest adding coffeescript to test process if continued support is desired.