### PR TITLE
Docs: Set "foreign" method name to lowercase

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,7 +185,7 @@
       <li>– <a href="#Schema-specificType">specificType</a></li>
       <li>– <a href="#Schema-index">index</a></li>
       <li>– <a href="#Schema-dropIndex">dropIndex</a></li>
-      <li>– <a href="#Schema-foreign">Foreign</a></li>
+      <li>– <a href="#Schema-foreign">foreign</a></li>
       <li>– <a href="#Schema-dropForeign">dropForeign</a></li>
       <li>– <a href="#Schema-dropUnique">dropUnique</a></li>
       <li>– <a href="#Schema-dropPrimary">dropPrimary</a></li>


### PR DESCRIPTION
Assuming this was just a typo.