### PR TITLE
Uint8Array data (e.g. Postgres "bytea" type) erroneously considered "undefined" by recent 0.11.7 update.

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -47,12 +47,15 @@ export function exit(msg) {
 export function containsUndefined(mixed) {
   let argContainsUndefined = false;
 
+  if (isTypedArray(mixed))
+    return false;
+
   if(mixed && isFunction(mixed.toSQL)) {
     //Any QueryBuilder or Raw will automatically be validated during compile.
     return argContainsUndefined;
   }
 
-  if(isArray(mixed) || isTypedArray(mixed)) {
+  if(isArray(mixed)) {
     for(let i = 0; i < mixed.length; i++) {
       if(argContainsUndefined) break;
       argContainsUndefined = this.containsUndefined(mixed[i]);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,6 @@
 /* eslint no-console:0 */
 
-import { map, pick, keys, isFunction, isUndefined, isObject, isArray } from 'lodash'
+import { map, pick, keys, isFunction, isUndefined, isObject, isArray, isTypedArray } from 'lodash'
 import chalk from 'chalk';
 
 // Pick off the attributes from only the current layer of the object.
@@ -52,7 +52,7 @@ export function containsUndefined(mixed) {
     return argContainsUndefined;
   }
 
-  if(isArray(mixed)) {
+  if(isArray(mixed) || isTypedArray(mixed)) {
     for(let i = 0; i < mixed.length; i++) {
       if(argContainsUndefined) break;
       argContainsUndefined = this.containsUndefined(mixed[i]);


### PR DESCRIPTION
Hi There,

Currently using bookshelf in a project. Upon update to knex v0.11.7, noticed that an update was failing with error "Undefined binding(s) detected when compiling RAW query: ...". 

I understand that any data field with value undefined will cause this type of error. 

I looked into my code and found that as part of my query, no data to be bound was "undefined". Digging deeper I found that input values of type "Uint8Array" were failing the deep inspection test on data to be bound in `helpers.js`:

```
export function containsUndefined(mixed) {
  let argContainsUndefined = false;

  if(mixed && isFunction(mixed.toSQL)) {
    //Any QueryBuilder or Raw will automatically be validated during compile.
    return argContainsUndefined;
  }

  if(isArray(mixed)) {
    for(let i = 0; i < mixed.length; i++) {
      if(argContainsUndefined) break;
      argContainsUndefined = this.containsUndefined(mixed[i]);
    }
  } else if(isObject(mixed)) {
    for(const key in mixed) {
      if(argContainsUndefined) break;
      argContainsUndefined = this.containsUndefined(mixed[key]);
    }
  } else {
    argContainsUndefined = isUndefined(mixed);
  }

  return argContainsUndefined;
}
```

The Uint8Array was failing the check because it fails the lodash "isArray" check, and so is evaluated as an object; it has an  internal property "parent" which was undefined. It should be noted that data returned from "pg" for Postgres "bytea" columns are passed back to knex as a "Uint8Array". In my use case, I was updating a record with data originally passed back from a previous query. Thus my value was not "undefined"

To fix this case, I propose that the lodash "isTypedArray" check also be used alongside the "isArray" check. Then a Uint8Array will be treated as an Array (with index 0-n and property length) thus not being considered "undefined" when it is not truely so:

```
export function containsUndefined(mixed) {

...
  if(isArray(mixed) || isTypedArray(mixed)) {
    ...

```

Please advise if this simple proposal is acceptable, if you have any additional feedback or approaches. I hope this change can be merged into the knex code base for the next release.