### PR TITLE
Ensure events are triggered on the builder as well as the client.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -128,7 +128,7 @@ assign(Client.prototype, {
     debugQuery(obj.sql)
     return this._query.call(this, connection, obj).catch((err) => {
       err.message = SqlString.format(obj.sql, obj.bindings) + ' - ' + err.message
-      this.emit('query-error', err, obj)
+      this.emit('query-error', err, assign({__knexUid: connection.__knexUid}, obj))
       throw err
     })
   },

--- a/src/runner.js
+++ b/src/runner.js
@@ -122,6 +122,7 @@ assign(Runner.prototype, {
     return queryPromise
       .then((resp) => {
         var processedResponse = this.client.processResponse(resp, runner);
+        this.builder.emit('query-response', processedResponse, assign({__knexUid: this.connection.__knexUid}, obj), this.builder)
         this.client.emit('query-response', processedResponse, assign({__knexUid: this.connection.__knexUid}, obj), this.builder)
         return processedResponse;
       }).catch(Promise.TimeoutError, error => {
@@ -132,6 +133,10 @@ assign(Runner.prototype, {
           timeout:  obj.timeout
         });
       })
+      .catch((error) => {
+        this.builder.emit('query-error', error, assign({__knexUid: this.connection.__knexUid}, obj))
+        throw error;
+      });
   }),
 
   // In the case of the "schema builder" we call `queryArray`, which runs each


### PR DESCRIPTION
Discovered in #1305 the events were not being triggered on the query builder, only the client.