### PR TITLE
BatchInsert remake proposal. Fixes #1391

### DIFF
--- a/index.html
+++ b/index.html
@@ -2382,15 +2382,29 @@ knex.select('e.lastname', 'e.salary', subcolumn)
 
     <h3 id="Utility-BatchInsert">Batch Insert</h3>
 
-    <p>The <tt>batchInsert</tt> utility will insert a batch of rows wrapped inside a transaction (which is automatically created), at a given <tt>chunkSize</tt>.</p>
+    <p>The <tt>batchInsert</tt> utility will insert a batch of rows wrapped inside a transaction <i>(which is automatically created unless explicitly given a transaction using <a href="#Builder-transacting">transacting</a>)</i>, at a given <tt>chunkSize</tt>.</p>
     <p>It's primarily designed to be used when you have thousands of rows to insert into a table.</p>
     <p>By default, the <tt>chunkSize</tt> is set to 1000.</p>
+
+    <p>BatchInsert also allows for <a href="#Builder-returning">returning values</a> and supplying transactions using <a href="#Builder-transacting">transacting</a>.</p>
 
 <pre>
 <code class="js">
   var rows = [{...}, {...}];
   var chunkSize = 30;
   knex.batchInsert('TableName', rows, chunkSize)
+  .returning('id')
+  .then(function(ids) {
+    ...
+  })
+  .catch(function(error) {
+    ...
+  });
+
+  knex.transaction(function(tr) {
+    return knex.batchInsert('TableName', rows, chunkSize)
+    .transacting(tr)
+  })
   .then(function() {
     ...
   })

--- a/src/util/batchInsert.js
+++ b/src/util/batchInsert.js
@@ -19,6 +19,7 @@ export default class BatchInsert {
     this._returning       = void 0;
     this._transaction     = null;
     this._autoTransaction = true;
+    
   }
 
   /**

--- a/src/util/batchInsert.js
+++ b/src/util/batchInsert.js
@@ -1,0 +1,84 @@
+'use strict';
+
+import {isNumber, isString, isArray, chunk, flatten} from 'lodash';
+import Promise from '../promise';
+
+export default class BatchInsert {
+	constructor (client, tableName, batch, chunkSize = 1000) {
+		if (!isNumber(chunkSize) || chunkSize < 1) {
+			throw new TypeError(`Invalid chunkSize: ${chunkSize}`);
+		}
+
+		if(!isArray(batch)) {
+			throw new TypeError(`Invalid batch: Expected array, got ${typeof batch}`)
+		}
+
+		this.client       = client;
+		this.tableName    = tableName;
+		this.batch        = chunk(batch, chunkSize);
+		this._returning   = void 0;
+		this._transaction = null;
+		this._autoCommit  = true;
+	}
+
+	/**
+	 * Columns to return from the batch operation.
+	 * @param returning
+	 */
+	returning (returning) {
+		if(isArray(returning) || isString(returning)) {
+			this._returning = returning;
+		}
+		return this;
+	}
+
+	/**
+	 * User may supply their own transaction.
+	 * If this is the case, don't autoCommit their transaction. The responsibility falls on the user.
+	 * @param transaction
+	 */
+	transacting (transaction) {
+		this._transaction = transaction;
+		this._autoCommit = false;
+		return this;
+	}
+
+	then (callback = function() {}) {
+		let transaction;
+		return Promise.resolve()
+		.then(() => {
+				if(this._transaction) {
+					transaction = this._transaction;
+					return Promise.resolve();
+				}
+				return new Promise((resolve) => {
+					this.client.transaction((tr) => {
+						transaction = tr;
+						resolve();
+					});
+				});
+			})
+		.then(() => {
+				return Promise.all(this.batch.map((items) => {
+					let promise = transaction(this.tableName)
+						.insert(items);
+					if(this._returning) {
+						promise.returning(this._returning);
+					}
+					return promise;
+				}));
+		})
+		.then((result) => {
+				if(this._autoCommit) {
+					transaction.commit();
+				}
+				return callback(flatten(result || []));
+		})
+			.catch((error) => {
+				if(this._autoCommit) {
+					transaction.rollback(error);
+				}
+				throw error;
+			});
+	}
+}

