### PR TITLE
Add oracledb stream support

### DIFF
--- a/src/dialects/oracledb/index.js
+++ b/src/dialects/oracledb/index.js
@@ -345,4 +345,14 @@ Client_Oracledb.prototype.processResponse = function(obj, runner) {
   }
 };
 
+Client_Oracledb.prototype._stream = function(connection, obj, stream, options) {
+  obj.sql = this.positionBindings(obj.sql);
+  return new Promise(function (resolver, rejecter) {
+    stream.on('error', rejecter);
+    stream.on('end', resolver);
+    const queryStream = connection.queryStream(obj.sql, obj.bindings || [])
+    queryStream.pipe(stream)
+  });
+};
+
 module.exports = Client_Oracledb;

--- a/test/tape/stream.js
+++ b/test/tape/stream.js
@@ -20,4 +20,19 @@ module.exports = function(knex) {
     })
   }
 
+  if (knex.client.driverName === 'oracledb') {
+    tape('it streams properly in oracle', function(t) {
+      const writableStream = new stream.Writable({
+        objectMode: true
+      });
+      w._write = function(chunk, _, next) {
+        setTimeout(next, 10);
+      }
+      knex.raw('select Rownum r From dual Connect By Rownum <= 10').pipe(w).on('finish', function () {
+        console.log('finished');
+        t.end()
+      });
+    })
+  }
+
 }

--- a/test/tape/stream.js
+++ b/test/tape/stream.js
@@ -22,7 +22,7 @@ module.exports = function(knex) {
 
   if (knex.client.driverName === 'oracledb') {
     tape('it streams properly in oracle', function(t) {
-      const writableStream = new stream.Writable({
+      var writableStream = new stream.Writable({
         objectMode: true
       });
       w._write = function(chunk, _, next) {
@@ -34,5 +34,4 @@ module.exports = function(knex) {
       });
     })
   }
-
 }


### PR DESCRIPTION
I took a stab at adding support for the Client_Oracledb class to use oracledb#queryStream method to stream results through knex. I added a test but not sure if more is needed so please let me know if I need to make more tests or change how I setup the streaming feature. Finally I wasn't sure how to get the tests working locally with oracledb and an oracle db so I'm hoping the tests will work correctly in travis but if not I'd appreciate some help in getting the tests working locally and I'll update the docs as well.
