### PR TITLE
Add sugar using ES6 template literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "bluebird": "^3.4.6",
     "chalk": "^1.0.0",
     "commander": "^2.2.0",
+    "common-tags": "^1.3.1",
     "debug": "^2.1.3",
     "generic-pool": "^2.4.2",
     "inherits": "~2.0.1",

--- a/src/client.js
+++ b/src/client.js
@@ -102,6 +102,10 @@ assign(Client.prototype, {
     return new Raw(this).set(...arguments)
   },
 
+  tpl() {
+    return new Raw(this).template(...arguments)
+  },
+
   _formatQuery(sql, bindings, timeZone) {
     bindings = bindings == null ? [] : [].concat(bindings);
     let index = 0;

--- a/src/raw.js
+++ b/src/raw.js
@@ -7,6 +7,7 @@ import { EventEmitter } from 'events';
 import debug from 'debug'
 
 import { assign, reduce, isPlainObject, isObject, isUndefined, isNumber } from 'lodash'
+import { stripIndent } from 'common-tags';
 import Formatter from './formatter'
 
 import uuid from 'node-uuid';
@@ -42,6 +43,10 @@ assign(Raw.prototype, {
     ) ? bindings : [bindings]
 
     return this
+  },
+
+  template(parts, ...bindings) {
+    return this.set(stripIndent`${parts.join('?')}`, bindings);
   },
 
   timeout(ms, {cancel} = {}) {

--- a/src/util/make-knex.js
+++ b/src/util/make-knex.js
@@ -33,6 +33,10 @@ export default function makeKnex(client) {
       return client.raw.apply(client, arguments)
     },
 
+    tpl() {
+      return client.tpl.apply(client, arguments)
+    },
+
     batchInsert(table, batch, chunkSize = 1000) {
       return new BatchInsert(this, table, batch, chunkSize);
     },


### PR DESCRIPTION
This allows the following:

```
knex.tpl`
  select * from "sometable"
  join "othertable"
    on "other_field" = ${otherFieldValue}
  where "some_field" = ${someFieldValue}`
```
And the bindings will be automatically separated and passed to `knex.raw`. Not too different from named bindings, but much less code internally.

Any feedback?