### PR TITLE
Add SQL Anywhere dialect support.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ You can optionally specify which dialects to test using the `DB` environment var
 * maria
 * oracle
 * mssql
+* sqlanywhere
 
 ```bash
 $ DB='postgres mysql' npm test

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Gitter chat
 
 A SQL query builder that is flexible, portable, and fun to use!
 
-A batteries-included, multi-dialect (MySQL, PostgreSQL, SQLite3, WebSQL, Oracle) query builder for
+A batteries-included, multi-dialect (MySQL, PostgreSQL, SQLite3, WebSQL, Oracle, SQL Anywhere) query builder for
 Node.js and the Browser, featuring:
 
 - [transactions](http://knexjs.org/#Transactions)

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "mariadb",
     "sqlite3",
     "oracle",
+    "sqlanywhere",
     "mssql"
   ],
   "author": {
@@ -90,6 +91,7 @@
     "mariasql": false,
     "pg": false,
     "pg-query-stream": false,
+    "sqlanywhere": false,
     "oracle": false,
     "strong-oracle": false,
     "sqlite3": false

--- a/src/dialects/sqlanywhere/formatter.js
+++ b/src/dialects/sqlanywhere/formatter.js
@@ -1,0 +1,28 @@
+
+var inherits        = require('inherits')
+var Formatter       = require('../../formatter')
+
+import {assign} from 'lodash'
+
+function Sqlanywhere_Formatter(client) {
+  Formatter.call(this, client)
+}
+inherits(Sqlanywhere_Formatter, Formatter)
+
+assign(Sqlanywhere_Formatter.prototype, {
+
+  alias: function(first, second) {
+    return first + ' ' + second;
+  },
+
+  parameter: function(value, notSetValue) {
+    // Returning helper uses always ROWID as string
+    if (typeof value === 'boolean') {
+      value = value ? 1 : 0
+    }
+    return Formatter.prototype.parameter.call(this, value, notSetValue)
+  }
+
+})
+
+module.exports = Sqlanywhere_Formatter

--- a/src/dialects/sqlanywhere/index.js
+++ b/src/dialects/sqlanywhere/index.js
@@ -1,0 +1,160 @@
+
+// Sqlanywhere Client
+// -------
+import {assign, map, flatten, values} from 'lodash'
+
+var inherits  = require('inherits')
+var Formatter = require('./formatter')
+var Client    = require('../../client')
+var Promise   = require('../../promise')
+var helpers   = require('../../helpers')
+
+var Transaction       = require('./transaction')
+var QueryCompiler     = require('./query/compiler')
+var SchemaCompiler    = require('./schema/compiler')
+var ColumnBuilder     = require('./schema/columnbuilder')
+var ColumnCompiler    = require('./schema/columncompiler')
+var TableCompiler     = require('./schema/tablecompiler')
+var ReturningHelper   = require('./utils').ReturningHelper
+var prepareValue      = require('./utils').prepareValue
+
+// Always initialize with the "QueryBuilder" and "QueryCompiler"
+// objects, which extend the base 'lib/query/builder' and
+// 'lib/query/compiler', respectively.
+function Client_Sqlanywhere(config) {
+  Client.call(this, config)
+}
+inherits(Client_Sqlanywhere, Client)
+
+assign(Client_Sqlanywhere.prototype, {
+
+  dialect: 'sqlanywhere',
+
+  driverName: 'sqlanywhere',
+
+  _driver: function() {
+    return require('sqlanywhere')
+  },
+
+  Transaction: Transaction,
+
+  Formatter: Formatter,
+
+  QueryCompiler: QueryCompiler,
+
+  SchemaCompiler: SchemaCompiler,
+
+  ColumnBuilder: ColumnBuilder,
+
+  ColumnCompiler: ColumnCompiler,
+
+  TableCompiler: TableCompiler,
+
+  prepBindings: function(bindings) {
+    return map(bindings, (value) => {
+      // returning helper uses always ROWID as string
+      if (value instanceof ReturningHelper && this.driver) {
+        return new this.driver.OutParam(this.driver.OCCISTRING)
+      }
+      return prepareValue( value )
+    })
+  },
+
+  // Get a raw connection, called by the `pool` whenever a new
+  // connection needs to be added to the pool.
+  acquireRawConnection: function() {
+    var client = this
+    return new Promise(function(resolver, rejecter) {
+      var connection = client.driver.createConnection();
+      connection.connect(client.connectionSettings,
+        function(err) {
+          if (err) return rejecter(err)
+          Promise.promisifyAll(connection)
+          connection.execAsync( "set temporary option auto_commit = 'on'" )
+            .then( function() {
+              resolver(connection)
+            }, rejecter );
+        })
+    })
+  },
+
+  // Used to explicitly close a connection, called internally by the pool
+  // when a connection times out or the pool is shutdown.
+  destroyRawConnection: function(connection, cb) {
+    connection.disconnect( cb )
+  },
+
+  // Return the database for the Sqlanywhere client.
+  database: function() {
+    return this.connectionSettings.dbn || this.connectionSettings.DatabaseName
+  },
+
+  _stream: function(connection, sql, stream/*, options*/) {
+    var client = this;
+    return new Promise(function(resolver, rejecter) {
+      stream.on('error', rejecter)
+      stream.on('end', resolver)
+      return client._query(connection, sql).then(function(obj) {
+        return obj.response
+      }).map(function(row) {
+        stream.write(row)
+      }).catch(function(err) {
+        stream.emit('error', err)
+        rejecter();
+      }).then(function() {
+        stream.end()
+        resolver();
+      })
+    })
+  },
+
+  // Runs the query on the specified connection, providing the bindings
+  // and any other necessary prep work.
+  _query: function(connection, obj) {
+    if (!obj.sql) throw new Error('The query is empty');
+
+    var ret = obj.bindings ? connection.execAsync(obj.sql, obj.bindings) : connection.execAsync(obj.sql);
+
+    return ret.then(function(response) {
+      obj.response = response;
+      return obj
+    })
+
+  },
+
+  // Process the response as returned from the query.
+  processResponse: function(obj, runner) {
+    var response = obj.response;
+    var method   = obj.method;
+    if (obj.output) return obj.output.call(runner, response);
+    switch (method) {
+      case 'select':
+      case 'pluck':
+      case 'first':
+        response = helpers.skim(response);
+        if (obj.method === 'pluck') response = map(response, obj.pluck);
+        return obj.method === 'first' ? response[0] : response;
+      case 'insert':
+      case 'del':
+      case 'update':
+      case 'counter':
+        if (obj.returning) {
+          if (obj.returning.length > 1 || obj.returning[0] === '*') {
+            return response;
+          }
+          // return an array with values if only one returning value was specified
+          return flatten(map(response, values));
+        }
+        return response;
+      default:
+        return response;
+    }
+  },
+
+  ping: function(resource, callback) {
+    resource.exec('SELECT 1', [], callback);
+  }
+
+})
+
+module.exports = Client_Sqlanywhere

--- a/src/dialects/sqlanywhere/query/compiler.js
+++ b/src/dialects/sqlanywhere/query/compiler.js
@@ -1,0 +1,201 @@
+
+// Sqlanywhere Query Builder & Compiler
+// ------
+import {assign, reduce, compact} from 'lodash'
+var inherits        = require('inherits');
+var QueryCompiler   = require('../../../query/compiler');
+
+// Query Compiler
+// -------
+
+// Set the "Formatter" to use for the queries,
+// ensuring that all parameterized values (even across sub-queries)
+// are properly built into the same query.
+function QueryCompiler_Sqlanywhere(client, builder) {
+  QueryCompiler.call(this, client, builder)
+}
+inherits(QueryCompiler_Sqlanywhere, QueryCompiler)
+
+assign(QueryCompiler_Sqlanywhere.prototype, {
+
+  _selectOverDML: function( dml, columns ) {
+    if (!columns) {
+        return dml;
+    }
+    if (!Array.isArray(columns)) {
+      columns = [columns];
+    }
+
+    return {
+      sql: 'select ' + this.formatter.columnize(columns) + ' from (' + dml + ') referencing (final as t_final)',
+      returning: columns
+    }
+  },
+
+  // Compiles an "insert" query, allowing for multiple
+  // inserts using a single query statement.
+  insert: function() {
+    var returning = this.single.returning;
+
+    var insertValues = this.single.insert || [];
+    var insertData = this._prepInsert(insertValues);
+    var multiRow = (insertData.values && insertData.values.length > 1);
+
+    var sql = '';
+    if (returning && multiRow) {
+      var sqls = [];
+      var origValues = insertValues;
+      if (!Array.isArray(insertValues)) {
+        insertValues = [insertValues];
+      }
+      var i = -1;
+      while (++i < insertValues.length) {
+        this.single.insert = insertValues[i];
+        sqls.push( this.insert().sql );
+      }
+      this.single.insert = origValues;
+
+      if (!Array.isArray(returning)) {
+        returning = [returning];
+      }
+
+      return {
+        sql: sqls.join( ' union all ' ),
+        returning: returning
+      }
+    }
+
+    sql = QueryCompiler.prototype.insert.call(this)
+    if (sql === '') return sql;
+    return this._selectOverDML( sql, returning );
+  },
+
+  // Update method, including joins, wheres, order & limits.
+  update: function() {
+    var sql = QueryCompiler.prototype.update.call(this)
+    if (sql === '') return sql;
+    return this._selectOverDML( sql, this.single.returning );
+  },
+
+  // Compiles a `truncate` query.
+  truncate: function() {
+    return 'truncate table ' + this.tableName;
+  },
+
+  forUpdate: function() {
+    return 'for update';
+  },
+
+  forShare: function() {
+    return 'for read only';
+  },
+
+  // Compiles a `columnInfo` query.
+  columnInfo: function() {
+    var column = this.single.columnInfo;
+    return {
+      sql: 'select COLUMN_NAME, DOMAIN_NAME, WIDTH, NULLS, "DEFAULT" from SYS.SYSTABCOL C join SYS.SYSTAB T on C.TABLE_ID = T.TABLE_ID join SYS.SYSDOMAIN D on C.DOMAIN_ID = D.DOMAIN_ID where TABLE_NAME = ?',
+      bindings: [this.single.table],
+      output: function(resp) {
+          var out = reduce(resp, function(columns, val) {
+          columns[val.COLUMN_NAME] = {
+            type: val.DOMAIN_NAME,
+            maxLength: val.WIDTH,
+            nullable: (val.NULLS === 'Y')
+          };
+          if (val.DEFAULT !== null) {
+            columns[val.COLUMN_NAME].defaultValue = val.DEFAULT;
+          }
+          return columns;
+        }, {});
+        return column && out[column] || out;
+      }
+    };
+  },
+
+  // Compiles the `select` statement, or nested sub-selects
+  // by calling each of the component compilers, trimming out
+  // the empties, and returning a generated query string.
+  select: function() {
+    var i = -1, statements = [];
+    while (++i < components.length) {
+      statements.push(this[components[i]](this));
+    }
+    return compact(statements).join(' ');
+  },
+
+  limit: function() {
+    var limit = this.single.lmit;
+    var noLimit = !limit && limit !== 0;
+    if(this.single.offset && noLimit) {
+      noLimit = false;
+      limit = 1234;
+    }
+    if (noLimit) return '';
+    return 'top ' + this.formatter.parameter(limit) + ' ';
+  },
+
+  offset: function() {
+    if (!this.single.offset) return '';
+    return 'start at ' + this.formatter.parameter(this.single.offset) + ' ';
+  },
+
+  columns: function() {
+    var distinct = false;
+    if (this.onlyUnions()) return ''
+    var columns = this.grouped.columns || []
+    var i = -1, sql = [];
+    if (columns) {
+      while (++i < columns.length) {
+        var stmt = columns[i];
+        if (stmt.distinct) distinct = true
+        if (stmt.type === 'aggregate') {
+          sql.push(this.aggregate(stmt))
+        }
+        else if (stmt.value && stmt.value.length > 0) {
+          sql.push(this.formatter.columnize(stmt.value))
+        }
+      }
+    }
+    if (sql.length === 0) sql = ['*'];
+    return 'select ' + (distinct ? 'distinct ' : '') +
+      this.limit() + this.offset() +
+      sql.join(', ') + (this.tableName ? ' from ' + this.tableName : '');
+  },
+
+  aggregate: function(stmt) {
+    var val = stmt.value;
+    var splitOn = val.toLowerCase().indexOf(' as ');
+    var distinct = stmt.aggregateDistinct ? 'distinct ' : '';
+    // Allows us to speciy an alias for the aggregate types.
+    if (splitOn !== -1) {
+      var col = val.slice(0, splitOn);
+      var alias = val.slice(splitOn + 4);
+      return stmt.method + '(' + distinct + this.formatter.wrap(col) + ') ' + this.formatter.wrap(alias);
+    }
+    return stmt.method + '(' + distinct + this.formatter.wrap(val) + ')';
+  },
+
+  multiWhereIn: function(statement) {
+    var i = -1, sql = 'ROW(' + this.formatter.columnize(statement.column) + ') '
+    sql += this._not(statement, 'in ') + '(ROW('
+    while (++i < statement.value.length) {
+      if (i !== 0) sql += '),ROW('
+      sql += this.formatter.parameterize(statement.value[i])
+    }
+    return sql + '))'
+  },
+
+})
+
+// Compiles the `select` statement, or nested sub-selects
+// by calling each of the component compilers, trimming out
+// the empties, and returning a generated query string.
+QueryCompiler_Sqlanywhere.prototype.first = QueryCompiler_Sqlanywhere.prototype.select
+
+var components = [
+  'columns', 'join', 'where', 'union', 'group', 'having', 'order', 'lock'
+];
+
+
+module.exports = QueryCompiler_Sqlanywhere;

--- a/src/dialects/sqlanywhere/schema/columnbuilder.js
+++ b/src/dialects/sqlanywhere/schema/columnbuilder.js
@@ -1,0 +1,19 @@
+
+var inherits      = require('inherits');
+var ColumnBuilder = require('../../../schema/columnbuilder');
+
+import {toArray} from 'lodash'
+
+function ColumnBuilder_Sqlanywhere() {
+  ColumnBuilder.apply(this, arguments);
+}
+inherits(ColumnBuilder_Sqlanywhere, ColumnBuilder);
+
+// checkIn added to the builder to allow the column compiler to change the
+// order via the modifiers ("check" must be after "default")
+ColumnBuilder_Sqlanywhere.prototype.checkIn = function () {
+  this._modifiers.checkIn = toArray(arguments);
+  return this;
+};
+
+module.exports = ColumnBuilder_Sqlanywhere

--- a/src/dialects/sqlanywhere/schema/columncompiler.js
+++ b/src/dialects/sqlanywhere/schema/columncompiler.js
@@ -1,0 +1,115 @@
+
+import {assign, uniq, map} from 'lodash'
+var inherits       = require('inherits')
+var Raw            = require('../../../raw')
+var ColumnCompiler = require('../../../schema/columncompiler')
+
+// Column Compiler
+// -------
+
+function ColumnCompiler_Sqlanywhere() {
+  this.modifiers = ['defaultTo', 'checkIn', 'nullable', 'comment'];
+  ColumnCompiler.apply(this, arguments);
+}
+inherits(ColumnCompiler_Sqlanywhere, ColumnCompiler);
+
+assign(ColumnCompiler_Sqlanywhere.prototype, {
+
+  increments: function () {
+    return 'integer not null primary key default autoincrement';
+  },
+
+  bigincrements: function () {
+    return 'bigint not null primary key default autoincrement';
+  },
+
+  floating: function(precision) {
+    var parsedPrecision = this._num(precision, 0);
+    return 'float' + (parsedPrecision ? '(' + parsedPrecision + ')' : '');
+  },
+
+  double: function(precision, scale) {
+    if (!precision) return 'double';
+    return 'numeric(' + this._num(precision, 8) + ', ' + this._num(scale, 2) + ')';
+  },
+
+  integer: function(length) {
+      return length ? 'numeric(' + this._num(length, 11) + ', 0)' : 'integer';
+  },
+
+  tinyint: 'tinyint',
+
+  smallint: 'smallint',
+
+  mediumint: 'integer',
+
+  biginteger: 'bigint',
+
+  text: 'long varchar',
+   
+  binary: 'long binary',
+
+  enu: function (allowed) {
+    allowed = uniq(allowed);
+    var maxLength = (allowed || []).reduce(function (maxLength, name) {
+      return Math.max(maxLength, String(name).length);
+    }, 1);
+
+    // implicitly add the enum values as checked values
+    this.columnBuilder._modifiers.checkIn = [allowed];
+
+    return "varchar(" + maxLength + ")";
+  },
+
+  time: 'timestamp with time zone',
+
+  datetime: function(without) {
+    return without ? 'timestamp' : 'timestamp with time zone';
+  },
+
+  timestamp: function(without) {
+    return without ? 'timestamp' : 'timestamp with time zone';
+  },
+
+  bit: 'bit',
+
+  json: 'long varchar',
+
+  bool: function () {
+    return 'bit';
+  },
+
+  varchar: function(length) {
+    return 'varchar(' + this._num(length, 255) + ')';
+  },
+
+  // Modifiers
+  // ------
+
+  comment: function(comment) {
+    this.pushAdditional(function() {
+      this.pushQuery('comment on column ' + this.tableCompiler.tableName() + '.' +
+        this.formatter.wrap(this.args[0]) + " is '" + (comment || '')+ "'");
+    }, comment);
+  },
+
+  checkIn: function (value) {
+    // TODO: Maybe accept arguments also as array
+    // TODO: value(s) should be escaped properly
+    if (value === undefined) {
+      return '';
+    } else if (value instanceof Raw) {
+      value = value.toQuery();
+    } else if (Array.isArray(value)) {
+      value = map(value, function (v) {
+        return "'" + v + "'";
+      }).join(', ');
+    } else {
+      value = "'" + value + "'";
+    }
+    return 'check (' + this.formatter.wrap(this.args[0]) + ' in (' + value + '))';
+  }
+
+});
+
+module.exports = ColumnCompiler_Sqlanywhere;

--- a/src/dialects/sqlanywhere/schema/compiler.js
+++ b/src/dialects/sqlanywhere/schema/compiler.js
@@ -1,0 +1,47 @@
+
+// Sqlanywhere Schema Compiler
+// -------
+var inherits       = require('inherits');
+var SchemaCompiler = require('../../../schema/compiler');
+
+function SchemaCompiler_Sqlanywhere() {
+  SchemaCompiler.apply(this, arguments);
+}
+inherits(SchemaCompiler_Sqlanywhere, SchemaCompiler);
+
+// Rename a table on the schema.
+SchemaCompiler_Sqlanywhere.prototype.renameTable = function(tableName, to) {
+  this.pushQuery('alter table ' + this.formatter.wrap(tableName) + ' rename ' + this.formatter.wrap(to));
+};
+
+// Check whether a table exists on the query.
+SchemaCompiler_Sqlanywhere.prototype.hasTable = function(tableName) {
+  this.pushQuery({
+    sql: 'select TABLE_NAME from SYS.SYSTABLE where TABLE_NAME = ' +
+      this.formatter.parameter(tableName),
+    output: function(resp) {
+      return resp.length > 0;
+    }
+  });
+};
+
+// Check whether a column exists on the schema.
+SchemaCompiler_Sqlanywhere.prototype.hasColumn = function(tableName, column) {
+  this.pushQuery({
+    sql: 'select COLUMN_NAME from SYS.SYSTABCOL C join SYS.SYSTAB T on C.TABLE_ID = T.TABLE_ID where TABLE_NAME = ' + this.formatter.parameter(tableName) +
+      ' and COLUMN_NAME = ' + this.formatter.parameter(column),
+    output: function(resp) {
+      return resp.length > 0;
+    }
+  });
+};
+
+SchemaCompiler_Sqlanywhere.prototype.dropTable = function (tableName) {
+  this.pushQuery('drop table ' + this.formatter.wrap(tableName));
+};
+
+SchemaCompiler_Sqlanywhere.prototype.dropTableIfExists = function(tableName) {
+  this.pushQuery('drop table if exists ' + this.formatter.wrap(tableName));
+};
+
+module.exports = SchemaCompiler_Sqlanywhere;

--- a/src/dialects/sqlanywhere/schema/tablecompiler.js
+++ b/src/dialects/sqlanywhere/schema/tablecompiler.js
@@ -1,0 +1,110 @@
+
+var inherits      = require('inherits');
+var utils         = require('../utils');
+var TableCompiler = require('../../../schema/tablecompiler');
+var helpers       = require('../../../helpers');
+
+import {assign} from 'lodash'
+
+// Table Compiler
+// ------
+
+function TableCompiler_Sqlanywhere() {
+  TableCompiler.apply(this, arguments);
+}
+inherits(TableCompiler_Sqlanywhere, TableCompiler);
+
+assign(TableCompiler_Sqlanywhere.prototype, {
+
+  // Compile a rename column command.
+  renameColumn: function(from, to) {
+    return this.pushQuery({
+      sql: 'alter table ' + this.tableName() + ' rename ' +
+        this.formatter.wrap(from) + ' to ' + this.formatter.wrap(to)
+    });
+  },
+
+  compileAdd: function(builder) {
+    var table = this.formatter.wrap(builder);
+    var columns = this.prefixArray('add column', this.getColumns(builder));
+    return this.pushQuery({
+      sql: 'alter table ' + table + ' ' + columns.join(', ')
+    });
+  },
+
+  // Adds the "create" query to the query sequence.
+  createQuery: function(columns, ifNot) {
+    var sql = 'create table ';
+    if( ifNot ) {
+      sql += 'if not exists ';   
+    }
+    sql += this.tableName() + ' (' + columns.sql.join(', ') + ')';
+    this.pushQuery({
+      sql: sql,
+      bindings: columns.bindings
+    });
+    if (this.single.comment) this.comment(this.single.comment);
+  },
+
+  // Compiles the comment on the table.
+  comment: function(comment) {
+    this.pushQuery('comment on table ' + this.tableName() + ' is ' + "'" + (comment || '') + "'");
+  },
+
+  addColumnsPrefix: 'add ',
+
+  dropColumn: function() {
+    var columns = helpers.normalizeArr.apply(null, arguments);
+    var sql = 'alter table ' + this.tableName();
+    var i = -1;
+    while( ++i < columns.length ) {
+       sql += ' drop ' + this.formatter.wrap(columns[i]);
+    }
+    this.pushQuery(sql);
+  },
+
+  changeType: function() {
+    // alter table + table + ' modify ' + wrapped + '// type';
+  },
+
+  _indexCommand: function(type, tableName, columns) {
+    return this.formatter.wrap(utils.generateCombinedName(type, tableName, columns));
+  },
+
+  primary: function(columns) {
+    this.pushQuery('alter table ' + this.tableName() + " add primary key (" + this.formatter.columnize(columns) + ")");
+  },
+
+  dropPrimary: function() {
+    this.pushQuery('alter table ' + this.tableName() + ' drop primary key');
+  },
+
+  index: function(columns, indexName) {
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
+    this.pushQuery('create index ' + indexName + ' on ' + this.tableName() +
+      ' (' + this.formatter.columnize(columns) + ')');
+  },
+
+  dropIndex: function(columns, indexName) {
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
+    this.pushQuery('drop index ' + indexName);
+  },
+
+  unique: function(columns, indexName) {
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, columns);
+    this.pushQuery('create unique index ' + indexName + ' on ' + this.tableName() + ' (' + this.formatter.columnize(columns) + ')');
+  },
+
+  dropUnique: function(columns, indexName) {
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, columns);
+    this.pushQuery('drop index ' + indexName);
+  },
+
+  dropForeign: function(columns, indexName) {
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('foreign', this.tableNameRaw, columns);
+    this.pushQuery('alter table ' + this.tableName() + ' drop constraint ' + indexName);
+  }
+
+})
+
+module.exports = TableCompiler_Sqlanywhere;

--- a/src/dialects/sqlanywhere/transaction.js
+++ b/src/dialects/sqlanywhere/transaction.js
@@ -1,0 +1,64 @@
+
+var inherits    = require('inherits')
+var Promise     = require('../../promise')
+var Transaction = require('../../transaction')
+var debugTx     = require('debug')('knex:tx')
+
+import {assign} from 'lodash'
+
+function Sqlanywhere_Transaction(client, container, config, outerTx) {
+  Transaction.call(this, client, container, config, outerTx)
+}
+inherits(Sqlanywhere_Transaction, Transaction)
+
+assign(Sqlanywhere_Transaction.prototype, {
+
+  // disable autocommit to allow correct behavior (default is on)
+  begin: function() {
+    return Promise.resolve()
+  },
+
+  commit: function(conn, value) {
+    this._completed = true
+    return conn.commitAsync()
+      .return(value)
+      .then(this._resolver, this._rejecter)
+  },
+
+  release: function(conn, value) {
+    return this._resolver(value)
+  },
+
+  rollback: function(conn, err) {
+    this._completed = true
+    debugTx('%s: rolling back', this.txid)
+    return conn.rollbackAsync()
+      .throw(err)
+      .catch(this._rejecter)
+  },
+
+  acquireConnection: function(config) {
+    var t = this
+    return Promise.try(function() {
+      return config.connection || t.client.acquireConnection()
+    }).tap(function(connection) {
+	if (!t.outerTx) {
+          return connection.execAsync( "set temporary option auto_commit = 'off'" )
+      }
+    }).disposer(function(connection) {
+      debugTx('%s: releasing connection', t.txid)
+      if (!t.outerTx ) {
+        return connection.execAsync( "set temporary option auto_commit = 'on'" ).then( function() {
+          if (!config.connection) {
+            t.client.releaseConnection(connection)
+          } else {
+            debugTx('%s: not releasing external connection', t.txid)
+          }
+        })
+      }
+    })
+  }
+
+})
+
+module.exports = Sqlanywhere_Transaction

--- a/src/dialects/sqlanywhere/utils.js
+++ b/src/dialects/sqlanywhere/utils.js
@@ -1,0 +1,90 @@
+
+var helpers = require('../../helpers');
+
+function generateCombinedName(postfix, name, subNames) {
+  var crypto = require('crypto');
+  var limit  = 128;
+  if (!Array.isArray(subNames)) subNames = subNames ? [subNames] : [];
+  var table = name.replace(/\.|-/g, '_');
+  var subNamesPart = subNames.join('_');
+  var result = (table + '_' + (subNamesPart.length ? subNamesPart + '_': '') + postfix).toLowerCase();
+  if (result.length > limit) {
+    helpers.warn('Automatically generated name "' + result + '" exceeds ' + limit + ' character limit for Sqlanywhere. Using base64 encoded sha1 of that name instead.');
+    // generates the sha1 of the name and encode it with base64
+    result = crypto.createHash('sha1')
+      .update(result)
+      .digest('base64')
+      .replace('=', '');
+  }
+  return result;
+}
+
+function ReturningHelper(columnName) {
+  this.columnName = columnName;
+}
+
+ReturningHelper.prototype.toString = function () {
+  return '[object ReturningHelper:' + this.columnName + ']';
+}
+
+function dateToString(date) {
+  function pad(number, digits) {
+    number = number.toString();
+    while (number.length < digits) {
+      number = "0" + number;
+    }
+    return number;
+  }
+
+  var offset = -date.getTimezoneOffset();
+  var ret = pad(date.getFullYear(), 4) + '-' +
+    pad(date.getMonth() + 1, 2) + '-' +
+    pad(date.getDate(), 2) + 'T' +
+    pad(date.getHours(), 2) + ':' +
+    pad(date.getMinutes(), 2) + ':' +
+    pad(date.getSeconds(), 2) + '.' +
+    pad(date.getMilliseconds(), 3);
+
+  if (offset < 0) {
+    ret += "-";
+    offset *= -1;
+  } else {
+    ret += "+";
+  }
+
+  return ret + pad(Math.floor(offset / 60), 2) + ":" + pad(offset % 60, 2);
+}
+
+// converts values from javascript types
+// to their 'raw' counterparts for use as a postgres parameter
+// note: you can override this function to provide your own conversion mechanism
+// for complex types, etc...
+var prepareValue = function (val/*, seen , valueForUndefined*/) {
+  if (val instanceof Buffer) {
+    return val;
+  }
+  if (val instanceof Date) {
+    return dateToString(val);
+  }
+  if (typeof val === 'boolean') {
+    return val ? 1 : 0;
+  }
+/*
+  if (Array.isArray(val)) {
+    return arrayString(val);
+  }
+  if (val === null) {
+    return null;
+  }
+  if (typeof val === 'object') {
+    return prepareObject(val, seen);
+  }
+*/
+  return val;
+};
+
+module.exports = {
+  generateCombinedName: generateCombinedName,
+  ReturningHelper: ReturningHelper,
+  prepareValue: prepareValue
+};

--- a/src/migrate/index.js
+++ b/src/migrate/index.js
@@ -289,8 +289,8 @@ export default class Migrator {
   // Returns the latest batch number.
   _latestBatchNumber() {
     return this.knex(this.config.tableName)
-      .max('batch as max_batch').then(function(obj) {
-        return (obj[0].max_batch || 0);
+	  .max('batch as max_batch').then(function(obj) {
+        return (obj.length > 0 ? (obj[0].max_batch || 0) : 0);
       });
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,7 @@ describe('Query Building Tests', function() {
   require('./unit/schema/sqlite3')
   require('./unit/schema/oracle')
   require('./unit/schema/mssql')
+  require('./unit/schema/sqlanywhere')
 })
 
 describe('Integration Tests', function() {

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -73,7 +73,10 @@ module.exports = function(knex) {
           })
         ])
         .spread(function(migration1, migration2) {
+          console.log( migration1 );
+          console.log( migration2 );
           return knex.migrate.status({directory: 'test/integration/migrate/test'}).then(function(migrationLevel) {
+            console.log( migrationLevel );
             expect(migrationLevel).to.equal(0);
           })
           .then(function() {
@@ -225,7 +228,7 @@ module.exports = function(knex) {
           // MySQL / Oracle commit transactions implicit for most common
           // migration statements (e.g. CREATE TABLE, ALTER TABLE, DROP TABLE),
           // so we need to check for dialect
-          if (knex.client.dialect === 'mysql' || knex.client.dialect === 'mariadb' || knex.client.dialect === 'oracle') {
+          if (knex.client.dialect === 'mysql' || knex.client.dialect === 'mariadb' || knex.client.dialect === 'oracle' || knex.client.dialect === 'sqlanywhere') {
             expect(exists).to.equal(true);
           } else {
             expect(exists).to.equal(false);
@@ -332,7 +335,7 @@ module.exports = function(knex) {
           // MySQL / Oracle commit transactions implicit for most common
           // migration statements (e.g. CREATE TABLE, ALTER TABLE, DROP TABLE),
           // so we need to check for dialect
-          if (knex.client.dialect === 'mysql' || knex.client.dialect === 'mariadb' || knex.client.dialect === 'oracle') {
+          if (knex.client.dialect === 'mysql' || knex.client.dialect === 'mariadb' || knex.client.dialect === 'oracle' || knex.client.dialect === 'sqlanywhere') {
             expect(exists).to.equal(true);
           } else {
             expect(exists).to.equal(false);

--- a/test/knexfile.js
+++ b/test/knexfile.js
@@ -129,6 +129,21 @@ var testConfigs = {
     pool: pool,
     migrations: migrations,
     seeds: seeds
+  },
+    
+  sqlanywhere: {
+    dialect: 'sqlanywhere',
+    connection: testConfig.sqlanywhere || {
+      uid: "knex_test",
+      pwd: "knex_test",
+      dbn: "knex_test",
+      dbf: __dirname + '/knex_test.db',
+      autostart: "YES",
+      start: "dbeng17"
+    },
+    pool: pool,
+    migrations: migrations,
+    seeds: seeds
   }
 };
 

--- a/test/tape/transactions.js
+++ b/test/tape/transactions.js
@@ -52,7 +52,8 @@ module.exports = function(knex) {
       // oracle & mssql: BEGIN & ROLLBACK not reported as queries
       var expectedQueryCount =
         knex.client.dialect === 'oracle' ||
-        knex.client.dialect === 'mssql' ? 1 : 3
+        knex.client.dialect === 'mssql' ||
+        knex.client.dialect === 'sqlanywhere' ? 1 : 3
       t.equal(trxQueryCount, expectedQueryCount, 'Expected number of transaction SQL queries executed')
       t.equal(trxRejected, true, 'Transaction promise rejected')
       return knex.select('*').from('test_table').then(function (results) {
@@ -80,7 +81,8 @@ module.exports = function(knex) {
       // oracle & mssql: BEGIN & ROLLBACK not reported as queries
       var expectedQueryCount =
         knex.client.dialect === 'oracle' ||
-        knex.client.dialect === 'mssql' ? 0 : 2
+        knex.client.dialect === 'mssql' ||
+        knex.client.dialect === 'sqlanywhere' ? 0 : 2
       t.equal(trxQueryCount, expectedQueryCount, 'Expected number of transaction SQL queries executed')
       t.equal(trxRejected, true, 'Transaction promise rejected')
     })
@@ -120,7 +122,8 @@ module.exports = function(knex) {
       // oracle & mssql: BEGIN & ROLLBACK not reported as queries
       var expectedTrx1QueryCount =
         knex.client.dialect === 'oracle' ||
-        knex.client.dialect === 'mssql' ? 1 : 3
+        knex.client.dialect === 'mssql' ||
+        knex.client.dialect === 'sqlanywhere' ? 1 : 3
       var expectedTrx2QueryCount = 4
       expectedTrx1QueryCount += expectedTrx2QueryCount
       t.equal(trx1QueryCount, expectedTrx1QueryCount, 'Expected number of parent transaction SQL queries executed')
@@ -161,7 +164,8 @@ module.exports = function(knex) {
       // oracle & mssql: BEGIN & ROLLBACK not reported as queries
       var expectedTrx1QueryCount =
         knex.client.dialect === 'oracle' ||
-        knex.client.dialect === 'mssql' ? 1 : 3
+        knex.client.dialect === 'mssql' ||
+        knex.client.dialect === 'sqlanywhere' ? 1 : 3
       var expectedTrx2QueryCount = 2
       expectedTrx1QueryCount += expectedTrx2QueryCount
       t.equal(trx1QueryCount, expectedTrx1QueryCount, 'Expected number of parent transaction SQL queries executed')
@@ -411,7 +415,8 @@ module.exports = function(knex) {
       // oracle & mssql: BEGIN & ROLLBACK not reported as queries
       var expectedQueryCount =
         knex.client.dialect === 'oracle' ||
-        knex.client.dialect === 'mssql' ? 1 : 3
+        knex.client.dialect === 'mssql' ||
+        knex.client.dialect === 'sqlanywhere' ? 1 : 3
       t.equal(queryCount, expectedQueryCount, 'Expected number of transaction SQL queries executed')
     })
 

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -7,12 +7,14 @@ var PG_Client      = require('../../../lib/dialects/postgres')
 var Oracle_Client  = require('../../../lib/dialects/oracle')
 var SQLite3_Client = require('../../../lib/dialects/sqlite3')
 var MSSQL_Client   = require('../../../lib/dialects/mssql')
+var Sqlanywhere_Client  = require('../../../lib/dialects/sqlanywhere')
 var Client         = require('../../../lib/client')
 
 var clients = {
   mysql:    new MySQL_Client({}),
   postgres: new PG_Client({}),
   oracle:   new Oracle_Client({}),
+  sqlanywhere:   new Sqlanywhere_Client({}),
   sqlite3:  new SQLite3_Client({}),
   mssql:  new MSSQL_Client({}),
   default:  new Client({})
@@ -23,6 +25,7 @@ var clientsWithNullAsDefault = {
   mysql:    new MySQL_Client(useNullAsDefaultConfig),
   postgres: new PG_Client(useNullAsDefaultConfig),
   oracle:   new Oracle_Client(useNullAsDefaultConfig),
+  sqlanywhere:   new Sqlanywhere_Client(useNullAsDefaultConfig),
   sqlite3:  new SQLite3_Client(useNullAsDefaultConfig),
   mssql:  new MSSQL_Client(useNullAsDefaultConfig),
   default:  new Client(useNullAsDefaultConfig)

--- a/test/unit/schema/sqlanywhere.js
+++ b/test/unit/schema/sqlanywhere.js
@@ -1,0 +1,486 @@
+/*global it, describe, expect*/
+
+'use strict';
+
+var Sqlanywhere_Client = require('../../../lib/dialects/sqlanywhere');
+var client        = new Sqlanywhere_Client({})
+
+describe("Sqlanywhere SchemaBuilder", function() {
+
+  var tableSql;
+  var equal = require('assert').equal;
+
+  it('test basic create table with charset and collate', function() {
+    tableSql = client.schemaBuilder().createTable('users', function(table) {
+      table.increments('id');
+      table.string('email');
+    });
+
+    equal(1, tableSql.toSQL().length);
+    expect(tableSql.toSQL()[0].sql).to.equal('create table "users" ("id" integer not null primary key default autoincrement, "email" varchar(255))');
+  });
+
+  it('test basic create table if not exists', function() {
+    tableSql = client.schemaBuilder().createTableIfNotExists('users', function(table) {
+      table.increments('id');
+      table.string('email');
+    });
+
+    equal(1, tableSql.toSQL().length);
+    expect(tableSql.toSQL()[0].sql).to.equal("create table if not exists \"users\" (\"id\" integer not null primary key default autoincrement, \"email\" varchar(255))");
+  });
+
+  it('test drop table', function() {
+    tableSql = client.schemaBuilder().dropTable('users').toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop table "users"');
+  });
+
+  it('test drop table if exists', function() {
+    tableSql = client.schemaBuilder().dropTableIfExists('users').toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop table if exists "users"');
+  });
+
+  it('test drop column', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.dropColumn('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop "foo"');
+  });
+
+  it('drops multiple columns with an array', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.dropColumn(['foo', 'bar']);
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop "foo" drop "bar"');
+  });
+
+  it('drops multiple columns as multiple arguments', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.dropColumn('foo', 'bar');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop "foo" drop "bar"');
+  });
+
+  it('test drop primary', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.dropPrimary();
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop primary key');
+  });
+
+  it('test drop unique', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.dropUnique('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index "users_foo_unique"');
+  });
+
+  it('test drop unique, custom', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.dropUnique(null, 'foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index "foo"');
+  });
+
+  it('test drop index', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.dropIndex('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index "users_foo_index"');
+  });
+
+  it('test drop index, custom', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.dropIndex(null, 'foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index "foo"');
+  });
+
+  it('test drop foreign', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.dropForeign('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint "users_foo_foreign"');
+  });
+
+  it('test drop foreign, custom', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.dropForeign(null, 'foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint "foo"');
+  });
+
+  it('test drop timestamps', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.dropTimestamps();
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop "created_at" drop "updated_at"');
+  });
+
+  it("rename table", function() {
+    tableSql = client.schemaBuilder().renameTable('users', 'foo').toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" rename "foo"');
+  });
+
+  it('test adding primary key', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.primary('foo', 'bar');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add primary key ("foo")');
+  });
+
+  it('test adding unique key', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.unique('foo', 'bar');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('create unique index "bar" on "users" ("foo")');
+  });
+
+  it('test adding index', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.index(['foo', 'bar'], 'baz');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('create index "baz" on "users" ("foo", "bar")');
+  });
+
+  it('test adding foreign key', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.foreign('foo_id').references('id').on('orders');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add constraint "users_foo_id_foreign" foreign key ("foo_id") references "orders" ("id")');
+  });
+
+  it("adds foreign key with onUpdate and onDelete", function() {
+    tableSql = client.schemaBuilder().createTable('person', function(table) {
+      table.integer('user_id').notNull().references('users.id').onDelete('SET NULL');
+      table.integer('account_id').notNull().references('id').inTable('accounts').onUpdate('cascade');
+    }).toSQL();
+    equal(3, tableSql.length);
+    expect(tableSql[1].sql).to.equal('alter table "person" add constraint "person_user_id_foreign" foreign key ("user_id") references "users" ("id") on delete SET NULL');
+    expect(tableSql[2].sql).to.equal('alter table "person" add constraint "person_account_id_foreign" foreign key ("account_id") references "accounts" ("id") on update cascade');
+  });
+
+  it('test adding incrementing id', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.increments('id');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "id" integer not null primary key default autoincrement');
+  });
+
+  it('test adding big incrementing id', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.bigIncrements('id');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "id" bigint not null primary key default autoincrement');
+  });
+
+  it('test rename column', function() {
+    tableSql = client.schemaBuilder().table('users', function () {
+      this.renameColumn('foo', 'bar');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" rename "foo" to "bar"');
+  });
+
+  it('test adding string', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.string('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" varchar(255)');
+  });
+
+  it('uses the varchar column constraint', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.string('foo', 100);
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" varchar(100)');
+  });
+
+  it('chains notNull and defaultTo', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.string('foo', 100).notNull().defaultTo('bar');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" varchar(100) default \'bar\' not null');
+  });
+
+  it('allows for raw values in the default field', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.string('foo', 100).nullable().defaultTo(client.raw('CURRENT TIMESTAMP'));
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" varchar(100) default CURRENT TIMESTAMP null');
+  });
+
+  it('test adding text', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.text('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" long varchar');
+  });
+
+  it('test adding big integer', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.bigInteger('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" bigint');
+  });
+
+  it('test adding integer', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.integer('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" integer');
+  });
+
+  it('test adding medium integer', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.mediumint('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" integer');
+  });
+
+  it('test adding small integer', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.smallint('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" smallint');
+  });
+
+  it('test adding tiny integer', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.tinyint('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" tinyint');
+  });
+
+  it('test adding default float', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.float('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" float');
+  });
+
+  it('test adding float with precision', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.float('foo', 5);
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" float(5)');
+  });
+
+  it('test adding double', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.double('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" double');
+  });
+
+  it('test adding double specifying precision', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.double('foo', 15, 8);
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" numeric(15, 8)');
+  });
+
+  it('test adding decimal', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.decimal('foo', 5, 2);
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" decimal(5, 2)');
+  });
+
+  it('test adding boolean', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.boolean('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" bit');
+  });
+
+  it('test adding enum', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.enum('foo', ['bar', 'baz']);
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" varchar(3) check ("foo" in (\'bar\', \'baz\'))');
+  });
+
+  it('test adding date', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.date('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" date');
+  });
+
+  it('test adding date time', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.dateTime('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" timestamp with time zone');
+  });
+
+  it('test adding date time without time zone', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.dateTime('foo', true);
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" timestamp');
+  });
+
+  it('test adding time', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.time('foo');
+    }).toSQL();
+
+    // sqlanywhere does not support time
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" timestamp with time zone');
+  });
+
+  it('test adding time stamp', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.timestamp('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" timestamp with time zone');
+  });
+
+  it('test adding time stamp without time zone', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.timestamp('foo', true);
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" timestamp');
+  });
+
+  it('test adding time stamps', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.timestamps();
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "created_at" timestamp with time zone, add "updated_at" timestamp with time zone');
+  });
+
+  it('test adding binary', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.binary('foo');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" long binary');
+  });
+
+  it('test adding decimal', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.decimal('foo', 2, 6);
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" decimal(2, 6)');
+  });
+
+  it('is possible to set raw statements in defaultTo, #146', function() {
+    tableSql = client.schemaBuilder().createTable('default_raw_test', function(t) {
+      t.timestamp('created_at').defaultTo(client.raw('CURRENT_TIMESTAMP'));
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('create table "default_raw_test" ("created_at" timestamp with time zone default CURRENT_TIMESTAMP)');
+  });
+
+  it('allows dropping a unique compound index with too long generated name', function() {
+    tableSql = client.schemaBuilder().table('composite_key_test', function(t) {
+      t.dropUnique(['column_a', 'column_b', 'column_c', 'column_d', 'column_e', 'column_f', 'column_g', 'column_h', 'column_i', 'column_j', 'column_k', 'column_l', 'column_m', 'column_n', 'column_o', 'column_p']);
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index "vv/UQHRTg8NBufYVs3xTGhuSa2Q"');
+  });
+
+  it('allows dropping a unique compound index with specified name', function() {
+    tableSql = client.schemaBuilder().table('composite_key_test', function(t) {
+      t.dropUnique(['column_a', 'column_b'], 'ckt_unique');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index "ckt_unique"');
+  });
+
+});


### PR DESCRIPTION
We have had a request from our users to be able to use knex with SQL Anywhere in Node.  I have written the dialect and the tests are all passing using SQL Anywhere 17.0.0 and the SQL Anywhere Node driver (npm install sqlanywhere).

To test:
- install SQL Anywhere 17 (developer edition download here: [http://scn.sap.com/community/developer-center/sql-anywhere](http://scn.sap.com/community/developer-center/sql-anywhere))
- source /opt/sqlanywhere17/bin64/sa_config.sh
- cd test
- dbinit -dba knex_test,knex_test knex_test.db
- cd ..
- DB='sqlanywhere' npm test
