### PR TITLE
`.timeout(ms, {cancel: true})` to cancel query after timeout (only implemented for MySQL)

### DIFF
--- a/index.html
+++ b/index.html
@@ -605,13 +605,26 @@ pg('table').insert({a: 'b'}).returning('*').toString();
     </p>
 
     <p id="Builder-timeout">
-      <b class="header">timeout</b><code>.timeout(ms)</code>
+      <b class="header">timeout</b><code>.timeout(ms, options={cancel: boolean})</code>
       <br />
       Sets a timeout for the query and will throw a <tt>TimeoutError</tt> if the timeout is exceeded.
       The error contains information about the query, bindings, and the timeout that was set.
       Useful for complex queries that you want to make sure are not taking too long to execute.
+      <br /><br />
+      Optional second argument for passing options:
+
+      <ul>
+        <li><b>cancel</b>: if <tt>true</tt>, cancel query if timeout is reached. <b>NOTE:</b> only supported in MySQL and MariaDB for now.</li>
+      </ul>
     </p>
 
+<pre class="display">
+knex.select().from('books').timeout(1000)
+</pre>
+
+<pre class="display">
+knex.select().from('books').timeout(1000, {cancel: true}) // MySQL and MariaDB only
+</pre>
 
     <p id="Builder-select">
       <b class="header">select</b><code>.select([*columns])</code>

