### PR TITLE
Transactions Rejecting with Undefined

### DIFF
--- a/src/dialects/mysql/transaction.js
+++ b/src/dialects/mysql/transaction.js
@@ -31,6 +31,8 @@ assign(Transaction_MySQL.prototype, {
       })
       .tap(function() {
         if (status === 1) t._resolver(value)
+        if (typeof value === "undefined")
+          value = new Error("Transaction result was undefined.");
         if (status === 2) t._rejecter(value)
       })
     if (status === 1 || status === 2) {


### PR DESCRIPTION
If you create a transaction and throw an error before committing it, you will get an `Unhandled rejection undefined` error.

I can reproduce it with the following.  You'll notice that the console will output `Unhandled rejection undefined` when running.  In certain instances (e.g. with complex nested promises handled by Bluebird), you can also get a `Warning: a promise was rejected with a non-error: [object Undefined]`

```
Bluebird.resolve()
.then ->
  new Bluebird (resolve, reject) ->
    knex.transaction (trx) ->
      Bluebird.resolve()
      .then ->
        console.log "foo"
      .then ->
        throw new Error "Some error"
      .then ->
        trx.commit()
      .then ->
        resolve "bar"
      .catch (internalErr) ->
        trx.rollback()
        .catch (rollbackErr) ->
          console.log "Rollback Error: #{rollbackErr}"
        .then ->
          reject internalErr
.then (result) ->
  console.log "Done: #{result}"
.catch (err) ->
  console.log "Error: #{err}"
.then ->
  process.exit 0
```

I can confirm that this fixes the issue in the code that I'm working on (proprietary) but also in the sample above.  I can't figure out a way to write a unit test around this as it's being printed from the Bluebird library.