### PR TITLE
Check for undefined bindings in WHERE clauses and RAW queries during…

### DIFF
--- a/index.html
+++ b/index.html
@@ -698,6 +698,20 @@ knex.withSchema('public').select('*').from('users')
       constructing subqueries. In most places existing knex queries may be used to compose sub-queries, etc. Take a look at a few of the examples for each method for instruction on use:
     </p>
 
+    <p>
+      <b>Important:</b> Supplying knex with an <tt>undefined</tt> value to any of the <tt>where</tt> functions will cause knex to throw an error during sql compilation.
+      This is both for yours and our sake. Knex cannot know what to do with undefined values in a where clause, and generally it would be a programmatic error to supply one to begin with.
+      The error will throw a message containing the type of query and the compiled query-string. Example:
+    </p>
+
+  <pre class="display">
+    knex('accounts')
+    .where('login', undefined)
+    .select()
+    .toSQL();
+    //Undefined binding(s) detected when compiling SELECT query: select * from "accounts" where "login" = ?
+  </pre>
+
     <p id="Builder-where">
       <b class="header">where</b><code>.where(~mixed~)</code>
     </p>

--- a/src/dialects/postgres/utils.js
+++ b/src/dialects/postgres/utils.js
@@ -50,9 +50,6 @@ const prepareValue = function (val, seen /*, valueForUndefined*/) {
   if (typeof val === 'object') {
     return prepareObject(val, seen);
   }
-  if (typeof val === 'undefined') {
-    throw new Error('SQL queries with undefined where clause option');
-  }
   return val.toString();
 };
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,6 @@
 /* eslint no-console:0 */
 
-import { map, pick, keys } from 'lodash'
+import { map, pick, keys, isFunction, isUndefined, isObject, isArray } from 'lodash'
 import chalk from 'chalk';
 
 // Pick off the attributes from only the current layer of the object.
