### PR TITLE
Add mssql to the list of supported database libraries

### DIFF
--- a/index.html
+++ b/index.html
@@ -394,7 +394,7 @@
 
     <p>
       The primary target environment for Knex is Node.js, you will need to install the <tt>knex</tt> library,
-      and then install the appropriate database library: <tt><a href="https://github.com/brianc/node-postgres">pg</a></tt> for PostgreSQL, <tt><a href="https://github.com/felixge/node-mysql">mysql</a></tt> for MySQL or MariaDB, or <a href="https://github.com/mapbox/node-sqlite3"><tt>sqlite3</tt></a> for SQLite3.
+      and then install the appropriate database library: <tt><a href="https://github.com/brianc/node-postgres">pg</a></tt> for PostgreSQL, <tt><a href="https://github.com/felixge/node-mysql">mysql</a></tt> for MySQL or MariaDB, <a href="https://github.com/mapbox/node-sqlite3"><tt>sqlite3</tt></a> for SQLite3, or <a href="https://github.com/patriksimek/node-mssql"><tt>mssql</tt></a> for MSSQL.
     </p>
 
 <pre>
@@ -408,6 +408,7 @@ $ npm install mysql2
 $ npm install mariasql
 $ npm install strong-oracle
 $ npm install oracle
+$ npm install mssql
 </pre>
 
     <h3 id="Installation-browser">Browser</h3>


### PR DESCRIPTION
When looking for MSSQL support it wasn't immediately clear that it was available within Knex. I was happy to find issue #240 but thought it should be listed as a supported database library in the docs.