### PR TITLE
update index.js to work with aliyun rds

### DIFF
--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -93,7 +93,7 @@ assign(Client_PG.prototype, {
     return new Promise(function(resolver, rejecter) {
       connection.query('select version();', function(err, resp) {
         if (err) return rejecter(err);
-        resolver(/^PostgreSQL (.*?) /.exec(resp.rows[0].version)[1]);
+        resolver(/^PostgreSQL (.*?)( |$)/.exec(resp.rows[0].version)[1]);
       });
     });
   },


### PR DESCRIPTION
aliyun.com RDS service return a simplified version "PostgreSQL x.x.x", and function checkVersion failed to handle it