### PR TITLE
Allow using custom Client/Dialect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ export default function Knex(config) {
   let Dialect;
   if (arguments.length === 0 || (!config.client && !config.dialect)) {
     Dialect = makeClient(Client)
-  } else if ((typeof config.client === 'object') && (config.client.prototype instanceof Client)) {
+  } else if (typeof config.client === 'object' && config.client.prototype instanceof Client) {
     Dialect = makeClient(config.client)
   } else {
     const clientName = config.client || config.dialect

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ export default function Knex(config) {
   let Dialect;
   if (arguments.length === 0 || (!config.client && !config.dialect)) {
     Dialect = makeClient(Client)
-  } else if (typeof config.client === 'object' && config.client.prototype instanceof Client) {
+  } else if (typeof config.client === 'function' && config.client.prototype instanceof Client) {
     Dialect = makeClient(config.client)
   } else {
     const clientName = config.client || config.dialect

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,8 @@ export default function Knex(config) {
   let Dialect;
   if (arguments.length === 0 || (!config.client && !config.dialect)) {
     Dialect = makeClient(Client)
+  } else if ((typeof config.client === 'object') && (config.client.prototype instanceof Client)) {
+    Dialect = makeClient(config.client)
   } else {
     const clientName = config.client || config.dialect
     Dialect = makeClient(require(`./dialects/${aliases[clientName] || clientName}/index.js`))

--- a/test/tape/knex.js
+++ b/test/tape/knex.js
@@ -23,18 +23,22 @@ test('it should allow to use proprietary dialect', function(t) {
   var Client = require('../../lib/dialects/mysql')
   var knexObj = knex({
     client: Client,
-    database: 'dbname',
-    host: 'example.com',
-    password: 'password',
-    user: 'user'
+    connection: {
+      database: 'dbname',
+      host: 'example.com',
+      password: 'password',
+      user: 'user'
+    }
   })
   t.ok(knexObj.client instanceof Client)
-  t.deepEqual(knexObj.client.config.connection, {
+  t.deepEqual(knexObj.client.config, {
     client: Client,
-    database: 'dbname',
-    host: 'example.com',
-    password: 'password',
-    user: 'user'
+    connection: {
+      database: 'dbname',
+      host: 'example.com',
+      password: 'password',
+      user: 'user'
+    }
   })
   knexObj.destroy()
 })
@@ -43,17 +47,21 @@ test('it should use knex suppoted dialect', function(t) {
   t.plan(1)
   var knexObj = knex({
     client: 'postgres',
-    database: 'dbname',
-    host: 'example.com',
-    password: 'password',
-    user: 'user'
+    connection: {
+      database: 'dbname',
+      host: 'example.com',
+      password: 'password',
+      user: 'user'
+    }
   })
-  t.deepEqual(knexObj.client.config.connection, {
+  t.deepEqual(knexObj.client.config, {
     client: 'postgres',
-    database: 'dbname',
-    host: 'example.com',
-    password: 'password',
-    user: 'user'
+    connection: {
+      database: 'dbname',
+      host: 'example.com',
+      password: 'password',
+      user: 'user'
+    }
   })
   knexObj.destroy()
 })

--- a/test/tape/knex.js
+++ b/test/tape/knex.js
@@ -17,3 +17,43 @@ test('it should parse the connection string', function(t) {
   })
   knexObj.destroy()
 })
+
+test('it should allow to use proprietary dialect', function(t) {
+  t.plan(2)
+  var Client = require('../../lib/dialects/mysql')
+  var knexObj = knex({
+    client: Client,
+    database: 'dbname',
+    host: 'example.com',
+    password: 'password',
+    user: 'user'
+  })
+  t.ok(knexObj.client instanceof Client)
+  t.deepEqual(knexObj.client.config.connection, {
+    client: Client,
+    database: 'dbname',
+    host: 'example.com',
+    password: 'password',
+    user: 'user'
+  })
+  knexObj.destroy()
+})
+
+test('it should use knex suppoted dialect', function(t) {
+  t.plan(1)
+  var knexObj = knex({
+    client: 'postgres',
+    database: 'dbname',
+    host: 'example.com',
+    password: 'password',
+    user: 'user'
+  })
+  t.deepEqual(knexObj.client.config.connection, {
+    client: 'postgres',
+    database: 'dbname',
+    host: 'example.com',
+    password: 'password',
+    user: 'user'
+  })
+  knexObj.destroy()
+})


### PR DESCRIPTION
Solve #1424

To oppose @rhys-vdw [note in #1424](https://github.com/tgriesser/knex/issues/1424#issuecomment-220247608).

I stand to my suggested solution. Client API is really much knex version dependent. If some version of knex would change the API, the plugin-client would stop working any way. So there is no point supporting any other soft verification.

Two tests added.
- One for currently present feature
- One for the new feature

As well PR #1427 merging with this PR would be welcomed.