### PR TITLE
Use Tarn.js as a pool instead of generic-pool. fixes #1694 #1703

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "chalk": "^1.0.0",
     "commander": "^2.2.0",
     "debug": "^2.1.3",
-    "generic-pool": "^2.4.2",
     "inherits": "~2.0.1",
     "interpret": "^0.6.5",
     "liftoff": "~2.2.0",
@@ -20,6 +19,7 @@
     "pg-connection-string": "^0.1.3",
     "pool2": "^1.1.0",
     "readable-stream": "^1.1.12",
+    "tarn": "^0.1.4",
     "tildify": "~1.0.0",
     "v8flags": "^2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "pg-connection-string": "^0.1.3",
     "pool2": "^1.1.0",
     "readable-stream": "^1.1.12",
-    "tarn": "^0.1.4",
+    "tarn": "^0.1.5",
     "tildify": "~1.0.0",
     "v8flags": "^2.0.2"
   },

--- a/test/integration/suite.js
+++ b/test/integration/suite.js
@@ -30,7 +30,7 @@ module.exports = function(knex) {
 
     describe('knex.destroy', function() {
       it('should allow destroying the pool with knex.destroy', function() {
-        var spy = sinon.spy(knex.client.pool, 'destroyAllNow');
+        var spy = sinon.spy(knex.client.pool, 'destroy');
         return knex.destroy().then(function() {
           expect(spy).to.have.callCount(1);
           expect(knex.client.pool).to.equal(undefined);

--- a/test/tape/pool.js
+++ b/test/tape/pool.js
@@ -2,7 +2,7 @@
 
 var test   = require('tape')
 var Client = require('../../lib/dialects/sqlite3');
-var Pool = require('generic-pool').Pool
+var Pool = require('tarn').Pool
 
 test('#822, pool config, max: 0 should skip pool construction', function(t) {
 


### PR DESCRIPTION
This pull request replaces the generic-pool with [Tarn.js](https://github.com/Vincit/tarn.js).

generic-pool doesn't have a built-in timeout for connection acquire nor does
it have a mechanism to cancel a pending acquire. Because of this the issue
#1694 is next to impossible to fix on the knex side.

generic-pool doesn't seem to be well maintained anymore. The last commit is
six monhts old at time of writing this and there are multiple pull requests
waiting, one of which is a fix for the acquire timeout needed here.

Tarn.js is a subset of generic-pool with added timeouts and a comprehensive
test suite. It is designed (by me) to be used with knex and I intend to make
that its only purpose. If you choose to merge this pull request. I'm committed 
to maintaining and bug fixing it to serve knex as well as possible. 

This pull request also fixes an issue #1703 where connections acquired for
transactions never time out, regardless of acquireConnectionTimeout