### PR TITLE
Create a new Redshift dialect that inherits from Postgres.

### DIFF
--- a/src/dialects/postgres/query/compiler.js
+++ b/src/dialects/postgres/query/compiler.js
@@ -82,7 +82,7 @@ assign(QueryCompiler_PG.prototype, {
       sql += ' and table_schema = ?';
       bindings.push(this.single.schema);
     } else {
-      sql += ' and table_schema = current_schema';
+      sql += ' and table_schema = current_schema()';
     }
 
     return {

--- a/src/dialects/postgres/schema/compiler.js
+++ b/src/dialects/postgres/schema/compiler.js
@@ -19,7 +19,7 @@ SchemaCompiler_PG.prototype.hasTable = function(tableName) {
     sql += ' and table_schema = ?';
     bindings.push(this.schema);
   } else {
-    sql += ' and table_schema = current_schema';
+    sql += ' and table_schema = current_schema()';
   }
 
   this.pushQuery({
@@ -40,7 +40,7 @@ SchemaCompiler_PG.prototype.hasColumn = function(tableName, columnName) {
     sql += ' and table_schema = ?';
     bindings.push(this.schema);
   } else {
-    sql += ' and table_schema = current_schema';
+    sql += ' and table_schema = current_schema()';
   }
 
   this.pushQuery({

--- a/src/dialects/redshift/index.js
+++ b/src/dialects/redshift/index.js
@@ -1,0 +1,24 @@
+
+// Redshift Client
+// -------
+import inherits from 'inherits';
+import Client_PG from '../postgres';
+import { assign } from 'lodash'
+
+import QueryCompiler from './query/compiler';
+import ColumnCompiler from './schema/columncompiler';
+
+function Client_Redshift(config) {
+  Client_PG.call(this, config)
+}
+inherits(Client_Redshift, Client_PG)
+
+assign(Client_Redshift.prototype, {
+  QueryCompiler,
+
+  ColumnCompiler,
+  
+  dialect: 'redshift'
+})
+
+export default Client_Redshift;

--- a/src/dialects/redshift/index.js
+++ b/src/dialects/redshift/index.js
@@ -7,6 +7,7 @@ import { assign } from 'lodash'
 
 import QueryCompiler from './query/compiler';
 import ColumnCompiler from './schema/columncompiler';
+import TableCompiler from './schema/tablecompiler';
 
 function Client_Redshift(config) {
   Client_PG.call(this, config)
@@ -17,6 +18,8 @@ assign(Client_Redshift.prototype, {
   QueryCompiler,
 
   ColumnCompiler,
+
+  TableCompiler,
   
   dialect: 'redshift'
 })

--- a/src/dialects/redshift/index.js
+++ b/src/dialects/redshift/index.js
@@ -1,10 +1,11 @@
 
-// Redshift Client
+// Redshift
 // -------
 import inherits from 'inherits';
 import Client_PG from '../postgres';
 import { assign } from 'lodash'
 
+import Transaction from './transaction';
 import QueryCompiler from './query/compiler';
 import ColumnCompiler from './schema/columncompiler';
 import TableCompiler from './schema/tablecompiler';
@@ -15,11 +16,21 @@ function Client_Redshift(config) {
 inherits(Client_Redshift, Client_PG)
 
 assign(Client_Redshift.prototype, {
-  QueryCompiler,
+  transaction() {
+    return new Transaction(this, ...arguments)
+  },
 
-  ColumnCompiler,
+  queryCompiler() {
+    return new QueryCompiler(this, ...arguments)
+  },
 
-  TableCompiler,
+  columnCompiler() {
+    return new ColumnCompiler(this, ...arguments)
+  },
+
+  tableCompiler() {
+    return new TableCompiler(this, ...arguments)
+  },
   
   dialect: 'redshift'
 })

--- a/src/dialects/redshift/query/compiler.js
+++ b/src/dialects/redshift/query/compiler.js
@@ -13,6 +13,10 @@ function QueryCompiler_Redshift(client, builder) {
 inherits(QueryCompiler_Redshift, QueryCompiler_PG);
 
 assign(QueryCompiler_Redshift.prototype, {
+  truncate() {
+    return `truncate ${this.tableName}`;
+  },
+
   _returning(value) {
     return '';
   }

--- a/src/dialects/redshift/query/compiler.js
+++ b/src/dialects/redshift/query/compiler.js
@@ -1,0 +1,21 @@
+
+// Redshift Query Builder & Compiler
+// ------
+import inherits from 'inherits';
+
+import QueryCompiler_PG from '../../postgres/query/compiler';
+
+import { assign } from 'lodash'
+
+function QueryCompiler_Redshift(client, builder) {
+  QueryCompiler_PG.call(this, client, builder);
+}
+inherits(QueryCompiler_Redshift, QueryCompiler_PG);
+
+assign(QueryCompiler_Redshift.prototype, {
+  _returning(value) {
+    return '';
+  }
+})
+
+export default QueryCompiler_Redshift;

--- a/src/dialects/redshift/schema/columncompiler.js
+++ b/src/dialects/redshift/schema/columncompiler.js
@@ -9,7 +9,6 @@ import { assign } from 'lodash'
 
 function ColumnCompiler_Redshift() {
   ColumnCompiler_PG.apply(this, arguments);
-  this.modifiers = ['nullable', 'defaultTo', 'comment']
 }
 inherits(ColumnCompiler_Redshift, ColumnCompiler_PG);
 

--- a/src/dialects/redshift/schema/columncompiler.js
+++ b/src/dialects/redshift/schema/columncompiler.js
@@ -1,0 +1,39 @@
+
+// Redshift Column Compiler
+// -------
+
+import inherits from 'inherits';
+import ColumnCompiler_PG from '../../postgres/schema/columncompiler';
+
+import { assign } from 'lodash'
+
+function ColumnCompiler_Redshift() {
+  ColumnCompiler_PG.apply(this, arguments);
+  this.modifiers = ['nullable', 'defaultTo', 'comment']
+}
+inherits(ColumnCompiler_Redshift, ColumnCompiler_PG);
+
+assign(ColumnCompiler_Redshift.prototype, {
+  bigincrements: 'bigint identity(1,1) primary key not null',
+  binary: 'varchar(max)',
+  bit(column) {
+    return column.length !== false ? `char(${column.length})` : 'char(1)';
+  },
+  blob: 'varchar(max)',
+  datetime: 'timestamp',
+  enu: 'text',
+  enum: 'text',
+  increments: 'integer identity(1,1) primary key not null',
+  json: 'varchar(max)',
+  jsonb: 'varchar(max)',
+  longblob: 'varchar(max)',
+  mediumblob: 'varchar(max)',
+  set: 'text',
+  text: 'varchar(max)',
+  timestamp: 'timestamp',
+  tinyblob: 'text',
+  uuid: 'char(32)',
+  varbinary: 'varchar(max)'
+})
+
+export default ColumnCompiler_Redshift;

--- a/src/dialects/redshift/schema/tablecompiler.js
+++ b/src/dialects/redshift/schema/tablecompiler.js
@@ -1,0 +1,22 @@
+/* eslint max-len: 0 */
+
+// Redshift Table Builder & Compiler
+// -------
+
+import { warn } from '../../../helpers';
+import inherits from 'inherits';
+import TableCompiler_PG from '../../postgres/schema/tablecompiler';
+
+function TableCompiler_Redshift() {
+  TableCompiler_PG.apply(this, arguments);
+}
+inherits(TableCompiler_Redshift, TableCompiler_PG);
+
+TableCompiler_Redshift.prototype.index = function(columns, indexName, indexType) {
+  warn('Redshift does not support the creation of indexes.');
+};
+TableCompiler_Redshift.prototype.dropIndex = function(columns, indexName) {
+  warn('Redshift does not support the deletion of indexes.');
+};
+
+export default TableCompiler_Redshift;

--- a/src/dialects/redshift/transaction.js
+++ b/src/dialects/redshift/transaction.js
@@ -1,0 +1,21 @@
+
+import Promise from 'bluebird';
+import { warn } from '../../helpers';
+import Transaction from '../../transaction';
+
+export default class Redshift_Transaction extends Transaction {
+  savepoint(conn) {
+    warn('Redshift does not support savepoints.');
+    return Promise.resolve()
+  }
+
+  release(conn, value) {
+    warn('Redshift does not support savepoints.');
+    return Promise.resolve()
+  }
+
+  rollbackTo(conn, error) {
+    warn('Redshift does not support savepoints.');
+    return Promise.resolve()
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,7 @@ describe('Query Building Tests', function() {
   require('./unit/schema/mysql')('maria')
   require('./unit/schema/mysql')('mysql2')
   require('./unit/schema/postgres')
+  require('./unit/schema/redshift')
   require('./unit/schema/sqlite3')
   require('./unit/schema/oracle')
   require('./unit/schema/mssql')

--- a/test/knexfile.js
+++ b/test/knexfile.js
@@ -117,6 +117,18 @@ var testConfigs = {
     seeds: seeds
   },
 
+  redshift: {
+    dialect: 'redshift',
+    connection: testConfig.redshift || {
+      adapter:  "postgresql",
+      database: "knex_test",
+      user:     "knex_test"
+    },
+    pool: pool,
+    migrations: migrations,
+    seeds: seeds
+  },
+
   sqlite3: {
     dialect: 'sqlite3',
     connection: testConfig.sqlite3 || {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -6,26 +6,29 @@ var MySQL_Client = require('../../../lib/dialects/mysql')
 var PG_Client = require('../../../lib/dialects/postgres')
 var Oracle_Client = require('../../../lib/dialects/oracle')
 var Oracledb_Client = require('../../../lib/dialects/oracledb')
+var Redshift_Client = require('../../../lib/dialects/redshift')
 var SQLite3_Client = require('../../../lib/dialects/sqlite3')
 var MSSQL_Client = require('../../../lib/dialects/mssql')
 
 var clients = {
   mysql: new MySQL_Client({}),
   postgres: new PG_Client({}),
+  redshift: new Redshift_Client({}),
   oracle: new Oracle_Client({}),
   oracledb: new Oracledb_Client({}),
   sqlite3: new SQLite3_Client({}),
-  mssql: new MSSQL_Client({}),
+  mssql: new MSSQL_Client({})
 }
 
 var useNullAsDefaultConfig = { useNullAsDefault: true };
 var clientsWithNullAsDefault = {
   mysql: new MySQL_Client(useNullAsDefaultConfig),
   postgres: new PG_Client(useNullAsDefaultConfig),
+  redshift: new Redshift_Client(useNullAsDefaultConfig),
   oracle: new Oracle_Client(useNullAsDefaultConfig),
   oracledb: new Oracledb_Client(useNullAsDefaultConfig),
   sqlite3: new SQLite3_Client(useNullAsDefaultConfig),
-  mssql: new MSSQL_Client(useNullAsDefaultConfig),
+  mssql: new MSSQL_Client(useNullAsDefaultConfig)
 }
 
 function qb() {

--- a/test/unit/schema/redshift.js
+++ b/test/unit/schema/redshift.js
@@ -1,0 +1,531 @@
+/*global describe, expect, it*/
+
+'use strict';
+
+var tableSql;
+
+var Redshift_Client = require('../../../lib/dialects/redshift');
+var client          = new Redshift_Client({})
+
+var equal  = require('assert').equal;
+
+describe("Redshift SchemaBuilder", function() {
+
+  it("fixes memoization regression", function() {
+    tableSql = client.schemaBuilder().createTable('users', function(table) {
+      table.uuid('key');
+      table.increments('id');
+      table.string('email');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('create table "users" ("key" char(32), "id" integer identity(1,1) primary key not null, "email" varchar(255))');
+  });
+
+  it("basic alter table", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.increments('id');
+      table.string('email');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "id" integer identity(1,1) primary key not null, add column "email" varchar(255)');
+  });
+
+  it("alter table with schema", function() {
+    tableSql = client.schemaBuilder().withSchema('myschema').table('users', function(table) {
+      table.increments('id');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "myschema"."users" add column "id" integer identity(1,1) primary key not null');
+  });
+
+  it("drop table", function() {
+    tableSql = client.schemaBuilder().dropTable('users').toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop table "users"');
+  });
+
+  it("drop table with schema", function() {
+    tableSql = client.schemaBuilder().withSchema('myschema').dropTable('users').toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop table "myschema"."users"');
+  });
+
+  it("drop table if exists", function() {
+    tableSql = client.schemaBuilder().dropTableIfExists('users').toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop table if exists "users"');
+  });
+
+  it("drop table if exists with schema", function() {
+    tableSql = client.schemaBuilder().withSchema('myschema').dropTableIfExists('users').toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop table if exists "myschema"."users"');
+  });
+
+  it("drop column", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.dropColumn('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop column "foo"');
+  });
+
+  it("drop multiple columns", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.dropColumn(['foo', 'bar']);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop column "foo", drop column "bar"');
+  });
+
+  it("drop multiple columns with arguments", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.dropColumn('foo', 'bar');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop column "foo", drop column "bar"');
+  });
+
+  it("drop primary", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.dropPrimary();
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint "users_pkey"');
+  });
+
+  it("drop unique", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.dropUnique('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint "users_foo_unique"');
+  });
+
+  it("drop unique, custom", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.dropUnique(null, 'foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint "foo"');
+  });
+
+  it("drop index", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.dropIndex('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index "users_foo_index"');
+  });
+
+  it("drop index, custom", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.dropIndex(null, 'foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index "foo"');
+  });
+
+  it("drop foreign", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.dropForeign('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint "users_foo_foreign"');
+  });
+
+  it("drop foreign", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.dropForeign(null, 'foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop constraint "foo"');
+  });
+
+  it("drop timestamps", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.dropTimestamps();
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" drop column "created_at", drop column "updated_at"');
+  });
+
+  it("rename table", function() {
+    tableSql = client.schemaBuilder().renameTable('users', 'foo').toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" rename to "foo"');
+  });
+
+  it("adding primary key", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.primary('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add constraint "users_pkey" primary key ("foo")');
+  });
+
+  it("adding primary key fluently", function() {
+    tableSql = client.schemaBuilder().createTable('users', function(table) {
+      table.string('name').primary();
+    }).toSQL();
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal('create table "users" ("name" varchar(255))');
+    expect(tableSql[1].sql).to.equal('alter table "users" add constraint "users_pkey" primary key ("name")');
+  });
+
+  it("adding foreign key", function() {
+    tableSql = client.schemaBuilder().createTable('accounts', function(table) {
+      table.integer('account_id').references('users.id');
+    }).toSQL();
+    expect(tableSql[1].sql).to.equal('alter table "accounts" add constraint "accounts_account_id_foreign" foreign key ("account_id") references "users" ("id")');
+  });
+
+  it("adds foreign key with onUpdate and onDelete", function() {
+    tableSql = client.schemaBuilder().createTable('person', function(table) {
+      table.integer('user_id').notNull().references('users.id').onDelete('SET NULL');
+      table.integer('account_id').notNull().references('id').inTable('accounts').onUpdate('cascade');
+    }).toSQL();
+    equal(3, tableSql.length);
+    expect(tableSql[1].sql).to.equal('alter table "person" add constraint "person_user_id_foreign" foreign key ("user_id") references "users" ("id") on delete SET NULL');
+    expect(tableSql[2].sql).to.equal('alter table "person" add constraint "person_account_id_foreign" foreign key ("account_id") references "accounts" ("id") on update cascade');
+  });
+
+  it("adding unique key", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.unique('foo', 'bar');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add constraint "bar" unique ("foo")');
+  });
+
+  it("adding unique key fluently", function() {
+    tableSql = client.schemaBuilder().createTable('users', function(table) {
+      table.string('email').unique();
+    }).toSQL();
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal('create table "users" ("email" varchar(255))');
+    expect(tableSql[1].sql).to.equal('alter table "users" add constraint "users_email_unique" unique ("email")');
+  });
+
+  it("adding index without value", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.index(['foo', 'bar']);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('create index "users_foo_bar_index" on "users" ("foo", "bar")');
+  });
+
+  it("adding index", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.index(['foo', 'bar'], 'baz');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('create index "baz" on "users" ("foo", "bar")');
+  });
+
+  it("adding index fluently", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.string('name').index();
+    }).toSQL();
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "name" varchar(255)');
+    expect(tableSql[1].sql).to.equal('create index "users_name_index" on "users" ("name")');
+  });
+
+  it("adding index with an index type", function() {
+     tableSql = client.schemaBuilder().table('users', function(table) {
+      table.index(['foo', 'bar'], 'baz', 'gist');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('create index "baz" on "users" using gist ("foo", "bar")');
+  });
+
+  it("adding index with an index type fluently", function() {
+     tableSql = client.schemaBuilder().table('users', function(table) {
+      table.string('name').index('baz', 'gist');
+    }).toSQL();
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "name" varchar(255)');
+    expect(tableSql[1].sql).to.equal('create index "baz" on "users" using gist ("name")');
+  });
+
+  it("adding index with an index type and default name fluently", function() {
+     tableSql = client.schemaBuilder().table('users', function(table) {
+      table.string('name').index(null, 'gist');
+    }).toSQL();
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "name" varchar(255)');
+    expect(tableSql[1].sql).to.equal('create index "users_name_index" on "users" using gist ("name")');
+  });
+
+  it("adding incrementing id", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.increments('id');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "id" integer identity(1,1) primary key not null');
+  });
+
+  it("adding big incrementing id", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.bigIncrements('id');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "id" bigint identity(1,1) primary key not null');
+  });
+
+  it("adding string", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.string('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" varchar(255)');
+  });
+
+  it("adding varchar with length", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.string('foo', 100);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" varchar(100)');
+  });
+
+  it("adding a string with a default", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.string('foo', 100).defaultTo('bar');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" varchar(100) default \'bar\'');
+  });
+
+  it("adding text", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.text('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" varchar(max)');
+  });
+
+  it("adding big integer", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.bigInteger('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" bigint');
+  });
+
+  it("tests a big integer as the primary autoincrement key", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.bigIncrements('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" bigint identity(1,1) primary key not null');
+  });
+
+  it("adding integer", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.integer('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" integer');
+  });
+
+  it("adding autoincrement integer", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.increments('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" integer identity(1,1) primary key not null');
+  });
+
+  it("adding medium integer", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.mediumint('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" integer');
+  });
+
+  it("adding tiny integer", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.tinyint('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" smallint');
+  });
+
+  it("adding small integer", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.smallint('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" smallint');
+  });
+
+  it("adding float", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.float('foo', 5, 2);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" real');
+  });
+
+  it("adding double", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.double('foo', 15, 8);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" double precision');
+  });
+
+  it("adding decimal", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.decimal('foo', 5, 2);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" decimal(5, 2)');
+  });
+
+  it("adding boolean", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.boolean('foo').defaultTo(false);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" boolean default \'0\'');
+  });
+
+  it("adding enum", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.enum('foo', ['bar', 'baz']);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" text');
+  });
+
+  it("adding date", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.date('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" date');
+  });
+
+  it("adding date time", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.dateTime('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" timestamp');
+  });
+
+  it("adding time", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.time('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" time');
+  });
+
+  it("adding timestamp", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.timestamp('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" timestamp');
+  });
+
+  it("adding timestamps", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.timestamps();
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "created_at" timestamp, add column "updated_at" timestamp');
+  });
+
+  it("adding timestamps with defaults", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.timestamps(false, true);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "created_at" timestamp not null default CURRENT_TIMESTAMP, add column "updated_at" timestamp not null default CURRENT_TIMESTAMP');
+  });
+
+  it("adding binary", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.binary('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" varchar(max)');
+  });
+
+  it('adding jsonb', function() {
+    tableSql = client.schemaBuilder().table('user', function(t) {
+      t.jsonb('preferences');
+    }).toSQL();
+    expect(tableSql[0].sql).to.equal('alter table "user" add column "preferences" varchar(max)');
+  });
+
+  it('allows adding default json objects when the column is json', function() {
+    tableSql = client.schemaBuilder().table('user', function(t) {
+      t.json('preferences').defaultTo({}).notNullable();
+    }).toSQL();
+    expect(tableSql[0].sql).to.equal('alter table "user" add column "preferences" varchar(max) not null {}');
+  });
+
+  it('sets specificType correctly', function() {
+    tableSql = client.schemaBuilder().table('user', function(t) {
+      t.specificType('email', 'CITEXT').unique().notNullable();
+    }).toSQL();
+    expect(tableSql[0].sql).to.equal('alter table "user" add column "email" CITEXT not null');
+  });
+
+  it('allows creating an extension', function() {
+    var sql = client.schemaBuilder().createExtension('test').toSQL();
+    expect(sql[0].sql).to.equal('create extension "test"');
+  });
+
+  it('allows dropping an extension', function() {
+    var sql = client.schemaBuilder().dropExtension('test').toSQL();
+    expect(sql[0].sql).to.equal('drop extension "test"');
+  });
+
+  it('allows creating an extension only if it doesn\'t exist', function() {
+    var sql = client.schemaBuilder().createExtensionIfNotExists('test').toSQL();
+    expect(sql[0].sql).to.equal('create extension if not exists "test"');
+  });
+
+  it('allows dropping an extension only if it exists', function() {
+    var sql = client.schemaBuilder().dropExtensionIfExists('test').toSQL();
+    expect(sql[0].sql).to.equal('drop extension if exists "test"');
+  });
+
+  it('table inherits another table', function() {
+    tableSql = client.schemaBuilder().createTable('inheriteeTable', function(t) {
+      t.string('username');
+      t.inherits('inheritedTable');
+    }).toSQL();
+    expect(tableSql[0].sql).to.equal('create table "inheriteeTable" ("username" varchar(255)) inherits ("inheritedTable")');
+  });
+
+  it('should warn on disallowed method', function() {
+    tableSql = client.schemaBuilder().createTable('users', function(t) {
+      t.string('username');
+      t.engine('myISAM');
+    }).toSQL();
+    expect(tableSql[0].sql).to.equal('create table "users" ("username" varchar(255))');
+  });
+
+  it('#1430 - .primary & .dropPrimary takes columns and constraintName', function() {
+    tableSql = client.schemaBuilder().table('users', function(t) {
+      t.primary(['test1', 'test2'], 'testconstraintname');
+    }).toSQL();
+    expect(tableSql[0].sql).to.equal('alter table "users" add constraint "testconstraintname" primary key ("test1", "test2")');
+
+    tableSql = client.schemaBuilder().createTable('users', function(t) {
+      t.string('test').primary('testconstraintname');
+    }).toSQL();
+
+    expect(tableSql[1].sql).to.equal('alter table "users" add constraint "testconstraintname" primary key ("test")');
+  });
+
+});

