### PR TITLE
Expose Knex version also on the constructor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,9 @@ export default function Knex(config) {
 // Expose Client on the main Knex namespace.
 Knex.Client = Client
 
+// Expose Knex version on the main Knex namespace.
+Knex.VERSION = require('../package.json').version
+
 // Run a "raw" query, though we can't do anything with it other than put
 // it in a query statement.
 Knex.raw = (sql, bindings) => new Raw({}).set(sql, bindings)

--- a/src/util/make-knex.js
+++ b/src/util/make-knex.js
@@ -8,6 +8,7 @@ import QueryInterface from '../query/methods';
 import * as helpers from '../helpers';
 import { assign } from 'lodash'
 import BatchInsert from './batchInsert';
+import Knex from "../index";
 
 export default function makeKnex(client) {
 
@@ -57,7 +58,7 @@ export default function makeKnex(client) {
 
   // The `__knex__` is used if you need to duck-type check whether this
   // is a knex builder, without a full on `instanceof` check.
-  knex.VERSION = knex.__knex__ = require('../../package.json').version;
+  knex.VERSION = knex.__knex__ = Knex.VERSION;
 
   // Hook up the "knex" object as an EventEmitter.
   const ee = new EventEmitter()

--- a/test/tape/knex.js
+++ b/test/tape/knex.js
@@ -3,6 +3,18 @@
 var knex = require('../../lib/index');
 var test = require('tape')
 
+test('it should have the same version as constructor has', function(t) {
+  t.plan(1)
+  var knexObj = knex({
+    database: 'dbname',
+    host: 'example.com',
+    password: 'password',
+    user: 'user'
+  })
+  t.equal(knexObj.VERSION, knex.VERSION)
+  knexObj.destroy()
+})
+
 test('it should parse the connection string', function(t) {
   t.plan(1)
   var knexObj = knex({


### PR DESCRIPTION
Previously only exposed on knex instance or read/parsed straight from `package.json`.

I suggest it would be more valuable than having it on knex instance. Its an improvement PR. So current API will remain the same.