### PR TITLE
Adding support for specifying a DATABASE_URL without a password

### DIFF
--- a/src/util/parse-connection.js
+++ b/src/util/parse-connection.js
@@ -53,6 +53,8 @@ function connectionObject(parsed) {
       if (idx < parsed.auth.length - 1) {
         connection.password = parsed.auth.slice(idx + 1);
       }
+    } else {
+      connection.user = parsed.auth;
     }
   }
   return connection

--- a/test/tape/parse-connection.js
+++ b/test/tape/parse-connection.js
@@ -17,6 +17,19 @@ test('parses standard connections', function(t) {
   })
 })
 
+test('parses standard connections without password', function(t) {
+  t.plan(1)
+  t.deepEqual(parseConnection('mysql://username@path.to.some-url:3306/testdb'), {
+    client: 'mysql',
+    connection: {
+      user: 'username',
+      host: 'path.to.some-url',
+      port: '3306',
+      database: 'testdb'
+    }
+  })
+})
+
 test('parses maria connections, aliasing database to db', function(t) {
   t.plan(3)
   var maria = {


### PR DESCRIPTION
Earlier today I found that Knex was not parsing a `user` from the following `DATABASE_URL`:

```
mysql://travis@127.0.0.1:3306/yodel_test
```

This was because the URL was missing a password. Because `pg-connection-string` is being used for Postgres connections, this already worked for Postgres URLs. If you want a laugh, feel free to look at my [commits](https://github.com/SpireTeam/yodel/commit/ae4491df4057268e0fbb3343b95e870f09b0a136) [from](https://github.com/SpireTeam/yodel/commit/191ac2687cb9379846b9e58ea1dd98bb45dfaa21) [earlier](https://github.com/SpireTeam/yodel/commit/d9df00d50537b9cf40e9b6879aa4fd2bb9aaa890) [today](https://github.com/SpireTeam/yodel/commit/71827c4064d766106c494bbe8399fc3ec187b723) where I clearly had no idea how I'd broken all our Travis tests by starting to use `DATABASE_URL`.

PS: Knex is awesome, thanks for all the work on this project.