### PR TITLE
Adding return's to address warnings mentioned in #1388

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -183,7 +183,7 @@ assign(Runner.prototype, {
   ensureConnection() {
     return Promise.try(() => {
       return this.connection || new Promise((resolver, rejecter) => {
-        this.client.acquireConnection()
+        return this.client.acquireConnection()
           .then(resolver)
           .catch(Promise.TimeoutError, (error) => {
             if (this.builder) {
@@ -195,7 +195,7 @@ assign(Runner.prototype, {
           .catch(rejecter)
       })
     }).disposer(() => {
-      this.client.releaseConnection(this.connection)
+      return this.client.releaseConnection(this.connection)
     })
   }
 


### PR DESCRIPTION
This addresses warnings generated because we don't explicitly return a promise as mentioned in Bluebird's API documentation:
http://bluebirdjs.com/docs/warning-explanations.html