### PR TITLE
Default pool.ping fn, and silently ignore 'Rollback' errors on a dead connection

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,7 +506,14 @@ pg('table').insert({a: 'b'}).returning('*').toString();
     <h3 id="Installation-pooling">Pooling</h3>
 
     <p>
-      The client created by the configuration initializes a connection pool, using the <a href="https://github.com/myndzi/pool2">Pool2</a> library. This connection pool has a default setting of a <tt>min: 2, max: 10</tt> for the MySQL and PG libraries, and a single connection for sqlite3 (due to issues with utilizing multiple connections on a single file). To change the config settings for the pool, pass a <tt>pool</tt> option as one of the keys in the initialize block. Checkout the <a href="https://github.com/myndzi/pool2">Pool2</a> library for more information.
+      The client created by the configuration initializes a connection pool, using the <a href="https://github.com/myndzi/pool2">Pool2</a> library. This connection pool has a default setting of a <tt>min: 2, max: 10</tt> for the MySQL and PG libraries, and a single connection for sqlite3 (due to issues with utilizing multiple connections on a single file). To change the config settings for the pool, pass a <tt>pool</tt> option as one of the keys in the initialize block.
+    </p>
+    <p>
+      The default connection pool also applies a <tt>ping</tt> function to verify that a connection is still alive by running a <tt>SELECT 1</tt> query.
+      If you don't want this check you may supply your own ping function to overwrite knex's default behavior.
+    </p>
+    <p>
+      Checkout the <a href="https://github.com/myndzi/pool2">Pool2</a> library for more information.
     </p>
 
 <pre>

--- a/src/client.js
+++ b/src/client.js
@@ -200,6 +200,9 @@ assign(Client.prototype, {
         } else if (connection !== void 0) {
           client.destroyRawConnection(connection, callback)
         }
+      },
+      ping: function(resource, callback) {
+        return client.ping(resource, callback);
       }
     }
   },

--- a/src/dialects/maria/index.js
+++ b/src/dialects/maria/index.js
@@ -115,6 +115,10 @@ assign(Client_MariaSQL.prototype, {
       default:
         return response;
     }
+  },
+
+  ping: function(resource, callback) {
+    resource.query('SELECT 1', callback);
   }
 
 })

--- a/src/dialects/mssql/index.js
+++ b/src/dialects/mssql/index.js
@@ -178,6 +178,10 @@ assign(Client_MSSQL.prototype, {
       default:
         return response
     }
+  },
+
+  ping: function(resource, callback) {
+    resource.query('SELECT 1', callback);
   }
 
 })

--- a/src/dialects/mysql/index.js
+++ b/src/dialects/mysql/index.js
@@ -127,6 +127,10 @@ assign(Client_MySQL.prototype, {
       connection.__knex__disposed = true;
       client.pool.destroy(connection);
     }
+  },
+
+  ping: function(resource, callback) {
+    resource.query('SELECT 1', callback);
   }
 
 })

--- a/src/dialects/mysql2/index.js
+++ b/src/dialects/mysql2/index.js
@@ -95,6 +95,10 @@ assign(Client_MySQL2.prototype, {
       default:
         return response
     }
+  },
+
+  ping: function(resource, callback) {
+    resource.query('SELECT 1', callback);
   }
 
 })

--- a/src/dialects/oracle/index.js
+++ b/src/dialects/oracle/index.js
@@ -167,6 +167,10 @@ assign(Client_Oracle.prototype, {
       default:
         return response;
     }
+  },
+
+  ping: function(resource, callback) {
+    resource.execute('SELECT 1', [], callback);
   }
 
 })

--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -190,6 +190,10 @@ assign(Client_PG.prototype, {
     }
   },
 
+  ping: function(resource, callback) {
+    resource.query('SELECT 1', [], callback);
+  }
+
 
 })
 

--- a/src/dialects/sqlite3/index.js
+++ b/src/dialects/sqlite3/index.js
@@ -148,6 +148,10 @@ assign(Client_SQLite3.prototype, {
       min: 1,
       max: 1
     })
+  },
+
+  ping: function(resource, callback) {
+    resource.each('SELECT 1', callback);
   }
 
 })

--- a/src/dialects/websql/index.js
+++ b/src/dialects/websql/index.js
@@ -99,6 +99,10 @@ assign(Client_WebSQL.prototype, {
       default:
         return resp;
     }
+  },
+
+  ping: function(resource, callback) {
+    callback();
   }
 
 })

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -96,10 +96,18 @@ assign(Transaction.prototype, {
 
   rollback: function(conn, error) {
     return this.query(conn, 'ROLLBACK;', 2, error)
+      .timeout(1000) //TODO: -- What's a reasonable timeout?
+      .catch(Promise.TimeoutError, () => {
+        this._resolver();
+      });
   },
 
   rollbackTo: function(conn, error) {
     return this.query(conn, 'ROLLBACK TO SAVEPOINT ' + this.txid, 2, error)
+      .timeout(1000) //TODO: -- What's a reasonable timeout?
+      .catch(Promise.TimeoutError, () => {
+        this._resolver();
+      });
   },
 
   query: function(conn, sql, status, value) {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -96,7 +96,7 @@ assign(Transaction.prototype, {
 
   rollback: function(conn, error) {
     return this.query(conn, 'ROLLBACK;', 2, error)
-      .timeout(1000) //TODO: -- What's a reasonable timeout?
+      .timeout(5000)
       .catch(Promise.TimeoutError, () => {
         this._resolver();
       });
@@ -104,7 +104,7 @@ assign(Transaction.prototype, {
 
   rollbackTo: function(conn, error) {
     return this.query(conn, 'ROLLBACK TO SAVEPOINT ' + this.txid, 2, error)
-      .timeout(1000) //TODO: -- What's a reasonable timeout?
+      .timeout(5000)
       .catch(Promise.TimeoutError, () => {
         this._resolver();
       });


### PR DESCRIPTION
This should cover the proposal in #1198 .

This will add a default `ping` function to the default `pool` config issuing a `SELECT 1` query to ensure the connection is still alive. So
1. Run query
2. Kill connection
3. Run query
=== Should be resolved. Previously this was rejected with different errors based on the dialect in use.

@woopstar has however confirmed that this does not solve the mysql error in the issue, so this doesn't cover all cases yet. Will want to cover that case as well before merging this.


A timeout has been added to `rollback` to prevent knex from hanging when rollback is issued on a dead connection. There's no harm in silently ignoring this as the connection is dead and the transaction state cannot be recovered.


**TODO**
- [x] Update docs
- [x] Decide a reasonable timeout for `.rollback`
- [x] ~~Reproduce mysql error, try find a solution~~ The PR solves the issue aside for when it occurs during transactions, at which point recovery is impossible. *(Bound to a single connection)*)
- [ ] Is it possible to write tests for this?


So far I've tested that this works when closing connections in postgres.

CC @rhys-vdw @elhigu @tgriesser if you have any input or thoughts please do tell. I hope these changes makes sense.