--- a/src/util/batchInsert.js
+++ b/src/util/batchInsert.js
@@ -57,12 +57,8 @@ export default class BatchInsert {
     return this._getTransaction()
       .then((transaction) => {
         return Promise.all(this.batch.map((items) => {
-          let insertBatchItems = transaction(this.tableName)
-            .insert(items);
-          if(this._returning) {
-            insertBatchItems.returning(this._returning);
-          }
-          return insertBatchItems;
+          return transaction(this.tableName)
+            .insert(items, this._returning);
         }))
           .then((result) => {
             if(this._autoTransaction) {

--- a/src/util/batchInsert.js
+++ b/src/util/batchInsert.js
@@ -45,7 +45,7 @@ export default class BatchInsert {
   }
 
   _getTransaction() {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       if(this._transaction) {
         return resolve(this._transaction);
       }

--- a/src/util/batchInsert.js
+++ b/src/util/batchInsert.js
@@ -4,81 +4,81 @@ import {isNumber, isString, isArray, chunk, flatten} from 'lodash';
 import Promise from '../promise';
 
 export default class BatchInsert {
-	constructor(client, tableName, batch, chunkSize = 1000) {
-		if(!isNumber(chunkSize) || chunkSize < 1) {
-			throw new TypeError(`Invalid chunkSize: ${chunkSize}`);
-		}
+  constructor(client, tableName, batch, chunkSize = 1000) {
+    if(!isNumber(chunkSize) || chunkSize < 1) {
+      throw new TypeError(`Invalid chunkSize: ${chunkSize}`);
+    }
 
-		if(!isArray(batch)) {
-			throw new TypeError(`Invalid batch: Expected array, got ${typeof batch}`)
-		}
+    if(!isArray(batch)) {
+      throw new TypeError(`Invalid batch: Expected array, got ${typeof batch}`)
+    }
 
-		this.client       = client;
-		this.tableName    = tableName;
-		this.batch        = chunk(batch, chunkSize);
-		this._returning   = void 0;
-		this._transaction = null;
-		this._autoCommit  = true;
-	}
+    this.client       = client;
+    this.tableName    = tableName;
+    this.batch        = chunk(batch, chunkSize);
+    this._returning   = void 0;
+    this._transaction = null;
+    this._autoCommit  = true;
+  }
 
-	/**
-	 * Columns to return from the batch operation.
-	 * @param returning
-	 */
-	returning(returning) {
-		if(isArray(returning) || isString(returning)) {
-			this._returning = returning;
-		}
-		return this;
-	}
+  /**
+   * Columns to return from the batch operation.
+   * @param returning
+   */
+  returning(returning) {
+    if(isArray(returning) || isString(returning)) {
+      this._returning = returning;
+    }
+    return this;
+  }
 
-	/**
-	 * User may supply their own transaction.
-	 * If this is the case, don't autoCommit their transaction. The responsibility falls on the user.
-	 * @param transaction
-	 */
-	transacting(transaction) {
-		this._transaction = transaction;
-		this._autoCommit  = false;
-		return this;
-	}
+  /**
+   * User may supply their own transaction.
+   * If this is the case, don't autoCommit their transaction. The responsibility falls on the user.
+   * @param transaction
+   */
+  transacting(transaction) {
+    this._transaction = transaction;
+    this._autoCommit  = false;
+    return this;
+  }
 
-	then(callback = function() {}) {
-		let transaction;
-		return Promise.resolve()
-			.then(() => {
-				if(this._transaction) {
-					transaction = this._transaction;
-					return Promise.resolve();
-				}
-				return new Promise((resolve) => {
-					this.client.transaction((tr) => {
-						transaction = tr;
-						resolve();
-					});
-				});
-			})
-			.then(() => {
-				return Promise.all(this.batch.map((items) => {
-					let promise = transaction(this.tableName)
-						.insert(items);
-					if(this._returning) {
-						promise.returning(this._returning);
-					}
-					return promise;
-				}));
-			})
-			.then((result) => {
-				if(this._autoCommit) {
-					transaction.commit();
-				}
-				return callback(flatten(result || []));
-			})
-			.catch((error) => {
-				if(this._autoCommit) {
-					transaction.rollback(error);
-				}
-				throw error;
-			});
-	}
+  then(callback = function() {}) {
+    let transaction;
+    return Promise.resolve()
+      .then(() => {
+        if(this._transaction) {
+          transaction = this._transaction;
+          return Promise.resolve();
+        }
+        return new Promise((resolve) => {
+          this.client.transaction((tr) => {
+            transaction = tr;
+            resolve();
+          });
+        });
+      })
+      .then(() => {
+        return Promise.all(this.batch.map((items) => {
+          let promise = transaction(this.tableName)
+            .insert(items);
+          if(this._returning) {
+            promise.returning(this._returning);
+          }
+          return promise;
+        }));
+      })
+      .then((result) => {
+        if(this._autoCommit) {
+          transaction.commit();
+        }
+        return callback(flatten(result || []));
+      })
+      .catch((error) => {
+        if(this._autoCommit) {
+          transaction.rollback(error);
+        }
+        throw error;
+      });
+  }
 }

--- a/src/util/batchInsert.js
+++ b/src/util/batchInsert.js
@@ -13,12 +13,12 @@ export default class BatchInsert {
       throw new TypeError(`Invalid batch: Expected array, got ${typeof batch}`)
     }
 
-    this.client       = client;
-    this.tableName    = tableName;
-    this.batch        = chunk(batch, chunkSize);
-    this._returning   = void 0;
-    this._transaction = null;
-    this._autoCommit  = true;
+    this.client           = client;
+    this.tableName        = tableName;
+    this.batch            = chunk(batch, chunkSize);
+    this._returning       = void 0;
+    this._transaction     = null;
+    this._autoTransaction = true;
   }
 
   /**
@@ -34,51 +34,47 @@ export default class BatchInsert {
 
   /**
    * User may supply their own transaction.
-   * If this is the case, don't autoCommit their transaction. The responsibility falls on the user.
+   * If this is the case, autoTransaction = false, meaning we don't automatically commit/rollback the transaction. The responsibility instead falls on the user.
    * @param transaction
    */
   transacting(transaction) {
-    this._transaction = transaction;
-    this._autoCommit  = false;
+    this._transaction     = transaction;
+    this._autoTransaction = false;
     return this;
   }
 
+  _getTransaction() {
+    return new Promise((resolve, reject) => {
+      if(this._transaction) {
+        return resolve(this._transaction);
+      }
+      this.client.transaction((tr) => resolve(tr));
+    });
+  }
+
   then(callback = function() {}) {
-    let transaction;
-    return Promise.resolve()
-      .then(() => {
-        if(this._transaction) {
-          transaction = this._transaction;
-          return Promise.resolve();
-        }
-        return new Promise((resolve) => {
-          this.client.transaction((tr) => {
-            transaction = tr;
-            resolve();
-          });
-        });
-      })
-      .then(() => {
+    return this._getTransaction()
+      .then((transaction) => {
         return Promise.all(this.batch.map((items) => {
-          let promise = transaction(this.tableName)
+          let insertBatchItems = transaction(this.tableName)
             .insert(items);
           if(this._returning) {
-            promise.returning(this._returning);
+            insertBatchItems.returning(this._returning);
           }
-          return promise;
-        }));
-      })
-      .then((result) => {
-        if(this._autoCommit) {
-          transaction.commit();
-        }
-        return callback(flatten(result || []));
-      })
-      .catch((error) => {
-        if(this._autoCommit) {
-          transaction.rollback(error);
-        }
-        throw error;
+          return insertBatchItems;
+        }))
+          .then((result) => {
+            if(this._autoTransaction) {
+              transaction.commit();
+            }
+            return callback(flatten(result || []));
+          })
+          .catch((error) => {
+            if(this._autoTransaction) {
+              transaction.rollback(error);
+            }
+            throw error;
+          });
       });
   }
 }

--- a/src/util/batchInsert.js
+++ b/src/util/batchInsert.js
@@ -4,8 +4,8 @@ import {isNumber, isString, isArray, chunk, flatten} from 'lodash';
 import Promise from '../promise';
 
 export default class BatchInsert {
-	constructor (client, tableName, batch, chunkSize = 1000) {
-		if (!isNumber(chunkSize) || chunkSize < 1) {
+	constructor(client, tableName, batch, chunkSize = 1000) {
+		if(!isNumber(chunkSize) || chunkSize < 1) {
 			throw new TypeError(`Invalid chunkSize: ${chunkSize}`);
 		}
 
@@ -25,7 +25,7 @@ export default class BatchInsert {
 	 * Columns to return from the batch operation.
 	 * @param returning
 	 */
-	returning (returning) {
+	returning(returning) {
 		if(isArray(returning) || isString(returning)) {
 			this._returning = returning;
 		}
@@ -37,16 +37,16 @@ export default class BatchInsert {
 	 * If this is the case, don't autoCommit their transaction. The responsibility falls on the user.
 	 * @param transaction
 	 */
-	transacting (transaction) {
+	transacting(transaction) {
 		this._transaction = transaction;
-		this._autoCommit = false;
+		this._autoCommit  = false;
 		return this;
 	}
 
-	then (callback = function() {}) {
+	then(callback = function() {}) {
 		let transaction;
 		return Promise.resolve()
-		.then(() => {
+			.then(() => {
 				if(this._transaction) {
 					transaction = this._transaction;
 					return Promise.resolve();
@@ -58,7 +58,7 @@ export default class BatchInsert {
 					});
 				});
 			})
-		.then(() => {
+			.then(() => {
 				return Promise.all(this.batch.map((items) => {
 					let promise = transaction(this.tableName)
 						.insert(items);
@@ -67,13 +67,13 @@ export default class BatchInsert {
 					}
 					return promise;
 				}));
-		})
-		.then((result) => {
+			})
+			.then((result) => {
 				if(this._autoCommit) {
 					transaction.commit();
 				}
 				return callback(flatten(result || []));
-		})
+			})
 			.catch((error) => {
 				if(this._autoCommit) {
 					transaction.rollback(error);

--- a/src/util/make-knex.js
+++ b/src/util/make-knex.js
@@ -8,6 +8,7 @@ var QueryInterface = require('../query/methods')
 var helpers        = require('../helpers')
 var Promise        = require('../promise')
 import {assign, isNumber, chunk} from 'lodash'
+import BatchInsert from './batchInsert';
 
 module.exports = function makeKnex(client) {
 
@@ -34,20 +35,7 @@ module.exports = function makeKnex(client) {
     },
 
     batchInsert: function(table, batch, chunkSize = 1000) {
-      if (!isNumber(chunkSize) || chunkSize < 1) {
-        throw new TypeError("Invalid chunkSize: " + chunkSize);
-      }
-
-      return this.transaction((tr) => {
-          // Avoid unnecessary call.
-          if(chunkSize !== 1) {
-            batch = chunk(batch, chunkSize)
-          }
-
-          return Promise.all(batch.map((items) => {
-            return tr(table).insert(items)
-          }));
-        })
+      return new BatchInsert(this, table, batch, chunkSize);
     },
 
     // Runs a new transaction, taking a container and returning a promise

--- a/src/util/make-knex.js
+++ b/src/util/make-knex.js
@@ -6,8 +6,7 @@ var Seeder         = require('../seed')
 var FunctionHelper = require('../functionhelper')
 var QueryInterface = require('../query/methods')
 var helpers        = require('../helpers')
-var Promise        = require('../promise')
-import {assign, isNumber, chunk} from 'lodash'
+import {assign} from 'lodash'
 import BatchInsert from './batchInsert';
 
 module.exports = function makeKnex(client) {

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -649,6 +649,7 @@ module.exports = function(knex) {
 
 
     describe('batchInsert', function() {
+      var dialect = String(knex.client.dialect).toUpperCase();
       var fiftyLengthString = 'rO8F8YrFS6uoivuRiVnwrO8F8YrFS6uoivuRiVnwuoivuRiVnw';
       var items             = [];
       var amountOfItems     = 100;
@@ -676,10 +677,13 @@ module.exports = function(knex) {
         return knex.batchInsert('BatchInsert', items, 30)
           .returning(['Col1', 'Col2'])
           .then(function (result) {
-            result.forEach(function(item) {
-              expect(item.Col1).to.equal(fiftyLengthString);
-              expect(item.Col2).to.equal(fiftyLengthString);
-            });
+            //Returning only supported by some dialects.
+            if(['POSTGRES', 'MYSQL', 'MYSQL2', 'ORACLE'].indexOf(dialect) !== -1) {
+              result.forEach(function(item) {
+                expect(item.Col1).to.equal(fiftyLengthString);
+                expect(item.Col2).to.equal(fiftyLengthString);
+              });
+            }
             return knex('BatchInsert').select();
           })
           .then(function (result) {

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -678,7 +678,7 @@ module.exports = function(knex) {
           .returning(['Col1', 'Col2'])
           .then(function (result) {
             //Returning only supported by some dialects.
-            if(['POSTGRES', 'MYSQL', 'MYSQL2', 'ORACLE'].indexOf(dialect) !== -1) {
+            if(['POSTGRES', 'ORACLE'].indexOf(dialect) !== -1) {
               result.forEach(function(item) {
                 expect(item.Col1).to.equal(fiftyLengthString);
                 expect(item.Col2).to.equal(fiftyLengthString);


### PR DESCRIPTION
Two things were requested for `batchInsert`:
- [x] Returning columns from inserted rows
- [x] Supply an outside transaction instead of auto-creating

I've added these two things to the current implementation.

I also decided to rewrite the whole procedure and move it out to a seperate file. I feel that it's very likely this function will eventually be ripped out of the knex repository into a seperate module at some point. Like a utility library of sorts. *(We've talked about this before)*

Not entirely satisfied with how complex-looking this simple thing became, and may have missed something. Please have a look  @rhys-vdw @elhigu !