--- a/test/unit/schema/redshift.js
+++ b/test/unit/schema/redshift.js
@@ -110,20 +110,11 @@ describe("Redshift SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table "users" drop constraint "foo"');
   });
 
-  it("drop index", function() {
+  it("drop index should be a no-op", function() {
     tableSql = client.schemaBuilder().table('users', function(table) {
       table.dropIndex('foo');
     }).toSQL();
-    equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('drop index "users_foo_index"');
-  });
-
-  it("drop index, custom", function() {
-    tableSql = client.schemaBuilder().table('users', function(table) {
-      table.dropIndex(null, 'foo');
-    }).toSQL();
-    equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('drop index "foo"');
+    equal(0, tableSql.length);
   });
 
   it("drop foreign", function() {
@@ -207,55 +198,11 @@ describe("Redshift SchemaBuilder", function() {
     expect(tableSql[1].sql).to.equal('alter table "users" add constraint "users_email_unique" unique ("email")');
   });
 
-  it("adding index without value", function() {
-    tableSql = client.schemaBuilder().table('users', function(table) {
-      table.index(['foo', 'bar']);
-    }).toSQL();
-    equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('create index "users_foo_bar_index" on "users" ("foo", "bar")');
-  });
-
-  it("adding index", function() {
+  it("adding index should be a no-op", function() {
     tableSql = client.schemaBuilder().table('users', function(table) {
       table.index(['foo', 'bar'], 'baz');
     }).toSQL();
-    equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('create index "baz" on "users" ("foo", "bar")');
-  });
-
-  it("adding index fluently", function() {
-    tableSql = client.schemaBuilder().table('users', function(table) {
-      table.string('name').index();
-    }).toSQL();
-    equal(2, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table "users" add column "name" varchar(255)');
-    expect(tableSql[1].sql).to.equal('create index "users_name_index" on "users" ("name")');
-  });
-
-  it("adding index with an index type", function() {
-     tableSql = client.schemaBuilder().table('users', function(table) {
-      table.index(['foo', 'bar'], 'baz', 'gist');
-    }).toSQL();
-    equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('create index "baz" on "users" using gist ("foo", "bar")');
-  });
-
-  it("adding index with an index type fluently", function() {
-     tableSql = client.schemaBuilder().table('users', function(table) {
-      table.string('name').index('baz', 'gist');
-    }).toSQL();
-    equal(2, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table "users" add column "name" varchar(255)');
-    expect(tableSql[1].sql).to.equal('create index "baz" on "users" using gist ("name")');
-  });
-
-  it("adding index with an index type and default name fluently", function() {
-     tableSql = client.schemaBuilder().table('users', function(table) {
-      table.string('name').index(null, 'gist');
-    }).toSQL();
-    equal(2, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table "users" add column "name" varchar(255)');
-    expect(tableSql[1].sql).to.equal('create index "users_name_index" on "users" using gist ("name")');
+    equal(0, tableSql.length);
   });
 
   it("adding incrementing id", function() {


### PR DESCRIPTION
I've implemented a dialect for Amazon Redshift inspired by @krainboltgreene's work in #1263. As suggested by @rhys-vdw, this Redshift dialect inherits from Postgres, which results in much less code.

Only a few modifications were necessary:
- Unsupported types have been remapped. I based my choices on several sources, including https://www.flydata.com/resources/flydata-sync/data-type-mapping/, http://docs.aws.amazon.com/redshift/latest/dg/c_unsupported-postgresql-datatypes.html, http://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html, and other official documentation.
- SERIAL columns have been replaced with IDENTITY columns.
- The query compiler nullifies the RETURNING clause normally added to Postgres queries.
- A small tweak to the Postgres dialect was made to use `current_schema()` instead of `current_schema`. Redshift treats it as a column name instead of a function if the parentheses aren't added.

The unit tests from Postgres have been copied and modified for Redshift. I attempted to add integration tests, but they seem to be keyed on the driver name (e.g. 'postgresql') instead of the dialect. I don't know know if this can be worked around without changing the structure of the tests.

We're currently using this to initialize new Redshift clusters (new databases/schemas/users/permissions etc.) and issue a range of SELECT, UPDATE, DELETE, and ALTER queries with no trouble.
