### PR TITLE
Prevent crash on `migrate:make`

### DIFF
--- a/src/migrate/index.js
+++ b/src/migrate/index.js
@@ -258,7 +258,7 @@ export default class Migrator {
   _generateStubTemplate() {
     var stubPath = this.config.stub || path.join(__dirname, 'stub', this.config.extension + '.stub');
     return Promise.promisify(fs.readFile, {context: fs})(stubPath).then(function(stub) {
-      return template(stub.toString(), null, {variable: 'd'});
+      return template(stub.toString(), {variable: 'd'});
     });
   }
 


### PR DESCRIPTION
Fixes error introduced in 1d27fb8. `template` fails if passed a `null` second argument.

Fixes #1385