### PR TITLE
Add example to Foreign Key

### DIFF
--- a/index.html
+++ b/index.html
@@ -2139,7 +2139,6 @@ knex.table('users')
       <tt>SET NULL</tt>, <tt>NO ACTION</tt>) for the operation.  Note, this is the same as <code>column.references(column)</code>
       but works for existing columns.
     <pre class="display">
-    knex.table('users');
     table.integer('user_id').unsigned();
     table.foreign('user_id').references('Items.user_id_in_items');
     </pre>

--- a/index.html
+++ b/index.html
@@ -2138,7 +2138,13 @@ knex.table('users')
       You can also chain <tt>onDelete</tt> and/or <tt>onUpdate</tt> to set the reference option (<tt>RESTRICT</tt>, <tt>CASCADE</tt>,
       <tt>SET NULL</tt>, <tt>NO ACTION</tt>) for the operation.  Note, this is the same as <code>column.references(column)</code>
       but works for existing columns.
+    <pre class="display">
+    knex.table('users');
+    table.integer('user_id').unsigned();
+    table.foreign('user_id').references('Items.user_id_in_items');
+    </pre>
     </p>
+
 
     <p id="Schema-dropForeign">
       <b class="header">dropForeign</b><code>table.dropForeign(columns, [foreignKeyName])</code>


### PR DESCRIPTION
Adds an example to Foreign Key method. This method of adding a column and foreign key currently works while the others seem to be broken.