### PR TITLE
Error on Node.JS 6.3.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,9 @@ export default function Knex(config) {
   if (typeof config === 'string') {
     return new Knex(assign(parseConnection(config), arguments[2]))
   }
+  if (config === undefined || config === null) {
+      config = {};
+  }
   let Dialect;
   if (arguments.length === 0 || (!config.client && !config.dialect)) {
     Dialect = makeClient(Client)


### PR DESCRIPTION
Special hotfix for that error:
```
<PATH-TO-PROJECT>/node_modules/knex/lib/index.js:46
  if (arguments.length === 0 || !config.client && !config.dialect) {
                                       ^


TypeError: Cannot read property 'client' of undefined
    at Knex (/home/user/Projects/yield-active-record/node_modules/knex/lib/index.js:46:40)
    at Object.getInstance (/home/user/Projects/yield-active-record/classes/db-socket.js:36:21)
    at Object.<anonymous> (/home/user/Projects/yield-active-record/classes/active-record.js:13:31)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/user/Projects/yield-active-record/index.js:5:5)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
```