### PR TITLE
Allow creating datetime in mysql with fractional second part

### DIFF
--- a/index.html
+++ b/index.html
@@ -1987,22 +1987,22 @@ knex.schema.raw("SET sql_mode='TRADITIONAL'")
     </p>
 
     <p id="Schema-dateTime">
-      <b class="header">dateTime</b><code>table.dateTime(name)</code>
+      <b class="header">dateTime</b><code>table.dateTime(name, [fsp])</code>
       <br />
-      Adds a dateTime column.
+      Adds a dateTime column, with optional fractional seconds part for MySQL.
     </p>
 
     <p id="Schema-time">
-      <b class="header">time</b><code>table.time(name)</code>
+      <b class="header">time</b><code>table.time(name, [fsp])</code>
       <br />
-      Adds a time column.
+      Adds a time column, with optional fractional seconds part for MySQL.
     </p>
 
     <p id="Schema-timestamp">
       <b class="header">timestamp</b><code>table.timestamp(name, [standard])</code>
       <br />
       Adds a timestamp column, defaults to <tt>timestamptz</tt> in PostgreSQL, unless true
-      is passed as the second argument.
+      is passed as the second argument. In MySQL the second argument can be used to set the fractional seconds part.
       <br />
       For Example:
 <pre class="display">

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -68,9 +68,17 @@ assign(ColumnCompiler_MySQL.prototype, {
     return `enum('${allowed.join("', '")}')`
   },
 
-  datetime: 'datetime',
+  time: function(fsp) {
+    return fsp ? 'time(' + this._num(fsp) + ')' : 'time'
+  },
 
-  timestamp: 'timestamp',
+  datetime: function(fsp) {
+    return fsp ? 'datetime(' + this._num(fsp) + ')' : 'datetime'
+  },
+
+  timestamp: function(fsp) {
+    return fsp ? 'timestamp(' + this._num(fsp) + ')' : 'timestamp'
+  },
 
   bit(length) {
     return length ? `bit(${this._num(length)})` : 'bit'

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -416,6 +416,15 @@ describe(dialect + " SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table `users` add `foo` datetime');
   });
 
+  it('uses the datetime column fractional seconds part', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.dateTime('foo', 6);
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table `users` add `foo` datetime(6)');
+  });
+
   it('test adding time', function() {
     tableSql = client.schemaBuilder().table('users', function() {
       this.time('foo');
@@ -425,6 +434,15 @@ describe(dialect + " SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table `users` add `foo` time');
   });
 
+  it('uses the time column fractional seconds part', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.time('foo', 6);
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table `users` add `foo` time(6)');
+  });
+
   it('test adding time stamp', function() {
     tableSql = client.schemaBuilder().table('users', function() {
       this.timestamp('foo');
@@ -432,6 +450,15 @@ describe(dialect + " SchemaBuilder", function() {
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal('alter table `users` add `foo` timestamp');
+  });
+
+  it('uses the timestamp column fractional seconds part', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.timestamp('foo', 6);
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table `users` add `foo` timestamp(6)');
   });
 
   it('test adding time stamps', function() {


### PR DESCRIPTION
Hi, just a small change to allow setting the fractional second part to datetime columns in mysql.

e.g.
table.datetime('created_at', 6)

will allow

```
mysql> select created_at from users;
+----------------------------+
| created_at                 |
+----------------------------+
| 2016-05-15 16:56:24.831000 |
+----------------------------+
```
