### PR TITLE
Read `version` from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "coveralls": "~2.11.1",
     "istanbul": "~0.3.0",
     "jshint": "^2.9.2",
+    "json-loader": "^0.5.4",
     "mariasql": "^0.2.3",
     "mocha": "^2.2.4",
     "mssql": "^2.3.2",
@@ -42,7 +43,8 @@
     "sqlite3": "^3.0.5",
     "tap-spec": "^4.0.0",
     "tape": "^4.0.0",
-    "through": "^2.3.4"
+    "through": "^2.3.4",
+    "webpack": "^1.13.0"
   },
   "scripts": {
     "dev": "babel -L -D -w src/ --out-dir lib/",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,10 +1,5 @@
 #!/bin/bash -e
 
-npm install webpack@1.8.11
-
-webpack=node_modules/.bin/webpack
-babel=node_modules/.bin/babel
-
 rm -rf tmp
 mkdir tmp
 rm -rf build
@@ -12,13 +7,13 @@ mkdir build
 
 rm -rf lib
 mkdir lib
-babel -D src/ --out-dir lib/
+npm run babel
 
 cp -r lib tmp/lib
 cp knex.js tmp
 
 node -p 'p=require("./package");p.main="lib";p.scripts=p.devDependencies=undefined;JSON.stringify(p,null,2)' > tmp/package.json
 
-$webpack --config scripts/webpack.config.js tmp build/knex.js
+$(npm bin)/webpack --config scripts/webpack.config.js tmp build/knex.js
 
 rm -rf tmp

--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -23,6 +23,12 @@ module.exports = {
     libraryTarget: 'umd'
   },
 
+  module: {
+    loaders: [{
+      test: /\.json$/, loader: 'json-loader'
+    }]
+  },
+
   externals: externals,
 
   plugins: plugins

--- a/src/util/make-knex.js
+++ b/src/util/make-knex.js
@@ -57,7 +57,7 @@ module.exports = function makeKnex(client) {
 
   // The `__knex__` is used if you need to duck-type check whether this
   // is a knex builder, without a full on `instanceof` check.
-  knex.VERSION = knex.__knex__  = '0.11.3'
+  knex.VERSION = knex.__knex__  = require('../../package.json').version;
 
   // Hook up the "knex" object as an EventEmitter.
   var ee = new EventEmitter()


### PR DESCRIPTION
Means that it's impossible to have `Knex#VERSION` and the version in `package.json` out of sync. This is one less thing to do for release.

This required the addition of `json-loader` for webpack. I've also added webpack to `devDependencies` rather than installing it manually during the `build` script.