--- a/src/client.js
+++ b/src/client.js
@@ -265,6 +265,13 @@ assign(Client.prototype, {
   },
 
   canCancelQuery: false,
+
+  assertCanCancelQuery() {
+    if (!this.canCancelQuery) {
+      throw new Error("Query cancelling not supported for this dialect");
+    }
+  },
+
   cancelQuery() {
     throw new Error("Query cancelling not supported for this dialect")
   }

--- a/src/client.js
+++ b/src/client.js
@@ -262,6 +262,11 @@ assign(Client.prototype, {
 
   toString() {
     return '[object KnexClient]'
+  },
+
+  canCancelQuery: false,
+  cancelQuery() {
+    throw new Error("Query cancelling not supported for this dialect")
   }
 
 })

--- a/src/dialects/mysql/index.js
+++ b/src/dialects/mysql/index.js
@@ -136,17 +136,26 @@ assign(Client_MySQL.prototype, {
 
   canCancelQuery: true,
   cancelQuery(connectionToKill) {
-    return this.acquireConnection().completed
-      .then((conn) => {
-        return this.query(conn, {
-          method: 'raw',
-          sql: 'KILL ?',
-          bindings: [connectionToKill.threadId],
-          options: {},
-        })
-        .finally(() => {
-          this.releaseConnection(conn)
-        });
+    const acquiringConn = this.acquireConnection().completed
+    let conn = undefined;
+
+    // Error out if we can't acquire connection in time.
+    // Purposely not putting timeout on `KILL QUERY` execution because erroring
+    // early there would release the `connectionToKill` back to the pool with
+    // a `KILL QUERY` command yet to finish.
+    return acquiringConn
+      .timeout(100)
+      .then((conn) => this.query(conn, {
+        method: 'raw',
+        sql: 'KILL QUERY ?',
+        bindings: [connectionToKill.threadId],
+        options: {},
+      }))
+      .finally(() => {
+        // NOT returning this promise because we want to release the connection
+        // in a non-blocking fashion
+        acquiringConn
+          .then((conn) => this.releaseConnection(conn));
       });
   }
 

--- a/src/dialects/mysql/index.js
+++ b/src/dialects/mysql/index.js
@@ -135,6 +135,7 @@ assign(Client_MySQL.prototype, {
   },
 
   canCancelQuery: true,
+
   cancelQuery(connectionToKill) {
     const acquiringConn = this.acquireConnection().completed
     let conn = undefined;

--- a/src/dialects/mysql/index.js
+++ b/src/dialects/mysql/index.js
@@ -132,6 +132,22 @@ assign(Client_MySQL.prototype, {
 
   ping(resource, callback) {
     resource.query('SELECT 1', callback);
+  },
+
+  canCancelQuery: true,
+  cancelQuery(connectionToKill) {
+    return this.acquireConnection().completed
+      .then((conn) => {
+        return this.query(conn, {
+          method: 'raw',
+          sql: 'KILL ?',
+          bindings: [connectionToKill.threadId],
+          options: {},
+        })
+        .finally(() => {
+          this.releaseConnection(conn)
+        });
+      });
   }
 
 })

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -57,9 +57,16 @@ assign(Builder.prototype, {
     return cloned;
   },
 
-  timeout(ms) {
+  timeout(ms, {cancel} = {}) {
     if(isNumber(ms) && ms > 0) {
       this._timeout = ms;
+      if (cancel) {
+        if (this.client.canCancelQuery) {
+          this._cancelOnTimeout = true;
+        } else {
+          throw new Error("Query cancelling not supported for this dialect");
+        }
+      }
     }
     return this;
   },

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -61,11 +61,8 @@ assign(Builder.prototype, {
     if(isNumber(ms) && ms > 0) {
       this._timeout = ms;
       if (cancel) {
-        if (this.client.canCancelQuery) {
-          this._cancelOnTimeout = true;
-        } else {
-          throw new Error("Query cancelling not supported for this dialect");
-        }
+        this.client.assertCanCancelQuery();
+        this._cancelOnTimeout = true;
       }
     }
     return this;

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -19,6 +19,7 @@ function QueryCompiler(client, builder) {
   this.options = builder._options;
   this.single = builder._single;
   this.timeout = builder._timeout || false;
+  this.cancelOnTimeout = builder._cancelOnTimeout || false;
   this.grouped = groupBy(builder._statements, 'grouping');
   this.formatter = client.formatter()
 }
@@ -41,6 +42,7 @@ assign(QueryCompiler.prototype, {
       method,
       options: reduce(this.options, assign, {}),
       timeout: this.timeout,
+      cancelOnTimeout: this.cancelOnTimeout,
       bindings: this.formatter.bindings
     };
     if (isString(val)) {

--- a/src/raw.js
+++ b/src/raw.js
@@ -30,9 +30,16 @@ assign(Raw.prototype, {
     return this
   },
 
-  timeout(ms) {
+  timeout(ms, {cancel} = {}) {
     if(isNumber(ms) && ms > 0) {
       this._timeout = ms;
+      if (cancel) {
+        if (this.client.canCancelQuery) {
+          this._cancelOnTimeout = true;
+        } else {
+          throw new Error("Query cancelling not supported for this dialect");
+        }
+      }
     }
     return this;
   },
@@ -73,6 +80,9 @@ assign(Raw.prototype, {
     this._cached.options = reduce(this._options, assign, {})
     if(this._timeout) {
       this._cached.timeout = this._timeout;
+      if (this._cancelOnTimeout) {
+        this._cached.cancelOnTimeout = this._cancelOnTimeout;
+      }
     }
     if(this.client && this.client.prepBindings) {
       this._cached.bindings = this.client.prepBindings(this._cached.bindings || [], tz);

--- a/src/raw.js
+++ b/src/raw.js
@@ -34,11 +34,8 @@ assign(Raw.prototype, {
     if(isNumber(ms) && ms > 0) {
       this._timeout = ms;
       if (cancel) {
-        if (this.client.canCancelQuery) {
-          this._cancelOnTimeout = true;
-        } else {
-          throw new Error("Query cancelling not supported for this dialect");
-        }
+        this.client.assertCanCancelQuery();
+        this._cancelOnTimeout = true;
       }
     }
     return this;

--- a/src/runner.js
+++ b/src/runner.js
@@ -145,7 +145,15 @@ assign(Runner.prototype, {
         }
 
         return cancelQuery
+          .catch((cancelError) => {
+            // cancellation failed
+            throw assign(cancelError, {
+              message: `After query timeout of ${timeout}ms exceeded, cancelling of query failed.`,
+              sql, bindings, timeout
+            });
+          })
           .then(() => {
+            // cancellation succeeded, rethrow timeout error
             throw assign(error, {
               message: `Defined query timeout of ${timeout}ms exceeded when running query.`,
               sql, bindings, timeout

--- a/src/runner.js
+++ b/src/runner.js
@@ -136,10 +136,21 @@ assign(Runner.prototype, {
         return processedResponse;
       }).catch(Promise.TimeoutError, error => {
         const { timeout, sql, bindings } = obj;
-        throw assign(error, {
-          message: `Defined query timeout of ${timeout}ms exceeded when running query.`,
-          sql, bindings, timeout
-        });
+
+        let cancelQuery;
+        if (obj.cancelOnTimeout) {
+          cancelQuery = this.client.cancelQuery(this.connection);
+        } else {
+          cancelQuery = Promise.resolve();
+        }
+
+        return cancelQuery
+          .then(() => {
+            throw assign(error, {
+              message: `Defined query timeout of ${timeout}ms exceeded when running query.`,
+              sql, bindings, timeout
+            });
+          });
       })
       .catch((error) => {
         this.builder.emit('query-error', error, assign({__knexUid: this.connection.__knexUid}, obj))

--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -348,7 +348,7 @@ module.exports = function(knex) {
       }
 
       // Only mysql/mariadb query cancelling supported for now
-      if (!dialect.startsWith("mysql") && !dialect.startsWith("maria")) {
+      if (!_.startsWith(dialect, "mysql") && !_.startsWith(dialect, "maria")) {
         expect(addTimeout).to.throw("Query cancelling not supported for this dialect");
         return;
       }
@@ -380,7 +380,7 @@ module.exports = function(knex) {
     it('.timeout(ms, {cancel: true}) should throw error if cancellation cannot acquire connection', function() {
       // Only mysql/mariadb query cancelling supported for now
       var dialect = knex.client.config.dialect;
-      if (!dialect.startsWith("mysql") && !dialect.startsWith("maria")) { return; }
+      if (!_.startsWith(dialect, "mysql") && !_.startsWith(dialect, "maria")) { return; }
 
       //To make this test easier, I'm changing the pool settings to max 1.
       var knexConfig = _.clone(knex.client.config);

--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -348,7 +348,7 @@ module.exports = function(knex) {
       }
 
       // Only mysql/mariadb query cancelling supported for now
-      if (!dialect.startsWith("mysql") && !dialect.startsWith("mariasql")) {
+      if (!dialect.startsWith("mysql") && !dialect.startsWith("maria")) {
         expect(addTimeout).to.throw("Query cancelling not supported for this dialect");
         return;
       }
@@ -380,7 +380,7 @@ module.exports = function(knex) {
     it('.timeout(ms, {cancel: true}) should throw error if cancellation cannot acquire connection', function() {
       // Only mysql/mariadb query cancelling supported for now
       var dialect = knex.client.config.dialect;
-      if (!dialect.startsWith("mysql") && !dialect.startsWith("mariasql")) { return; }
+      if (!dialect.startsWith("mysql") && !dialect.startsWith("maria")) { return; }
 
       //To make this test easier, I'm changing the pool settings to max 1.
       var knexConfig = _.clone(knex.client.config);


### PR DESCRIPTION
Taking a stab at addressing #707 

Adds an optional `options` argument to `.timeout()`.

For MySQL, a `KILL threadId` query will get sent. For all other dialects an error will be thrown immediately from the `.timeout()` call.

While writing tests, I discovered some potentially worrying behavior (comment also added in the test). After a timeout, `knex` releases the connection back to the pool, but the connection may not be usable because the original slow query is still being performed. A subsequent query will acquire the connection (still in-use) and hang until the first query finishes.