### PR TITLE
Fix invalid SQL in Oracle dialect ping function

### DIFF
--- a/src/dialects/oracle/index.js
+++ b/src/dialects/oracle/index.js
@@ -165,7 +165,7 @@ assign(Client_Oracle.prototype, {
   },
 
   ping(resource, callback) {
-    resource.execute('SELECT 1', [], callback);
+    resource.execute('SELECT 1 FROM DUAL', [], callback);
   }
 
 })


### PR DESCRIPTION
"SELECT 1" results in the error: ORA-00923: FROM keyword not found where expected

The correct syntax should be "SELECT 1 FROM DUAL".