### PR TITLE
Mysql2 should also listen to 'error' events.

### DIFF
--- a/src/dialects/mysql2/index.js
+++ b/src/dialects/mysql2/index.js
@@ -62,10 +62,12 @@ assign(Client_MySQL2.prototype, {
   // Get a raw connection, called by the `pool` whenever a new
   // connection needs to be added to the pool.
   acquireRawConnection: function() {
+    var client = this;
     var connection = this.driver.createConnection(pick(this.connectionSettings, configOptions))
     return new Promise(function(resolver, rejecter) {
       connection.connect(function(err) {
         if (err) return rejecter(err)
+        connection.on('error', client._connectionErrorHandler.bind(null, client, connection))
         resolver(connection)
       })
     })


### PR DESCRIPTION
Briefly noticed in #1198 there's a diff between how `mysql` and `mysql2` handle events, yet they're both almost identical. I can't find an `end` event in `mysql2`, but the `error` is there *(with the appropiate "fatal" flag)* so unless I'm missing something it should be listened to here as well.

https://github.com/sidorares/node-mysql2/blob/master/lib/connection.js#L96

@elhigu @rhys-vdw Does this make sense to you?