### PR TITLE
Abort request for connection from pool upon knex timeout

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -210,16 +210,26 @@ assign(Client.prototype, {
   // Acquire a connection from the pool.
   acquireConnection: function() {
     var client = this
-    return new Promise(function(resolver, rejecter) {
+    var request = null
+    var completed = new Promise(function(resolver, rejecter) {
       if (!client.pool) {
         return rejecter(new Error('There is no pool defined on the current client'))
       }
-      client.pool.acquire(function(err, connection) {
+      request = client.pool.acquire(function(err, connection) {
         if (err) return rejecter(err)
-        debug('acquiring connection from pool: %s', connection.__knexUid)
+        debug('acquired connection from pool: %s', connection.__knexUid)
         resolver(connection)
       })
     })
+    var abort = function(reason) {
+      if (request && !request.fulfilled) {
+        request.abort(reason)
+      }
+    }
+    return {
+      completed: completed,
+      abort: abort
+    }
   },
 
   // Releases a connection back to the connection pool,

--- a/src/dialects/mssql/transaction.js
+++ b/src/dialects/mssql/transaction.js
@@ -57,7 +57,7 @@ assign(Transaction_MSSQL.prototype, {
     var t = this
     var configConnection = config && config.connection
     return Promise.try(function() {
-      return (t.outerTx ? t.outerTx.conn : null) || configConnection || t.client.acquireConnection()
+      return (t.outerTx ? t.outerTx.conn : null) || configConnection || t.client.acquireConnection().completed
     }).tap(function(conn) {
       if (!t.outerTx) {
         t.conn = conn

--- a/src/dialects/oracle/transaction.js
+++ b/src/dialects/oracle/transaction.js
@@ -40,7 +40,7 @@ assign(Oracle_Transaction.prototype, {
   acquireConnection: function(config) {
     var t = this
     return Promise.try(function() {
-      return config.connection || t.client.acquireConnection()
+      return config.connection || t.client.acquireConnection().completed
     }).tap(function(connection) {
       if (!t.outerTx) {
         connection.setAutoCommit(false)

--- a/src/runner.js
+++ b/src/runner.js
@@ -158,7 +158,9 @@ assign(Runner.prototype, {
     var acquireConnectionTimeout = runner.client.config.acquireConnectionTimeout || 60000
     return Promise.try(function() {
       return runner.connection || new Promise((resolver, rejecter) => {
-            runner.client.acquireConnection()
+            var acquireConnection = runner.client.acquireConnection()
+
+            acquireConnection.completed
             .timeout(acquireConnectionTimeout)
             .then(resolver)
             .catch(Promise.TimeoutError, (error) => {
@@ -173,6 +175,9 @@ assign(Runner.prototype, {
                   }
 
                   assign(timeoutError, additionalErrorInformation)
+
+                  // Let the pool know that this request for a connection timed out
+                  acquireConnection.abort('Knex: Timeout acquiring a connection.')
 
                   rejecter(timeoutError)
             })

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -5,6 +5,7 @@ var Promise      = require('./promise')
 var EventEmitter = require('events').EventEmitter
 var inherits     = require('inherits')
 
+var noop         = require('./util/noop')
 var makeKnex     = require('./util/make-knex')
 var debug        = require('debug')('knex:tx')
 
@@ -236,10 +237,13 @@ function makeTxClient(trx, client, connection) {
       return _stream.call(trxClient, conn, obj, stream, options)
     })
   }
-  trxClient.acquireConnection = function() {
-    return trx._previousSibling.reflect().then(function () {
-      return connection
-    })
+  trxClient.acquireConnection = function () {
+    return {
+      completed: trx._previousSibling.reflect().then(function () {
+        return connection
+      }),
+      abort: noop
+    }
   }
   trxClient.releaseConnection = function() {
     return Promise.resolve()

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -143,7 +143,7 @@ assign(Transaction.prototype, {
   acquireConnection: function(client, config, txid) {
     var configConnection = config && config.connection
     return Promise.try(function() {
-      return configConnection || client.acquireConnection()
+      return configConnection || client.acquireConnection().completed
     })
     .disposer(function(connection) {
       if (!configConnection) {


### PR DESCRIPTION
See #1382 for a more in-depth description of the bug.

This PR aborts the request to pool2 for a connection when knex times out due to `acquireConnectionTimeout`.  The purpose of this PR is to fix the issue without introducing a breaking change.  I think in the future `acquireConnectionTimeout` should be implemented using pool2's `requestTimeout`, or knex should simply set a default for `requestTimeout` (pool2 sets it to `Infinity`).  When that happens, this PR can probably be reverted.

This is my first time working on the knex codebase.  One thing I was unsure of was how the dialects' implementations relate to the base client implementation.  The client's implementation of `acquireConnection()` now returns an object containing a promise, while the dialect/transactional versions of the same method simply return a promise.  I wasn't able to test the affected dialects (mssql and oracle), so I'm not sure if there's anything wrong there.  I _think_ it's all set though.