### PR TITLE
Reorder components

### DIFF
--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -27,8 +27,8 @@ function QueryCompiler(client, builder) {
 }
 
 const components = [
-  'columns', 'join', 'where', 'union', 'group',
-  'having', 'order', 'limit', 'offset', 'lock'
+  'columns', 'join', 'where', 'group', 'having',
+  'order', 'limit', 'offset', 'union', 'lock'
 ];
 
 assign(QueryCompiler.prototype, {

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -28,7 +28,7 @@ function QueryCompiler(client, builder) {
 
 const components = [
   'columns', 'join', 'where', 'group', 'having',
-  'order', 'limit', 'offset', 'union', 'lock'
+  'limit', 'offset', 'union', 'order', 'lock'
 ];
 
 assign(QueryCompiler.prototype, {


### PR DESCRIPTION
This is a version of the fix people have been using to address #913. It changes the priority of the union component be be behind group, having, limit and offset.

I had to keep order _after_ union still, so now order is after limit and offset instead of before. I don't fully understand the repercussions of this, but it works fine in my limited testing.