### PR TITLE
MSSQL columnInfo() had hard coded schema name

### DIFF
--- a/src/dialects/mssql/query/compiler.js
+++ b/src/dialects/mssql/query/compiler.js
@@ -158,11 +158,19 @@ assign(QueryCompiler_MSSQL.prototype, {
   // Compiles a `columnInfo` query.
   columnInfo() {
     const column = this.single.columnInfo;
-    const sql =
-      `select * from information_schema.columns where table_name = ? and table_schema = 'dbo'`;
+    let sql =`select * from information_schema.columns where table_name = ? and table_catalog = ?`;
+    let bindings = [this.single.table, this.client.database()];
+
+    if (this.single.schema) {
+      sql += ' and table_schema = ?';
+      bindings.push(this.single.schema);
+    } else {
+      sql += ` and table_schema = 'dbo'`;
+    }
+
     return {
       sql,
-      bindings: [this.single.table],
+      bindings: bindings,
       output(resp) {
         const out = resp.reduce(function(columns, val) {
           columns[val.COLUMN_NAME] = {

--- a/src/dialects/mssql/query/compiler.js
+++ b/src/dialects/mssql/query/compiler.js
@@ -159,7 +159,7 @@ assign(QueryCompiler_MSSQL.prototype, {
   columnInfo() {
     const column = this.single.columnInfo;
     let sql =`select * from information_schema.columns where table_name = ? and table_catalog = ?`;
-    let bindings = [this.single.table, this.client.database()];
+    const bindings = [this.single.table, this.client.database()];
 
     if (this.single.schema) {
       sql += ' and table_schema = ?';

--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -121,8 +121,8 @@ module.exports = function(knex) {
           }
         );
         tester('mssql',
-          'select * from information_schema.columns where table_name = ? and table_schema = \'dbo\'',
-          ['datatype_test'], {
+          'select * from information_schema.columns where table_name = ? and table_catalog = ? and table_schema = \'dbo\'',
+          ['datatype_test', 'knex_test'], {
             "enum_value": {
               "defaultValue": null,
               "maxLength": 100,
@@ -173,7 +173,7 @@ module.exports = function(knex) {
           }
         );
         tester('mssql',
-          'select * from information_schema.columns where table_name = ? and table_schema = \'dbo\'',
+          'select * from information_schema.columns where table_name = ? and table_catalog = ? and table_schema = \'dbo\'',
           null, {
             "defaultValue": null,
             "maxLength": null,


### PR DESCRIPTION
columnInfo() for MSSQL has the default schema (dbo) hard coded.  It should take the database and schema as parameters like the Postgres version does.
