### PR TITLE
Fixes "a promise was created but was not returned" warning

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -52,6 +52,7 @@ function Transaction(client, container, config, outerTx) {
           transactor.rollback(err)
         })
       }
+      return null;
     })
     .catch((e) => this._rejecter(e))
 


### PR DESCRIPTION
This would fix Warning: a promise was created in a handler but not returned from it
Issue: #1388