### PR TITLE
Fix: config.pool default min may greater than user's config max

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -163,9 +163,11 @@ assign(Client.prototype, {
 
   poolDefaults(poolConfig) {
     const name = this.dialect + ':' + this.driverName + ':' + this.__cid
+    let min = poolConfig.min || 2, max = poolConfig.max || 10
+    if (max > min) min = max
     return {
-      min: 2,
-      max: 10,
+      min: min,
+      max: max,
       name: name,
       log(str, level) {
         if (level === 'info') {


### PR DESCRIPTION
use case: 

```
  const knex = require('knex')({
    pool: {max: 1}
  })
```

Now, knex would thorw error, while pool max should greater than min.
