### PR TITLE
Use calling transaction with batchInsert

### DIFF
--- a/src/util/batchInsert.js
+++ b/src/util/batchInsert.js
@@ -19,6 +19,10 @@ export default class BatchInsert {
     this._returning = void 0;
     this._transaction = null;
     this._autoTransaction = true;
+
+    if (client.transacting) {
+      this.transacting(client);
+    }
   }
 
   /**

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -702,6 +702,15 @@ module.exports = function(knex) {
         })
       });
 
+      it('transaction.batchInsert using specified transaction', function() {
+        return knex.transaction(function(tr) {
+          tr.batchInsert('BatchInsert', items, 30)
+          .returning(['Col1', 'Col2'])
+          .then(tr.commit)
+          .catch(tr.rollback);
+        })
+      });
+
     });
 
     it('should validate batchInsert batchSize parameter', function() {


### PR DESCRIPTION
Updates `batchInsert` so that it will use the existing transaction which calls it.
```js
// Existing method for using a transaction with batchInsert
knex.batchInsert(data).transacting(trx);

// New method
trx.batchInsert(data);
```
Implements a change discussed in #1354 