### PR TITLE
.renameColumn should not drop defaultValue or nullable state.

### DIFF
--- a/src/dialects/mysql/schema/tablecompiler.js
+++ b/src/dialects/mysql/schema/tablecompiler.js
@@ -77,8 +77,17 @@ assign(TableCompiler_MySQL.prototype, {
               if (!refs.length) { return; }
               return compiler.dropFKRefs(runner, refs);
             }).then(function () {
+              let sql = `alter table ${table} change ${wrapped} ${column.Type}`;
+
+              if(String(column.Null).toUpperCase() !== 'YES') {
+                sql += ` NOT NULL`
+              }
+              if(column.Default !== void 0 && column.Default !== null) {
+                sql += ` DEFAULT '${column.Default}'`
+              }
+
               return runner.query({
-                sql: 'alter table ' + table + ' change ' + wrapped + ' ' + column.Type
+                sql: sql
               });
             }).then(function () {
               if (!refs.length) { return; }

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -440,25 +440,25 @@ module.exports = function(knex) {
       });
 
       it('#933 - .renameColumn should not drop null or default value', function() {
-        return knex.transaction((tr) => {
-          let getColInfo = () => tr('renameColTest').columnInfo();
+        return knex.transaction(function (tr) {
+          var getColInfo = function() { return tr('renameColTest').columnInfo()};
           return tr.schema.dropTableIfExists('renameColTest')
-            .createTable('renameColTest', (table) => {
+            .createTable('renameColTest', function (table) {
               table.integer('colnameint').defaultTo(1);
               table.string('colnamestring').defaultTo('knex').notNullable();
             })
             .then(getColInfo)
-            .then((colInfo) => {
+            .then(function (colInfo) {
               expect(String(colInfo.colnameint.defaultValue)).to.contain('1');
               expect(colInfo.colnamestring.defaultValue).to.contain('knex'); //Using contain because of different response per dialect. IE mysql 'knex', postgres 'knex::character varying'
               expect(colInfo.colnamestring.nullable).to.equal(false);
-              return tr.schema.table('renameColTest', (table) => {
+              return tr.schema.table('renameColTest', function (table) {
                 table.renameColumn('colnameint', 'colnameintchanged');
                 table.renameColumn('colnamestring', 'colnamestringchanged');
               })
             })
             .then(getColInfo)
-            .then((columnInfo) => {
+            .then(function (columnInfo) {
               expect(String(columnInfo.colnameintchanged.defaultValue)).to.contain('1');
               expect(columnInfo.colnamestringchanged.defaultValue).to.contain('knex');
               expect(columnInfo.colnamestringchanged.nullable).to.equal(false);


### PR DESCRIPTION
Currently this happens for mysql. Fixes #933