### PR TITLE
Pass valueForUndefined also to transacting client. Fixes #1423

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -195,6 +195,7 @@ function makeTxClient(trx, client, connection) {
   trxClient.driver             = client.driver
   trxClient.connectionSettings = client.connectionSettings
   trxClient.transacting        = true
+  trxClient.valueForUndefined  = client.valueForUndefined
 
   trxClient.on('query', function(arg) {
     trx.emit('query', arg)

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -751,5 +751,31 @@ module.exports = function(knex) {
           return knex('accounts').delete().whereIn('id', results.map(function (row) { return row.id }));
         });
     });
+
+    it('#1423 should replace undefined keys in single insert with DEFAULT also in transacting query', function() {
+      if (knex.client.dialect === 'sqlite3') {
+        return true;
+      }
+      return knex.transaction(function(trx) {
+        return trx('accounts')
+          .insert({
+            last_name: 'First Item',
+            email:'findme@example.com',
+            logins: undefined,
+            about: 'Lorem ipsum Dolore labore incididunt enim.',
+            created_at: new Date(),
+            updated_at: new Date()
+          })
+          .then(function (results) {
+            return trx('accounts').where('email', 'findme@example.com');
+          })
+          .then(function (results) {
+            expect(results[0].logins).to.equal(1);
+            // cleanup to prevent needs for too much changes to other tests
+            return trx('accounts').delete().where('id', results[0].id);
+          });
+      });
+    });
+
   });
 };


### PR DESCRIPTION
I had no idea that transacting client didn't inherit root client completely, but is actually constructed from it. Related issue https://github.com/tgriesser/knex/issues/1423
