### PR TITLE
Implement schema .setNullable/.dropNullable. Fixes #1218

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,6 +188,7 @@
       <li>– <a href="#Schema-dropForeign">dropForeign</a></li>
       <li>– <a href="#Schema-dropUnique">dropUnique</a></li>
       <li>– <a href="#Schema-dropPrimary">dropPrimary</a></li>
+      <li>– <a href="#Schema-setNullable">setNullable</a></li>
       <li><a href="#Chainable"><b>Chainable:</b></li>
       <li>– <a href="#Chainable-index">index</a></li>
       <li>– <a href="#Chainable-primary">primary</a></li>
@@ -2098,6 +2099,13 @@ knex.table('users')
       <b class="header">dropPrimary</b><code>table.dropPrimary()</code>
       <br />
       Drops the primary key constraint on a table.
+    </p>
+
+
+    <p id="Schema-setNullable">
+      <b class="header">setNullable</b><code>table.setNullable(column, [true|false])</code>
+      <br />
+      Alters a columns nullable constraint.
     </p>
 
     <h3 id="Chainable">Chainable Methods:</h3>

--- a/index.html
+++ b/index.html
@@ -189,6 +189,7 @@
       <li>– <a href="#Schema-dropUnique">dropUnique</a></li>
       <li>– <a href="#Schema-dropPrimary">dropPrimary</a></li>
       <li>– <a href="#Schema-setNullable">setNullable</a></li>
+      <li>– <a href="#Schema-dropNullable">dropNullable</a></li>
       <li><a href="#Chainable"><b>Chainable:</b></li>
       <li>– <a href="#Chainable-index">index</a></li>
       <li>– <a href="#Chainable-primary">primary</a></li>
@@ -2103,9 +2104,16 @@ knex.table('users')
 
 
     <p id="Schema-setNullable">
-      <b class="header">setNullable</b><code>table.setNullable(column, [true|false])</code>
+      <b class="header">setNullable</b><code>table.setNullable(column)</code>
       <br />
-      Alters a columns nullable constraint.
+      Alters a columns nullable constraint to allow null.
+    </p>
+
+
+    <p id="Schema-dropNullable">
+      <b class="header">dropNullable</b><code>table.dropNullable(column)</code>
+      <br />
+      Alters a columns nullable constraint to disallow null.
     </p>
 
     <h3 id="Chainable">Chainable Methods:</h3>

--- a/src/dialects/mssql/schema/tablecompiler.js
+++ b/src/dialects/mssql/schema/tablecompiler.js
@@ -6,7 +6,7 @@ var TableCompiler = require('../../../schema/tablecompiler');
 var helpers = require('../../../helpers');
 var Promise = require('../../../promise');
 
-import {assign, isEmpty} from 'lodash'
+import {assign} from 'lodash'
 
 // Table Compiler
 // ------