@@ -42,4 +42,29 @@ export function warn(msg) {
 export function exit(msg) {
   console.log(chalk.red(msg))
   process.exit(1)
+}
+
+export function containsUndefined(mixed) {
+  let argContainsUndefined = false;
+
+  if(mixed && isFunction(mixed.toSQL)) {
+    //Any QueryBuilder or Raw will automatically be validated during compile.
+    return argContainsUndefined;
+  }
+
+  if(isArray(mixed)) {
+    for(let i = 0; i < mixed.length; i++) {
+      if(argContainsUndefined) break;
+      argContainsUndefined = this.containsUndefined(mixed[i]);
+    }
+  } else if(isObject(mixed)) {
+    for(const key in mixed) {
+      if(argContainsUndefined) break;
+      argContainsUndefined = this.containsUndefined(mixed[key]);
+    }
+  } else {
+    argContainsUndefined = isUndefined(mixed);
+  }
+
+  return argContainsUndefined;
 }

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -48,11 +48,20 @@ assign(QueryCompiler.prototype, {
     if (isString(val)) {
       val = {sql: val};
     }
-    if (method === 'select' && this.single.as) {
-      defaults.as = this.single.as;
+
+    defaults.bindings = defaults.bindings || [];
+
+    if (method === 'select') {
+      if(this.single.as) {
+        defaults.as = this.single.as;
+      }
+
+      if(helpers.containsUndefined(defaults.bindings)) {
+        throw new Error(`Undefined binding(s) detected when compiling SELECT query: ${val.sql}`);
+      }
     }
 
-    defaults.bindings = this.client.prepBindings(defaults.bindings || [], tz);
+    defaults.bindings = this.client.prepBindings(defaults.bindings, tz);
 
     return assign(defaults, val);
   },

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -212,7 +212,7 @@ assign(QueryCompiler.prototype, {
     let i = -1;
     while (++i < wheres.length) {
       const stmt = wheres[i]
-      if(helpers.containsUndefined(stmt.value)) {
+      if(stmt.hasOwnProperty('value') && helpers.containsUndefined(stmt.value)) {
         this._undefinedInWhereClause = true;
       }
       const val = this[stmt.type](stmt)

--- a/test/tape/raw.js
+++ b/test/tape/raw.js
@@ -71,16 +71,6 @@ test('allows for options in raw queries, #605', function(t) {
   })
 })
 
-test('undefined named bindings are ignored', function(t) {
-  
-  t.plan(2)
-  
-  t.equal(raw('select :item from :place', {}).toSQL().sql, 'select :item from :place')
-
-  t.equal(raw('select :item :cool 2 from :place', {item: 'col1'}).toSQL().sql, 'select ? :cool 2 from :place')
-
-})
-
 test('raw bindings are optional, #853', function(t) {
   
   t.plan(2)

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -3371,4 +3371,64 @@ describe("QueryBuilder", function() {
     })
   });
 
+
+  it('Any undefined binding in a SELECT query should throw an error', function() {
+    var expectedErrorMessageContains = 'Undefined binding(s) detected when compiling SELECT query:'; //This test is not for asserting correct queries
+    var qbuilders = [
+      qb().from('accounts').where({Login: void 0}).select(),
+      qb().from('accounts').where('Login', void 0).select(),
+      qb().from('accounts').where('Login', '>=', void 0).select(),
+      qb().from('accounts').whereIn('Login', ['test', 'val', void 0]).select(),
+      qb().from('accounts').where({Login: ['1', '2', '3', void 0]}),
+      qb().from('accounts').where({Login: {Test: '123', Value: void 0}}),
+      qb().from('accounts').where({Login: ['1', ['2', [void 0]]]})
+    ];
+    qbuilders.forEach(function(qbuilder) {
+      try {
+        //Must be present, but makes no difference since it throws.
+        testsql(qbuilder, {
+          mysql: {
+            sql: '',
+            bindings: []
+          },
+          oracle: {
+            sql: '',
+            bindings: []
+          },
+          mssql: {
+            sql: '',
+            bindings: []
+          },
+          postgres: {
+            sql: '',
+            bindings: []
+          }
+        });
+        expect(true).to.equal(false, 'Expected to throw error in compilation about undefined bindings.');
+      } catch(error) {
+        expect(error.message).to.contain(expectedErrorMessageContains); //This test is not for asserting correct queries
+      }
+    });
+  });
+
+
+  it('Any undefined binding in a RAW query should throw an error', function() {
+    var expectedErrorMessageContains = 'Undefined binding(s) detected when compiling RAW query:'; //This test is not for asserting correct queries
+    var raws = [
+      raw('?', [undefined]),
+      raw(':col = :value', {col: 'test', value: void 0}),
+      raw('? = ?', ['test', void 0]),
+      raw('? = ?', ['test', {test: void 0}]),
+      raw('?', [['test', void 0]])
+    ];
+    raws.forEach(function(raw) {
+      try {
+        raw = raw.toSQL();
+        expect(true).to.equal(false, 'Expected to throw error in compilation about undefined bindings.');
+      } catch(error) {
+        expect(error.message).to.contain(expectedErrorMessageContains); //This test is not for asserting correct queries
+      }
+    });
+  });
+
 });

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -3381,7 +3381,8 @@ describe("QueryBuilder", function() {
       qb().from('accounts').whereIn('Login', ['test', 'val', void 0]).select(),
       qb().from('accounts').where({Login: ['1', '2', '3', void 0]}),
       qb().from('accounts').where({Login: {Test: '123', Value: void 0}}),
-      qb().from('accounts').where({Login: ['1', ['2', [void 0]]]})
+      qb().from('accounts').where({Login: ['1', ['2', [void 0]]]}),
+      qb().from('accounts').update({test: '1', test2: void 0}).where({abc: 'test', cba: void 0})
     ];
     qbuilders.forEach(function(qbuilder) {
       try {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -3373,7 +3373,6 @@ describe("QueryBuilder", function() {
 
 
   it('Any undefined binding in a SELECT query should throw an error', function() {
-    var expectedErrorMessageContains = 'Undefined binding(s) detected when compiling SELECT query:'; //This test is not for asserting correct queries
     var qbuilders = [
       qb().from('accounts').where({Login: void 0}).select(),
       qb().from('accounts').where('Login', void 0).select(),
@@ -3407,7 +3406,7 @@ describe("QueryBuilder", function() {
         });
         expect(true).to.equal(false, 'Expected to throw error in compilation about undefined bindings.');
       } catch(error) {
-        expect(error.message).to.contain(expectedErrorMessageContains); //This test is not for asserting correct queries
+        expect(error.message).to.contain('Undefined binding(s) detected when compiling ' + qbuilder._method.toUpperCase() + ' query:'); //This test is not for asserting correct queries
       }
     });
   });


### PR DESCRIPTION
… compile and throw an error.

This is what I had in mind for #1448 . We mentioned an entire suite for testing `undefined` in the issue, but I feel this is a good starting point. The idea is to throw an error during compile if a `SELECT` query contains an undefined binding, or if a `RAW` query contains an undefined binding.

The check is currently recursive. Not sure if this is needed or not.

CC @elhigu @jurko-gospodnetic @rhys-vdw 