### PR TITLE
Added padding to avoid header sticking to the example usage.

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -81,6 +81,7 @@ h1, h2, h3, h4, h5, h6 {
     font-size: 20px;
   }
 b.header {
+  margin-right: 5px;
   font-size: 16px;
   line-height: 30px;
 }


### PR DESCRIPTION
Dear Sirs,

Currently, especially in [some](http://knexjs.org/#Builder-main) [places](http://knexjs.org/#Schema) the header and code seem to be too close to each other. I have taken the liberty to add some padding between them.