--- a/src/dialects/mssql/schema/tablecompiler.js
+++ b/src/dialects/mssql/schema/tablecompiler.js
@@ -49,7 +49,7 @@ assign(TableCompiler_MSSQL.prototype, {
     this.pushQuery('exec sp_rename ' + this.formatter.parameter(this.tableName() + '.' + from) + ', ' + this.formatter.parameter(to) + ', \'COLUMN\'');
   },
 
-  setNullable: function (column, nullable) {
+  _setNullableState: function (column, nullable) {
     let tableName = this.tableName();
     let columnName = this.formatter.columnize(column);
     return this.pushQuery({

--- a/src/dialects/mssql/schema/tablecompiler.js
+++ b/src/dialects/mssql/schema/tablecompiler.js
@@ -37,6 +37,8 @@ assign(TableCompiler_MSSQL.prototype, {
 
   dropColumnPrefix: 'DROP COLUMN ',
 
+  alterColumnPrefix: 'alter column',
+
   // Compiles the comment on the table.
   comment: function () {
   },
@@ -47,27 +49,6 @@ assign(TableCompiler_MSSQL.prototype, {
   // Renames a column on the table.
   renameColumn: function (from, to) {
     this.pushQuery('exec sp_rename ' + this.formatter.parameter(this.tableName() + '.' + from) + ', ' + this.formatter.parameter(to) + ', \'COLUMN\'');
-  },
-
-  _setNullableState: function (column, nullable) {
-    let tableName = this.tableName();
-    let columnName = this.formatter.columnize(column);
-    return this.pushQuery({
-      sql: 'SELECT 1',
-      output: () => {
-        return this.client.queryBuilder().from(this.tableNameRaw).columnInfo(column)
-          .then((columnInfo) => {
-            if(isEmpty(columnInfo)) {
-              throw new Error(`.setNullable: Column ${columnName} does not exist in table ${tableName}.`)
-            }
-            let nullableType = nullable ? 'null' : 'not null';
-            let columnType = columnInfo.type + (columnInfo.maxLength ? `(${columnInfo.maxLength})` : '');
-            let defaultValue = (columnInfo.defaultValue !== null && columnInfo.defaultValue !== void 0) ? `default '${columnInfo.defaultValue}'` : '';
-            let sql = `alter table ${tableName} alter column ${columnName} ${columnType} ${nullableType} ${defaultValue}`;
-            return this.client.raw(sql);
-          });
-      }
-    });
   },
 
   dropFKRefs: function (runner, refs) {

--- a/src/dialects/mssql/schema/tablecompiler.js
+++ b/src/dialects/mssql/schema/tablecompiler.js
@@ -6,7 +6,7 @@ var TableCompiler = require('../../../schema/tablecompiler');
 var helpers = require('../../../helpers');
 var Promise = require('../../../promise');
 
-import {assign} from 'lodash'
+import {assign, isEmpty} from 'lodash'
 
 // Table Compiler
 // ------
@@ -47,6 +47,27 @@ assign(TableCompiler_MSSQL.prototype, {
   // Renames a column on the table.
   renameColumn: function (from, to) {
     this.pushQuery('exec sp_rename ' + this.formatter.parameter(this.tableName() + '.' + from) + ', ' + this.formatter.parameter(to) + ', \'COLUMN\'');
+  },
+
+  setNullable: function (column, nullable) {
+    let tableName = this.tableName();
+    let columnName = this.formatter.columnize(column);
+    return this.pushQuery({
+      sql: 'SELECT 1',
+      output: () => {
+        return this.client.queryBuilder().from(this.tableNameRaw).columnInfo(column)
+          .then((columnInfo) => {
+            if(isEmpty(columnInfo)) {
+              throw new Error(`.setNullable: Column ${columnName} does not exist in table ${tableName}.`)
+            }
+            let nullableType = nullable ? 'null' : 'not null';
+            let columnType = columnInfo.type + (columnInfo.maxLength ? `(${columnInfo.maxLength})` : '');
+            let defaultValue = (columnInfo.defaultValue !== null && columnInfo.defaultValue !== void 0) ? `default '${columnInfo.defaultValue}'` : '';
+            let sql = `alter table ${tableName} alter column ${columnName} ${columnType} ${nullableType} ${defaultValue}`;
+            return this.client.raw(sql);
+          });
+      }
+    });
   },
 
   dropFKRefs: function (runner, refs) {

--- a/src/dialects/postgres/schema/tablecompiler.js
+++ b/src/dialects/postgres/schema/tablecompiler.js
@@ -18,8 +18,7 @@ TableCompiler_PG.prototype.renameColumn = function(from, to) {
   });
 };
 
-
-TableCompiler_PG.prototype.setNullable = function (column, nullable) {
+TableCompiler_PG.prototype._setNullableState = function (column, nullable) {
   let constraintAction = nullable ? 'drop not null' : 'set not null';
   let sql = `alter table ${this.tableName()} alter column ${this.formatter.wrap(column)} ${constraintAction}`;
   return this.pushQuery({

--- a/src/dialects/postgres/schema/tablecompiler.js
+++ b/src/dialects/postgres/schema/tablecompiler.js
@@ -18,6 +18,15 @@ TableCompiler_PG.prototype.renameColumn = function(from, to) {
   });
 };
 
+
+TableCompiler_PG.prototype.setNullable = function (column, nullable) {
+  let constraintAction = nullable ? 'drop not null' : 'set not null';
+  let sql = `alter table ${this.tableName()} alter column ${this.formatter.wrap(column)} ${constraintAction}`;
+  return this.pushQuery({
+    sql: sql
+  });
+};
+
 TableCompiler_PG.prototype.compileAdd = function(builder) {
   var table = this.formatter.wrap(builder);
   var columns = this.prefixArray('add column', this.getColumns(builder));

--- a/src/dialects/postgres/schema/tablecompiler.js
+++ b/src/dialects/postgres/schema/tablecompiler.js
@@ -11,6 +11,8 @@ function TableCompiler_PG() {
 }
 inherits(TableCompiler_PG, TableCompiler);
 
+TableCompiler_PG.prototype.alterColumnPrefix = 'alter column';
+
 // Compile a rename column command.
 TableCompiler_PG.prototype.renameColumn = function(from, to) {
   return this.pushQuery({

--- a/src/dialects/sqlite3/schema/tablecompiler.js
+++ b/src/dialects/sqlite3/schema/tablecompiler.js
@@ -108,7 +108,7 @@ TableCompiler_SQLite3.prototype.renameColumn = function(from, to) {
 };
 
 
-TableCompiler_SQLite3.prototype.setNullable = function() {
+TableCompiler_SQLite3.prototype._setNullableState = function() {
   throw new Error('.setNullable is not supported for SQLite.');
 };
 

--- a/src/dialects/sqlite3/schema/tablecompiler.js
+++ b/src/dialects/sqlite3/schema/tablecompiler.js
@@ -107,6 +107,11 @@ TableCompiler_SQLite3.prototype.renameColumn = function(from, to) {
   });
 };
 
+
+TableCompiler_SQLite3.prototype.setNullable = function() {
+  throw new Error('.setNullable is not supported for SQLite.');
+};
+
 TableCompiler_SQLite3.prototype.dropColumn = function(column) {
   var compiler = this;
   this.pushQuery({

--- a/src/dialects/sqlite3/schema/tablecompiler.js
+++ b/src/dialects/sqlite3/schema/tablecompiler.js
@@ -108,8 +108,9 @@ TableCompiler_SQLite3.prototype.renameColumn = function(from, to) {
 };
 
 
-TableCompiler_SQLite3.prototype._setNullableState = function() {
-  throw new Error('.setNullable is not supported for SQLite.');
+TableCompiler_SQLite3.prototype._setNullableState = function(column, nullable) {
+  let fnCalled = nullable ? '.setNullable' : '.dropNullable';
+  throw new Error(`${fnCalled} is not supported for SQLite.`);
 };
 
 TableCompiler_SQLite3.prototype.dropColumn = function(column) {

--- a/src/schema/tablebuilder.js
+++ b/src/schema/tablebuilder.js
@@ -250,11 +250,21 @@ var AlterMethods = {
     return this.dropColumns(['created_at', 'updated_at']);
   },
 
-  setNullable: function(column, nullable) {
+  setNullable: function(column) {
     this._statements.push({
       grouping: 'alterTable',
       method: 'setNullable',
-      args: [column, nullable === true]
+      args: [column]
+    });
+
+    return this;
+  },
+
+  dropNullable: function(column) {
+    this._statements.push({
+      grouping: 'alterTable',
+      method: 'dropNullable',
+      args: [column]
     });
 
     return this;

--- a/src/schema/tablebuilder.js
+++ b/src/schema/tablebuilder.js
@@ -248,6 +248,16 @@ var AlterMethods = {
 
   dropTimestamps: function() {
     return this.dropColumns(['created_at', 'updated_at']);
+  },
+
+  setNullable: function(column, nullable) {
+    this._statements.push({
+      grouping: 'alterTable',
+      method: 'setNullable',
+      args: [column, nullable === true]
+    });
+
+    return this;
   }
 
   // TODO: changeType

--- a/src/schema/tablecompiler.js
+++ b/src/schema/tablecompiler.js
@@ -17,6 +17,8 @@ function TableCompiler(client, tableBuilder) {
   this._formatting = client.config && client.config.formatting
 }
 
+TableCompiler.prototype.alterColumnPrefix = 'modify column';
+
 TableCompiler.prototype.pushQuery = helpers.pushQuery
 
 TableCompiler.prototype.pushAdditional = helpers.pushAdditional
@@ -211,6 +213,7 @@ TableCompiler.prototype._indexCommand = function (type, tableName, columns) {
 TableCompiler.prototype._setNullableState = function(column, nullable) {
   let tableName = this.tableName();
   let columnName = this.formatter.columnize(column);
+  let alterColumnPrefix = this.alterColumnPrefix;
   return this.pushQuery({
     sql: 'SELECT 1',
     output: () => {
@@ -222,7 +225,7 @@ TableCompiler.prototype._setNullableState = function(column, nullable) {
           let nullableType = nullable ? 'null' : 'not null';
           let columnType = columnInfo.type + (columnInfo.maxLength ? `(${columnInfo.maxLength})` : '');
           let defaultValue = (columnInfo.defaultValue !== null && columnInfo.defaultValue !== void 0) ? `default '${columnInfo.defaultValue}'` : '';
-          let sql = `alter table ${tableName} modify column ${columnName} ${columnType} ${nullableType} ${defaultValue}`;
+          let sql = `alter table ${tableName} ${alterColumnPrefix} ${columnName} ${columnType} ${nullableType} ${defaultValue}`;
           return this.client.raw(sql);
         });
     }

--- a/src/schema/tablecompiler.js
+++ b/src/schema/tablecompiler.js
@@ -208,7 +208,7 @@ TableCompiler.prototype._indexCommand = function (type, tableName, columns) {
 
 //Default implementation of setNullable. Overwrite on dialect-specific tablecompiler when needed
 //(See postgres/mssql for reference)
-TableCompiler.prototype.setNullable = function(column, nullable) {
+TableCompiler.prototype._setNullableState = function(column, nullable) {
   let tableName = this.tableName();
   let columnName = this.formatter.columnize(column);
   return this.pushQuery({
@@ -227,6 +227,15 @@ TableCompiler.prototype.setNullable = function(column, nullable) {
         });
     }
   });
+};
+
+
+TableCompiler.prototype.setNullable = function(column) {
+  return this._setNullableState(column, true);
+};
+
+TableCompiler.prototype.dropNullable = function(column) {
+  return this._setNullableState(column, false);
 };
 
 module.exports = TableCompiler;

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -469,11 +469,11 @@ module.exports = function(knex) {
 
     if(knex.client.dialect !== 'sqlite3') {
       //Not supported by sqlite3
-      describe('setNullable', function() {
+      describe('Alter Nullable state', function() {
 
 
-        it('setNullable true & false', function() {
-          var tableName = 'setNullableTest';
+        it('.setNullable & .dropNullable', function() {
+          var tableName = 'nullableTest';
           var columnName = 'colname';
           var getColInfo = function() { return knex(tableName).columnInfo(columnName); };
 

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -467,5 +467,44 @@ module.exports = function(knex) {
       });
     });
 
+    if(knex.client.dialect !== 'sqlite3') {
+      //Not supported by sqlite3
+      describe('setNullable', function() {
+
+
+        it('setNullable true & false', function() {
+          var tableName = 'setNullableTest';
+          var columnName = 'colname';
+          var getColInfo = function() { return knex(tableName).columnInfo(columnName); };
+
+          return knex.schema.dropTableIfExists(tableName)
+            .createTable(tableName, function(table) {
+              table.string(columnName).notNullable();
+            })
+            .then(getColInfo)
+            .then(function(columnInfo) {
+              expect(columnInfo.nullable).to.equal(false);
+              return knex.schema.table(tableName, function(table) {
+                table.setNullable(columnName, true);
+              });
+            })
+            .then(function() {
+              return getColInfo();
+            })
+            .then(function(columnInfo) {
+              expect(columnInfo.nullable).to.equal(true);
+              return knex.schema.table(tableName, function(table) {
+                table.setNullable(columnName, false);
+              });
+            })
+            .then(getColInfo)
+            .then(function(columnInfo) {
+              expect(columnInfo.nullable).to.equal(false);
+            });
+        });
+
+      });
+    }
+
   });
 };

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -485,7 +485,7 @@ module.exports = function(knex) {
             .then(function(columnInfo) {
               expect(columnInfo.nullable).to.equal(false);
               return knex.schema.table(tableName, function(table) {
-                table.setNullable(columnName, true);
+                table.setNullable(columnName);
               });
             })
             .then(function() {
@@ -494,7 +494,7 @@ module.exports = function(knex) {
             .then(function(columnInfo) {
               expect(columnInfo.nullable).to.equal(true);
               return knex.schema.table(tableName, function(table) {
-                table.setNullable(columnName, false);
+                table.dropNullable(columnName);
               });
             })
             .then(getColInfo)

--- a/test/unit/schema/sqlite3.js
+++ b/test/unit/schema/sqlite3.js
@@ -444,5 +444,20 @@ describe("SQLite SchemaBuilder", function() {
         expect(doReplace(sql2, '"id"', '"id_foo"')).to.equal(sql2b);
       }).toSQL();
     });
+
   });
+
+
+  it('.setNullable and .dropNullable should throw error', function() {
+    //.setNullable and .dropNullable are not supported in SQLite
+    var call = function(fnName) {
+      return function() {
+        client.schemaBuilder().table('foo', function(table) {
+          table[fnName]('column');
+        }).toSQL();
+      };
+    };
+    expect(call('setNullable')).to.throw(Error);
+    expect(call('dropNullable')).to.throw(Error);
+  })
 });


### PR DESCRIPTION
~~This adds `.setNullable(column, [true|false])` to alter a columns nullable constraint.~~
This adds `.setNullable(column)` and `.dropNullable(column)` to alter a columns nullable constraint.

I'm not too happy with the implementation having to call `SELECT 1`, but this was the only way I found to support async actions, which are required in this case. See for example `renameColumn` for a similar case.

This is built around the information gathered in #1218 , so feel free to correct if anything is wrong.
