### PR TITLE
fix: allow oracledb connectString (issue #1573)

### DIFF
--- a/src/dialects/oracledb/index.js
+++ b/src/dialects/oracledb/index.js
@@ -59,7 +59,8 @@ Client_Oracledb.prototype.acquireRawConnection = function() {
     client.driver.getConnection({
       user: client.connectionSettings.user,
       password: client.connectionSettings.password,
-      connectString: client.connectionSettings.host + '/' + client.connectionSettings.database
+      connectString: client.connectionSettings.connectString ||
+        (client.connectionSettings.host + '/' + client.connectionSettings.database)
     }, function(err, connection) {
       if (err)
         return rejecter(err);


### PR DESCRIPTION
fixes #1573 

*Question:*

I'm not sure where I can add tests for this... There are tests for the `connectionParser` but my fix is in the oracledb dialect directly.  Should I add a new test file that instantiates this client and tests the parsing? Maybe mocking the actual oracledb package? Seems a little complicated, but let me know what you guys think...

Side note, I've tested this locally and it works, while maintaining backwards compatibility.

ping @rhys-vdw @elhigu because I see you guys were involved in the oracledb merge :-)