### PR TITLE
Evaluated multi insert default for undefined already in query compiler

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -22,7 +22,7 @@ var inherits       = require('inherits')
 var EventEmitter   = require('events').EventEmitter
 var SqlString      = require('./query/string')
 
-import {assign, uniqueId, cloneDeep, map} from 'lodash'
+import {assign, uniqueId, cloneDeep} from 'lodash'
 
 var debug          = require('debug')('knex:client')
 var debugQuery     = require('debug')('knex:query')
@@ -141,9 +141,7 @@ assign(Client.prototype, {
   },
 
   prepBindings: function(bindings) {
-    return map(bindings, (binding) => {
-      return binding === undefined ? this.valueForUndefined : binding
-    });
+    return bindings;
   },
 
   wrapIdentifier: function(value) {

--- a/src/dialects/mssql/index.js
+++ b/src/dialects/mssql/index.js
@@ -85,15 +85,6 @@ assign(Client_MSSQL.prototype, {
     })
   },
 
-  prepBindings: function(bindings) {
-    return map(bindings, (value) => {
-      if (value === undefined) {
-        return this.valueForUndefined
-      }
-      return value
-    })
-  },
-
   // Grab a connection, run the query via the MSSQL streaming interface,
   // and pass that through to the stream we've sent back to the client.
   _stream: function(connection, obj, stream, options) {

--- a/src/dialects/mssql/query/compiler.js
+++ b/src/dialects/mssql/query/compiler.js
@@ -44,7 +44,7 @@ assign(QueryCompiler_MSSQL.prototype, {
         var i = -1
         while (++i < insertData.values.length) {
           if (i !== 0) sql += '), ('
-          sql += this.formatter.parameterize(insertData.values[i])
+          sql += this.formatter.parameterize(insertData.values[i], this.client.valueForUndefined)
         }
         sql += ')';
       } else if (insertValues.length === 1 && insertValues[0]) {

--- a/src/dialects/oracle/index.js
+++ b/src/dialects/oracle/index.js
@@ -63,9 +63,6 @@ assign(Client_Oracle.prototype, {
       else if (Buffer.isBuffer(value)) {
         return SqlString.bufferToString(value)
       }
-      else if (value === undefined) {
-        return this.valueForUndefined
-      }
       return value
     })
   },

--- a/src/dialects/oracle/query/compiler.js
+++ b/src/dialects/oracle/query/compiler.js
@@ -60,7 +60,7 @@ assign(QueryCompiler_Oracle.prototype, {
     sql.sql = 'begin ' +
       map(insertData.values, (value) => {
           var returningHelper;
-          var parameterizedValues = !insertDefaultsOnly ? this.formatter.parameterize(value) : '';
+          var parameterizedValues = !insertDefaultsOnly ? this.formatter.parameterize(value, this.client.valueForUndefined) : '';
           var returningValues = Array.isArray(returning) ? returning : [returning];
           var subSql = 'insert into ' + this.tableName + ' ';
 
@@ -79,11 +79,14 @@ assign(QueryCompiler_Oracle.prototype, {
 
           // pre bind position because subSql is an execute immediate parameter
           // later position binding will only convert the ? params
+
           subSql = this.formatter.client.positionBindings(subSql);
+
+          var parameterizedValuesWithoutDefault = parameterizedValues.replace('DEFAULT, ', '').replace(', DEFAULT', '');
           return 'execute immediate \'' + subSql.replace(/'/g, "''") +
-            ((parameterizedValues || returning) ? '\' using ' : '') +
-            parameterizedValues +
-            ((parameterizedValues && returning) ? ', ' : '') +
+            ((parameterizedValuesWithoutDefault || returning) ? '\' using ' : '') +
+            parameterizedValuesWithoutDefault +
+            ((parameterizedValuesWithoutDefault && returning) ? ', ' : '') +
             (returning ? 'out ?' : '') + ';';
       }).join(' ') +
       'end;';

--- a/src/dialects/postgres/utils.js
+++ b/src/dialects/postgres/utils.js
@@ -34,7 +34,7 @@ var arrayString;
 // to their 'raw' counterparts for use as a postgres parameter
 // note: you can override this function to provide your own conversion mechanism
 // for complex types, etc...
-var prepareValue = function (val, seen, valueForUndefined) {
+var prepareValue = function (val, seen /*, valueForUndefined*/) {
   if (val instanceof Buffer) {
     return val;
   }
@@ -46,9 +46,6 @@ var prepareValue = function (val, seen, valueForUndefined) {
   }
   if (val === null) {
     return null;
-  }
-  if (val === undefined) {
-    return valueForUndefined;
   }
   if (typeof val === 'object') {
     return prepareObject(val, seen);

--- a/src/dialects/sqlite3/index.js
+++ b/src/dialects/sqlite3/index.js
@@ -110,16 +110,6 @@ assign(Client_SQLite3.prototype, {
     })
   },
 
-  prepBindings: function(bindings) {
-    return map(bindings, (binding) => {
-      if (binding === undefined && this.valueForUndefined !== null) {
-        throw new TypeError("`sqlite` does not support inserting default values. Specify values explicitly or use the `useNullAsDefault` config flag. (see docs http://knexjs.org/#Builder-insert).");
-      } else {
-        return binding
-      }
-    });
-  },
-
   // Ensures the response is returned in the same format as other clients.
   processResponse: function(obj, runner) {
     var ctx      = obj.context;

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -92,7 +92,7 @@ assign(QueryCompiler.prototype, {
         var i = -1
         while (++i < insertData.values.length) {
           if (i !== 0) sql += '), ('
-          sql += this.formatter.parameterize(insertData.values[i])
+          sql += this.formatter.parameterize(insertData.values[i], this.client.valueForUndefined)
         }
         sql += ')';
       } else if (insertValues.length === 1 && insertValues[0]) {

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -703,42 +703,44 @@ module.exports = function(knex) {
       });
 
     });
-  });
 
-  it('should validate batchInsert batchSize parameter', function() {
-    expect(function () { knex.batchInsert('test', []) }).to.not.throw();
-    expect(function () { knex.batchInsert('test', [], null) }).to.throw(TypeError);
-    expect(function () { knex.batchInsert('test', [], 0) }).to.throw(TypeError);
-    expect(function () { knex.batchInsert('test', [], 'still no good') }).to.throw(TypeError);
-  });
+    it('should validate batchInsert batchSize parameter', function() {
+      expect(function () { knex.batchInsert('test', []) }).to.not.throw();
+      expect(function () { knex.batchInsert('test', [], null) }).to.throw(TypeError);
+      expect(function () { knex.batchInsert('test', [], 0) }).to.throw(TypeError);
+      expect(function () { knex.batchInsert('test', [], 'still no good') }).to.throw(TypeError);
+    });
 
-  it('should replace undefined keys in multi insert with DEFAULT', function() {
-    if (knex.client.dialect === 'sqlite3') {
-      return true;
-    }
-    return knex('accounts')
-      .insert([{
-        last_name: 'First Item',
-        email:'single-test1@example.com',
-        about: 'Lorem ipsum Dolore labore incididunt enim.',
-        created_at: new Date(),
-        updated_at: new Date()
-      }, {
-        last_name: 'Second Item',
-        email:'double-test1@example.com',
-        logins: 2,
-        created_at: new Date(),
-        updated_at: new Date()
-      }])
-      .then(function () {
-        return knex('accounts').whereIn('email', [
-          'single-test1@example.com',
-          'double-test1@example.com'
-        ]).orderBy('email', 'desc');
-      })
-      .then(function (results) {
-        expect(results[0].logins).to.equal(1);
-        expect(results[1].about).to.equal(null);
-      });
+    it('should replace undefined keys in multi insert with DEFAULT', function() {
+      if (knex.client.dialect === 'sqlite3') {
+        return true;
+      }
+      return knex('accounts')
+        .insert([{
+          last_name: 'First Item',
+          email:'single-test1@example.com',
+          about: 'Lorem ipsum Dolore labore incididunt enim.',
+          created_at: new Date(),
+          updated_at: new Date()
+        }, {
+          last_name: 'Second Item',
+          email:'double-test1@example.com',
+          logins: 2,
+          created_at: new Date(),
+          updated_at: new Date()
+        }])
+        .then(function () {
+          return knex('accounts').whereIn('email', [
+            'single-test1@example.com',
+            'double-test1@example.com'
+          ]).orderBy('email', 'desc');
+        })
+        .then(function (results) {
+          expect(results[0].logins).to.equal(1);
+          expect(results[1].about).to.equal(null);
+          // cleanup to prevent needs for too much changes to other tests
+          return knex('accounts').delete().whereIn('id', results.map(function (row) { return row.id }));
+        });
+    });
   });
 };

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -712,4 +712,33 @@ module.exports = function(knex) {
     expect(function () { knex.batchInsert('test', [], 'still no good') }).to.throw(TypeError);
   });
 
+  it('should replace undefined keys in multi insert with DEFAULT', function() {
+    if (knex.client.dialect === 'sqlite3') {
+      return true;
+    }
+    return knex('accounts')
+      .insert([{
+        last_name: 'First Item',
+        email:'single-test1@example.com',
+        about: 'Lorem ipsum Dolore labore incididunt enim.',
+        created_at: new Date(),
+        updated_at: new Date()
+      }, {
+        last_name: 'Second Item',
+        email:'double-test1@example.com',
+        logins: 2,
+        created_at: new Date(),
+        updated_at: new Date()
+      }])
+      .then(function () {
+        return knex('accounts').whereIn('email', [
+          'single-test1@example.com',
+          'double-test1@example.com'
+        ]).orderBy('email', 'desc');
+      })
+      .then(function (results) {
+        expect(results[0].logins).to.equal(1);
+        expect(results[1].about).to.equal(null);
+      });
+  });
 };

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -28,15 +28,6 @@ var clientsWithNullAsDefault = {
   default:  new Client(useNullAsDefaultConfig)
 }
 
-var valuesForUndefined = {
-  mysql: clients.mysql.valueForUndefined,
-  sqlite3: clients.sqlite3.valueForUndefined,
-  oracle: clients.oracle.valueForUndefined,
-  postgres: clients.postgres.valueForUndefined,
-  mssql: clients.mssql.valueForUndefined,
-  default: clients.default.valueForUndefined
-};
-
 function qb() {
   return clients.default.queryBuilder()
 }
@@ -1831,7 +1822,7 @@ describe("QueryBuilder", function() {
   it("multiple inserts with partly undefined keys", function() {
     testquery(qb().from('users').insert([{email: 'foo', name: 'taylor'}, {name: 'dayle'}]), {
       mysql: "insert into `users` (`email`, `name`) values ('foo', 'taylor'), (DEFAULT, 'dayle')",
-      oracle: 'begin execute immediate \'insert into "users" ("email", "name") values (:1, :2)\' using \'foo\', \'taylor\'; execute immediate \'insert into "users" ("email", "name") values (:1, :2)\' using DEFAULT, \'dayle\';end;',
+      oracle: 'begin execute immediate \'insert into "users" ("email", "name") values (:1, :2)\' using \'foo\', \'taylor\'; execute immediate \'insert into "users" ("email", "name") values (DEFAULT, :1)\' using \'dayle\';end;',
       mssql: "insert into [users] ([email], [name]) values ('foo', 'taylor'), (DEFAULT, 'dayle')",
       default: 'insert into "users" ("email", "name") values (\'foo\', \'taylor\'), (DEFAULT, \'dayle\')'
     });
@@ -1956,12 +1947,12 @@ describe("QueryBuilder", function() {
         bindings: [1, undefined, undefined, undefined, 2, undefined, 2, undefined, 3]
       },
       oracle: {
-        sql: "begin execute immediate 'insert into \"table\" (\"a\", \"b\", \"c\") values (:1, :2, :3)' using ?, ?, ?; execute immediate 'insert into \"table\" (\"a\", \"b\", \"c\") values (:1, :2, :3)' using ?, ?, ?; execute immediate 'insert into \"table\" (\"a\", \"b\", \"c\") values (:1, :2, :3)' using ?, ?, ?;end;",
-        bindings: [1, valuesForUndefined.oracle, valuesForUndefined.oracle, valuesForUndefined.oracle, 2, valuesForUndefined.oracle, 2, valuesForUndefined.oracle, 3]
+        sql: "begin execute immediate 'insert into \"table\" (\"a\", \"b\", \"c\") values (:1, DEFAULT, DEFAULT)' using ?; execute immediate 'insert into \"table\" (\"a\", \"b\", \"c\") values (DEFAULT, :1, DEFAULT)' using ?; execute immediate 'insert into \"table\" (\"a\", \"b\", \"c\") values (:1, DEFAULT, :2)' using ?, ?;end;",
+        bindings: [1, 2, 2, 3]
       },
       mssql: {
-        sql: 'insert into [table] ([a], [b], [c]) values (?, ?, ?), (?, ?, ?), (?, ?, ?)',
-        bindings: [1, valuesForUndefined.mssql, valuesForUndefined.mssql, valuesForUndefined.mssql, 2, valuesForUndefined.mssql, 2, valuesForUndefined.mssql, 3]
+        sql: 'insert into [table] ([a], [b], [c]) values (?, DEFAULT, DEFAULT), (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
+        bindings: [1, 2, 2, 3]
       },
       default: {
         sql: 'insert into "table" ("a", "b", "c") values (?, DEFAULT, DEFAULT), (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
@@ -3308,12 +3299,12 @@ describe("QueryBuilder", function() {
         bindings: ['test', 1, 'none']
       },
       oracle: {
-        sql: 'begin execute immediate \'insert into "users" ("id", "name", "occupation") values (:1, :2, :3)\' using ?, ?, ?; execute immediate \'insert into "users" ("id", "name", "occupation") values (:1, :2, :3)\' using ?, ?, ?;end;',
-        bindings: [valuesForUndefined.oracle, 'test', valuesForUndefined.oracle, 1, valuesForUndefined.oracle, 'none']
+        sql: 'begin execute immediate \'insert into "users" ("id", "name", "occupation") values (DEFAULT, :1, DEFAULT)\' using ?; execute immediate \'insert into "users" ("id", "name", "occupation") values (:1, DEFAULT, :2)\' using ?, ?;end;',
+        bindings: ['test', 1, 'none']
       },
       mssql: {
-        sql: 'insert into [users] ([id], [name], [occupation]) values (?, ?, ?), (?, ?, ?)',
-        bindings: [valuesForUndefined.mssql, 'test', valuesForUndefined.mssql, 1, valuesForUndefined.mssql, 'none']
+        sql: 'insert into [users] ([id], [name], [occupation]) values (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
+        bindings: ['test', 1, 'none']
       },
       postgres: {
         sql: 'insert into "users" ("id", "name", "occupation") values (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -1948,8 +1948,8 @@ describe("QueryBuilder", function() {
 
     testsql(qb().insert(data).into('table'), {
       mysql: {
-        sql: 'insert into `table` (`a`, `b`, `c`) values (?, ?, ?), (?, ?, ?), (?, ?, ?)',
-        bindings: [1, valuesForUndefined.mysql, valuesForUndefined.mysql, valuesForUndefined.mysql, 2, valuesForUndefined.mysql, 2, valuesForUndefined.mysql, 3]
+        sql: 'insert into `table` (`a`, `b`, `c`) values (?, DEFAULT, DEFAULT), (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
+        bindings: [1, 2, 2, 3]
       },
       sqlite3: {
         sql: 'insert into "table" ("a", "b", "c") select ? as "a", ? as "b", ? as "c" union all select ? as "a", ? as "b", ? as "c" union all select ? as "a", ? as "b", ? as "c"',
@@ -1964,8 +1964,8 @@ describe("QueryBuilder", function() {
         bindings: [1, valuesForUndefined.mssql, valuesForUndefined.mssql, valuesForUndefined.mssql, 2, valuesForUndefined.mssql, 2, valuesForUndefined.mssql, 3]
       },
       default: {
-        sql: 'insert into "table" ("a", "b", "c") values (?, ?, ?), (?, ?, ?), (?, ?, ?)',
-        bindings: [1, valuesForUndefined.default, valuesForUndefined.default, valuesForUndefined.default, 2, valuesForUndefined.default, 2, valuesForUndefined.default, 3]
+        sql: 'insert into "table" ("a", "b", "c") values (?, DEFAULT, DEFAULT), (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
+        bindings: [1, 2, 2, 3]
       }
     });
     clients.sqlite3.valueForUndefined = previousValuesForUndefinedSqlite3;
@@ -3304,8 +3304,8 @@ describe("QueryBuilder", function() {
   it('#1268 - valueForUndefined should be in toSQL(QueryCompiler)', function() {
     testsql(qb().insert([{id: void 0, name: 'test', occupation: void 0}, {id: 1, name: void 0, occupation: 'none'}]).into('users'), {
       mysql: {
-        sql: 'insert into `users` (`id`, `name`, `occupation`) values (?, ?, ?), (?, ?, ?)',
-        bindings: [valuesForUndefined.mysql, 'test', valuesForUndefined.mysql, 1, valuesForUndefined.mysql, 'none']
+        sql: 'insert into `users` (`id`, `name`, `occupation`) values (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
+        bindings: ['test', 1, 'none']
       },
       oracle: {
         sql: 'begin execute immediate \'insert into "users" ("id", "name", "occupation") values (:1, :2, :3)\' using ?, ?, ?; execute immediate \'insert into "users" ("id", "name", "occupation") values (:1, :2, :3)\' using ?, ?, ?;end;',
@@ -3316,8 +3316,8 @@ describe("QueryBuilder", function() {
         bindings: [valuesForUndefined.mssql, 'test', valuesForUndefined.mssql, 1, valuesForUndefined.mssql, 'none']
       },
       postgres: {
-        sql: 'insert into "users" ("id", "name", "occupation") values (?, ?, ?), (?, ?, ?)',
-        bindings: [valuesForUndefined.postgres, 'test', valuesForUndefined.postgres, '1', valuesForUndefined.postgres, 'none']
+        sql: 'insert into "users" ("id", "name", "occupation") values (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
+        bindings: ['test', '1', 'none']
       }
     });
 


### PR DESCRIPTION
Drivers cannot take knex.raw replacement values as positional replacement values, so they must be evaluated already in query compile time to sql string which is passed to driver.