### PR TITLE
Mssql fixes

### DIFF
--- a/src/dialects/mssql/schema/tablecompiler.js
+++ b/src/dialects/mssql/schema/tablecompiler.js
@@ -20,7 +20,7 @@ assign(TableCompiler_MSSQL.prototype, {
 
   createAlterTableMethods: ['foreign', 'primary', 'unique'],
   createQuery: function (columns, ifNot) {
-    var createStatement = ifNot ? 'if object_id(\'' + this.tableName() + '\', \'U\') is not null CREATE TABLE ' : 'CREATE TABLE ';
+    var createStatement = ifNot ? 'if object_id(\'' + this.tableName() + '\', \'U\') is null CREATE TABLE ' : 'CREATE TABLE ';
     var sql = createStatement + this.tableName() + (this._formatting ? ' (\n    ' : ' (') + columns.sql.join(this._formatting ? ',\n    ' : ', ') + ')';
 
     if (this.single.comment) {

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -101,9 +101,9 @@ module.exports = function(knex) {
               'create index "NkZo/dGRI9O73/NE2fHo+35d4jk" on "test_table_one" ("first_name")',
               'alter table "test_table_one" add constraint "test_table_one_email_unique" unique ("email")',
               'create index "test_table_one_logins_index" on "test_table_one" ("logins")']);
-            tester('mssql', ['CREATE TABLE [test_table_one] ([id] bigint identity(1,1) not null primary key, [first_name] nvarchar(255), [last_name] nvarchar(255), [email] nvarchar(255) null, [logins] int default \'1\', [about] nvarchar(max), [created_at] datetime, [updated_at] datetime, CONSTRAINT test_table_one_email_unique UNIQUE ([email]))',
-              'CREATE INDEX test_table_one_first_name_index ON [test_table_one] ([first_name])',
-              'CREATE INDEX test_table_one_logins_index ON [test_table_one] ([logins])']);
+            tester('mssql', ['CREATE TABLE [test_table_one] ([id] bigint identity(1,1) not null primary key, [first_name] nvarchar(255), [last_name] nvarchar(255), [email] nvarchar(255) null, [logins] int default \'1\', [about] nvarchar(max), [created_at] datetime, [updated_at] datetime, CONSTRAINT [test_table_one_email_unique] UNIQUE ([email]))',
+              'CREATE INDEX [test_table_one_first_name_index] ON [test_table_one] ([first_name])',
+              'CREATE INDEX [test_table_one_logins_index] ON [test_table_one] ([logins])']);
           });
       });
 
@@ -138,7 +138,7 @@ module.exports = function(knex) {
             tester('pg', ['create table "test_table_three" ("main" integer not null, "paragraph" text default \'Lorem ipsum Qui quis qui in.\')','alter table "test_table_three" add primary key ("main")']);
             tester('sqlite3', ['create table "test_table_three" ("main" integer not null, "paragraph" text default \'Lorem ipsum Qui quis qui in.\', primary key ("main"))']);
             tester('oracle', ['create table "test_table_three" ("main" integer not null, "paragraph" clob default \'Lorem ipsum Qui quis qui in.\')','alter table "test_table_three" add primary key ("main")']);
-            tester('mssql', ['CREATE TABLE [test_table_three] ([main] int not null, [paragraph] nvarchar(max), CONSTRAINT test_table_three_main_primary PRIMARY KEY ([main]))']);
+            tester('mssql', ['CREATE TABLE [test_table_three] ([main] int not null, [paragraph] nvarchar(max), CONSTRAINT [test_table_three_main_primary] PRIMARY KEY ([main]))']);
           });
       });
 
@@ -173,7 +173,7 @@ module.exports = function(knex) {
             "create or replace trigger \"test_foreign_table_two_id_trg\" before insert on \"test_foreign_table_two\" for each row when (new.\"id\" is null)  begin select \"test_foreign_table_two_seq\".nextval into :new.\"id\" from dual; end;",
             'alter table "test_foreign_table_two" add constraint "q7TfvbIx3HUQbh+l+e5N+J+Guag" foreign key ("fkey_two") references "test_table_two" ("id")'
           ]);
-          tester('mssql', ['CREATE TABLE [test_foreign_table_two] ([id] int identity(1,1) not null primary key, [fkey_two] int, CONSTRAINT test_foreign_table_two_fkey_two_foreign FOREIGN KEY ([fkey_two]) REFERENCES [test_table_two] ([id]))']);
+          tester('mssql', ['CREATE TABLE [test_foreign_table_two] ([id] int identity(1,1) not null primary key, [fkey_two] int, CONSTRAINT [test_foreign_table_two_fkey_two_foreign] FOREIGN KEY ([fkey_two]) REFERENCES [test_table_two] ([id]))']);
         });
       });
 
@@ -204,7 +204,7 @@ module.exports = function(knex) {
             tester('pg', ['create table "composite_key_test" ("column_a" integer, "column_b" integer, "details" text, "status" smallint)','alter table "composite_key_test" add constraint "composite_key_test_column_a_column_b_unique" unique ("column_a", "column_b")']);
             tester('sqlite3', ['create table "composite_key_test" ("column_a" integer, "column_b" integer, "details" text, "status" tinyint)','create unique index "composite_key_test_column_a_column_b_unique" on "composite_key_test" ("column_a", "column_b")']);
             tester('oracle', ['create table "composite_key_test" ("column_a" integer, "column_b" integer, "details" clob, "status" smallint)','alter table "composite_key_test" add constraint "zYmMt0VQwlLZ20XnrMicXZ0ufZk" unique ("column_a", "column_b")']);
-            tester('mssql', ['CREATE TABLE [composite_key_test] ([column_a] int, [column_b] int, [details] nvarchar(max), [status] tinyint, CONSTRAINT composite_key_test_column_a_column_b_unique UNIQUE ([column_a], [column_b]))']);
+            tester('mssql', ['CREATE TABLE [composite_key_test] ([column_a] int, [column_b] int, [details] nvarchar(max), [status] tinyint, CONSTRAINT [composite_key_test_column_a_column_b_unique] UNIQUE ([column_a], [column_b]))']);
           }).then(function() {
             return knex('composite_key_test').insert([{
               column_a: 1,


### PR DESCRIPTION
This PR fixes the `mssql` driver's `createTableIfNotExists()` function, which previously (due to an inverted condition) would never actually create the table.

It also gets the integration tests *mostly* working; there's one last error I haven't resolved yet:
```
  1) Integration Tests mssql | mssql Schema createTable rejects setting foreign key where tableName is not typeof === string:
     TypeError: Cannot read property 'sql' of undefined
      at TableCompiler.alterTableForCreate (lib/schema/tablecompiler.js:9:10850)
      at TableCompiler.create (lib/schema/tablecompiler.js:9:2125)
      at TableCompiler.toSQL (lib/schema/tablecompiler.js:9:1456)
      at TableBuilder.toSQL (lib/schema/tablebuilder.js:9:1630)
      at SchemaCompiler.createTable (lib/schema/compiler.js:9:2304)
      at SchemaCompiler.toSQL (lib/schema/compiler.js:9:1782)
      at SchemaBuilder.toSQL (lib/schema/builder.js:9:2260)
      at lib/runner.js:9:1117
  From previous event:
      at Runner.run (lib/runner.js:9:733)
      at SchemaBuilder.Target.then (lib/interface.js:9:1345)
```

Thanks to @elhigu for all the help understanding how the knex internals work.
