### PR TITLE
Updated README with info about multiple references

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ NOTE: When you are referencing knex in more than one files follow this method in
 
 ```js
 // Initial reference (index.js / app.js)
-var knex = require('knex')(connection_object);
+var Knex = require('knex');
+// Pass connection parameters
+Knex.knex({...});
 
 // Subsequent references in other modules
-var knex = require('knex').knex;
+var Knex = require('knex').knex;

--- a/README.md
+++ b/README.md
@@ -75,3 +75,11 @@ knex.schema.createTable('users', function(table) {
   console.error(e);
 });
 ```
+NOTE: When you are referencing knex in more than one files follow this method in order to reuse the existing connection pool. Failing this step makes knex wait forever till it gets timed out.
+
+```js
+// Initial reference (index.js / app.js)
+var knex = require('knex')(connection_object);
+
+// Subsequent references in other modules
+var knex = require('knex').knex;


### PR DESCRIPTION
This issue occurs when multiple references are made to knex. It would be great if there is a way to avoid this or if this occurence is documented. I had to search for a lot of time and finally found this fix here http://stackoverflow.com/a/25854598/1459670
