### PR TITLE
Adding link to ease editing the docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
       <li>&raquo; <a href="#support">Support</a></li>
       <li>&raquo; <a href="#faq">FAQ</a></li>
       <li>&raquo; <a href="#changelog">Change Log</a></li>
+      <li>&raquo; <a href="{{site.github.repository_url}}/blob/gh-pages/{{page.path}}">Edit this page</a></li>
     </ul>
 
     <a class="toc_title" href="#Upgrading">


### PR DESCRIPTION
According to https://github.com/jekyll/jekyll-help/issues/5, this type of link will work, however, I don't know how to test to make sure this will produce a meaningful link. Suggestions welcome.