### PR TITLE
Feature/alter column

### DIFF
--- a/src/dialects/mssql/schema/tablecompiler.js
+++ b/src/dialects/mssql/schema/tablecompiler.js
@@ -41,10 +41,12 @@ assign(TableCompiler_MSSQL.prototype, {
   alterColumnPrefix: 'ALTER COLUMN ',
 
   // Compiles column add.  Multiple columns need only one ADD clause (not one ADD per column) so core addColumns doesn't work.  #1348
-  addColumns (columns) {
+  addColumns (columns, prefix) {
+    prefix = prefix || this.addColumnsPrefix;
+
     if (columns.sql.length > 0) {
       this.pushQuery({
-        sql: (this.lowerCase ? 'alter table ' : 'ALTER TABLE ') + this.tableName() + ' ' + this.addColumnsPrefix + columns.sql.join(', '),
+        sql: (this.lowerCase ? 'alter table ' : 'ALTER TABLE ') + this.tableName() + ' ' + prefix + columns.sql.join(', '),
         bindings: columns.bindings
       });
     }

--- a/src/dialects/mssql/schema/tablecompiler.js
+++ b/src/dialects/mssql/schema/tablecompiler.js
@@ -38,6 +38,8 @@ assign(TableCompiler_MSSQL.prototype, {
 
   dropColumnPrefix: 'DROP COLUMN ',
 
+  alterColumnPrefix: 'ALTER COLUMN ',
+
   // Compiles column add.  Multiple columns need only one ADD clause (not one ADD per column) so core addColumns doesn't work.  #1348
   addColumns (columns) {
     if (columns.sql.length > 0) {

--- a/src/dialects/mysql/schema/tablecompiler.js
+++ b/src/dialects/mysql/schema/tablecompiler.js
@@ -50,6 +50,8 @@ assign(TableCompiler_MySQL.prototype, {
 
   addColumnsPrefix: 'add ',
 
+  alterColumnsPrefix: 'modify ',
+
   dropColumnPrefix: 'drop ',
 
   // Compiles the comment on the table.

--- a/src/dialects/oracle/schema/tablecompiler.js
+++ b/src/dialects/oracle/schema/tablecompiler.js
@@ -51,6 +51,8 @@ assign(TableCompiler_Oracle.prototype, {
 
   addColumnsPrefix: 'add ',
 
+  alterColumnsPrefix: 'modify ',
+
   dropColumn() {
     const columns = helpers.normalizeArr.apply(null, arguments);
     this.pushQuery(`alter table ${this.tableName()} drop (${this.formatter.columnize(columns)})`);

--- a/src/schema/columnbuilder.js
+++ b/src/schema/columnbuilder.js
@@ -3,7 +3,8 @@ import { extend, each, toArray } from 'lodash'
 
 // The chainable interface off the original "column" method.
 export default function ColumnBuilder(client, tableBuilder, type, args) {
-  this.client = client
+  this.client = client;
+  this._method = 'add';
   this._single = {};
   this._modifiers = {};
   this._statements = [];
@@ -69,6 +70,7 @@ const AlterMethods = {};
 // over all other rules for the column.
 AlterMethods.drop = function() {
   this._single.drop = true;
+
   return this;
 };
 
@@ -80,9 +82,16 @@ AlterMethods.alterType = function(type) {
     grouping: 'alterType',
     value: type
   });
+
   return this;
 };
 
+// Set column method to alter (default is add).
+AlterMethods.alter = function() {
+  this._method = 'alter';
+
+  return this;
+};
 
 // Alias a few methods for clarity when processing.
 const columnAlias = {

--- a/test/unit/schema/mssql.js
+++ b/test/unit/schema/mssql.js
@@ -92,6 +92,17 @@ describe("MSSQL SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] DROP CONSTRAINT [users_foo_unique]');
   });
 
+  it('should alter columns with the alter flag', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.string('foo').alter();
+      this.string('bar');
+    }).toSQL();
+
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [bar] nvarchar(255)');
+    expect(tableSql[1].sql).to.equal('ALTER TABLE [users] alter column [foo] nvarchar(255)');
+  });
+
   it('test drop unique, custom', function() {
     tableSql = client.schemaBuilder().table('users', function() {
       this.dropUnique(null, 'foo');

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -461,6 +461,17 @@ describe(dialect + " SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table `users` add `foo` decimal(2, 6)');
   });
 
+  it('should alter columns with the alter flag', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.string('foo').alter();
+      this.string('bar');
+    }).toSQL();
+
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table `users` add `bar` varchar(255)');
+    expect(tableSql[1].sql).to.equal('alter table `users` modify `foo` varchar(255)');
+  });
+
   it('is possible to set raw statements in defaultTo, #146', function() {
     tableSql = client.schemaBuilder().createTable('default_raw_test', function(t) {
       t.timestamp('created_at').defaultTo(client.raw('CURRENT_TIMESTAMP'));

--- a/test/unit/schema/oracle.js
+++ b/test/unit/schema/oracle.js
@@ -74,6 +74,17 @@ describe("Oracle SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table "users" drop ("foo", "bar")');
   });
 
+  it('should alter columns with the alter flag', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.string('foo').alter();
+      this.string('bar');
+    }).toSQL();
+
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "bar" varchar2(255)');
+    expect(tableSql[1].sql).to.equal('alter table "users" modify "foo" varchar2(255)');
+  });
+
   it('test drop primary', function() {
     tableSql = client.schemaBuilder().table('users', function() {
       this.dropPrimary();


### PR DESCRIPTION
Fixes some issues from #46 

After this PR, a couple of things will have to be done:
1. ~~Update the docs to document this method~~ https://github.com/knex/documentation/pull/8
2. ~~Add to dialects (alter column works for most, and I already added mysql)~~
3. ~~Add tests~~

The code in this PR works as follows:

``` js
knex.alterTable('user', table => {
  table.string('something', 50).notNullable();
  table.string('username', 35).notNullable().alter();
  table.dropColumn('reasons');
});
```

which generates:

```
~/projects/wetland [ time node app
alter table `user` add `something` varchar(50) not null;
alter table `user` modify `username` varchar(35) not null;
alter table `user` drop `reasons`;
```
