### PR TITLE
Enable Oracle multiple insert to handle CURRENT_TIMESTAMP correctly

### DIFF
--- a/src/dialects/oracle/index.js
+++ b/src/dialects/oracle/index.js
@@ -100,9 +100,13 @@ assign(Client_Oracle.prototype, {
   },
 
   // Position the bindings for the query.
-  positionBindings: function(sql) {
-    var questionCount = 0
-    return sql.replace(/\?/g, function() {
+  positionBindings: function(sql, opt) {
+    var replaceExpression = /\?/g;
+    if (opt && opt.isMultipleInsert) {
+      replaceExpression = /\?|CURRENT_TIMESTAMP/g;
+    }
+    var questionCount = 0;
+    return sql.replace(replaceExpression, function () {
       questionCount += 1
       return ':' + questionCount
     })

--- a/src/dialects/oracle/query/compiler.js
+++ b/src/dialects/oracle/query/compiler.js
@@ -79,7 +79,7 @@ assign(QueryCompiler_Oracle.prototype, {
 
           // pre bind position because subSql is an execute immediate parameter
           // later position binding will only convert the ? params
-          subSql = this.formatter.client.positionBindings(subSql);
+          subSql = this.formatter.client.positionBindings(subSql, {isMultipleInsert: true});
           return 'execute immediate \'' + subSql.replace(/'/g, "''") +
             ((parameterizedValues || returning) ? '\' using ' : '') +
             parameterizedValues +


### PR DESCRIPTION
This fixes the case on Oracle where if you perform a multiple insert query with an object that contains `knex.fn.now()`, the resulting sql query will have misaligned bindings in the sub-query's values. I didn't want to change `parameterize`, so I just added a regex switch in Oracle's `positionBindings`.

Before:

```
begin
  execute immediate 'insert into "users" ("deleted_at", "email") values (CURRENT_TIMESTAMP, :1)'
  using CURRENT_TIMESTAMP, ?;

  execute immediate 'insert into "users" ("deleted_at", "email") values (CURRENT_TIMESTAMP, :1)'
  using CURRENT_TIMESTAMP, ?;
end;
```

After:

```
begin
  execute immediate 'insert into "users" ("deleted_at", "email") values (:1, :2)'
  using CURRENT_TIMESTAMP, ?;

  execute immediate 'insert into "users" ("deleted_at", "email") values (:1, :2)'
  using CURRENT_TIMESTAMP, ?;
end;
```

@rhys-vdw Any chance this can go into 0.11.0? :wink: 
