### PR TITLE
🚨 Add test for bad client supplied in Knex config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 
 import Raw from './raw';
-import { warn } from './helpers';
+import { error, warn } from './helpers';
 import Client from './client';
 
 import makeClient from './util/make-client';
@@ -29,7 +29,15 @@ export default function Knex(config) {
     Dialect = makeClient(config.client)
   } else {
     const clientName = config.client || config.dialect
-    Dialect = makeClient(require(`./dialects/${aliases[clientName] || clientName}/index.js`))
+    try {
+      Dialect = makeClient(require(`./dialects/${aliases[clientName] || clientName}/index.js`))
+    } catch (reason) {
+      error(`Client or dialect provided, "${clientName}", ` +
+        `to the knex configuration was not found. ` +
+        `Did you make a typo? ` +
+        `Example dialects: "maria", "pg", etc.`)
+      throw reason;
+    }
   }
   if (typeof config.connection === 'string') {
     config = assign({}, config, {connection: parseConnection(config.connection).connection})

--- a/test/index.js
+++ b/test/index.js
@@ -29,6 +29,11 @@ describe('Query Building Tests', function() {
   require('./unit/schema/oracle')
   require('./unit/schema/mssql')
   require('./unit/schema/oracledb')
+})
+
+describe('Configuration Tests', function () {
+  this.timeout(process.env.KNEX_TEST_TIMEOUT || 5000);
+  
   require('./unit/knexfile-test')
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -29,6 +29,7 @@ describe('Query Building Tests', function() {
   require('./unit/schema/oracle')
   require('./unit/schema/mssql')
   require('./unit/schema/oracledb')
+  require('./unit/knexfile-test')
 })
 
 describe('Integration Tests', function() {

--- a/test/unit/knexfile-test.js
+++ b/test/unit/knexfile-test.js
@@ -1,14 +1,34 @@
-/*global expect, describe, it*/
+/*global expect, describe, it, beforeEach, afterEach*/
 
 'use strict';
 
+// const sinon = require('sinon')
+
 describe('Bad knexfile.js', function() {
+  // let sandbox
+
+  // beforeEach(function() {
+  //   sandbox = sinon.sandbox.create()
+  // });
+
+  // afterEach(function() {
+  //   sandbox.restore()
+  // })
 
   it('should throw an error when a bad client is supplied', function() {
-    var knex = require('../../knex');
+    // sandbox.stub(console, 'log')
+    const knex = require('../../knex');
     expect(function () {
       knex({client: 'badclient'})
-    }).to.throw(/Cannot find module '\.\/dialects\/badclient\/index.js'/)
+    })
+    .to.throw(/Cannot find module '\.\/dialects\/badclient\/index.js'/)
+    // expect(console.log.calledOnce).to.be.true;
+    // expect(console.log.calledWith(
+    //   `Client or dialect provided, "badclient", ` +
+    //   `to the knex configuration was not found. ` +
+    //   `Did you make a typo? ` +
+    //   `Example dialects: "maria", "pg", etc.`)
+    // ).to.be.true;
   });
 
 });

--- a/test/unit/knexfile-test.js
+++ b/test/unit/knexfile-test.js
@@ -1,34 +1,15 @@
-/*global expect, describe, it, beforeEach, afterEach*/
+/*global expect, describe, it*/
 
 'use strict';
 
-// const sinon = require('sinon')
-
 describe('Bad knexfile.js', function() {
-  // let sandbox
-
-  // beforeEach(function() {
-  //   sandbox = sinon.sandbox.create()
-  // });
-
-  // afterEach(function() {
-  //   sandbox.restore()
-  // })
 
   it('should throw an error when a bad client is supplied', function() {
-    // sandbox.stub(console, 'log')
-    const knex = require('../../knex');
+    var knex = require('../../knex');
     expect(function () {
       knex({client: 'badclient'})
     })
     .to.throw(/Cannot find module '\.\/dialects\/badclient\/index.js'/)
-    // expect(console.log.calledOnce).to.be.true;
-    // expect(console.log.calledWith(
-    //   `Client or dialect provided, "badclient", ` +
-    //   `to the knex configuration was not found. ` +
-    //   `Did you make a typo? ` +
-    //   `Example dialects: "maria", "pg", etc.`)
-    // ).to.be.true;
   });
 
 });

--- a/test/unit/knexfile-test.js
+++ b/test/unit/knexfile-test.js
@@ -1,0 +1,14 @@
+/*global expect, describe, it*/
+
+'use strict';
+
+describe('Bad knexfile.js', function() {
+
+  it('should throw an error when a bad client is supplied', function() {
+    var knex = require('../../knex');
+    expect(function () {
+      knex({client: 'badclient'})
+    }).to.throw(/Cannot find module '\.\/dialects\/badclient\/index.js'/)
+  });
+
+});


### PR DESCRIPTION
When the user provides a bad client in the `knexfile.js`, provide a more useful error than the one thrown by `require`.

I left in some commented out code for testing against `console.log`, but it was ugly so I took it out.
