### PR TITLE
Support knexfile, migration and seeds in TypeScript

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -71,7 +71,7 @@ function initKnex(env) {
 
 function invoke(env) {
 
-  var filetypes = ['js', 'coffee', 'eg', 'ls'];
+  var filetypes = ['js', 'coffee', 'ts', 'eg', 'ls'];
   var pending = null;
 
   commander

--- a/src/migrate/index.js
+++ b/src/migrate/index.js
@@ -18,7 +18,7 @@ function LockError(msg) {
 inherits(LockError, Error);
 
 const SUPPORTED_EXTENSIONS = Object.freeze([
-  '.co', '.coffee', '.eg', '.iced', '.js', '.litcoffee', '.ls'
+  '.co', '.coffee', '.eg', '.iced', '.js', '.litcoffee', '.ls', '.ts'
 ]);
 
 const CONFIG_DEFAULT = Object.freeze({

--- a/src/migrate/stub/knexfile-ts.stub
+++ b/src/migrate/stub/knexfile-ts.stub
@@ -1,0 +1,44 @@
+// Update with your config settings.
+
+module.exports = {
+
+  development: {
+    client: "sqlite3",
+    connection: {
+      filename: "./dev.sqlite3"
+    }
+  },
+
+  staging: {
+    client: "postgresql",
+    connection: {
+      database: "my_db",
+      user: "username",
+      password: "password"
+    },
+    pool: {
+      min: 2,
+      max: 10
+    },
+    migrations: {
+      tableName: "knex_migrations"
+    }
+  },
+
+  production: {
+    client: "postgresql",
+    connection: {
+      database: "my_db",
+      user: "username",
+      password: "password"
+    },
+    pool: {
+      min: 2,
+      max: 10
+    },
+    migrations: {
+      tableName: "knex_migrations"
+    }
+  }
+
+};

--- a/src/migrate/stub/ts.stub
+++ b/src/migrate/stub/ts.stub
@@ -1,0 +1,16 @@
+import * as Knex from "knex";
+
+exports.up = function (knex: Knex) {
+    <% if (d.tableName) { %>
+    return knex.schema.createTable("<%= d.tableName %>", function (t) {
+        t.increments();
+        t.timestamps();
+    });
+    <% } %>
+};
+
+exports.down = function (knex: Knex) {
+    <% if (d.tableName) { %>
+    return knex.schema.dropTable("<%= d.tableName %>");
+    <% } %>
+};

--- a/src/migrate/stub/ts.stub
+++ b/src/migrate/stub/ts.stub
@@ -1,6 +1,6 @@
 import * as Knex from "knex";
 
-exports.up = function (knex: Knex) {
+exports.up = function (knex: Knex): Promise<any> {
     <% if (d.tableName) { %>
     return knex.schema.createTable("<%= d.tableName %>", function (t) {
         t.increments();
@@ -9,7 +9,7 @@ exports.up = function (knex: Knex) {
     <% } %>
 };
 
-exports.down = function (knex: Knex) {
+exports.down = function (knex: Knex): Promise<any> {
     <% if (d.tableName) { %>
     return knex.schema.dropTable("<%= d.tableName %>");
     <% } %>

--- a/src/seed/index.js
+++ b/src/seed/index.js
@@ -43,7 +43,7 @@ Seeder.prototype._listAll = Promise.method(function(config) {
     .then(seeds =>
       filter(seeds, function(value) {
         const extension = path.extname(value);
-        return includes(['.co', '.coffee', '.eg', '.iced', '.js', '.litcoffee', '.ls'], extension);
+        return includes(['.co', '.coffee', '.eg', '.iced', '.js', '.litcoffee', '.ls', '.ts'], extension);
       }).sort()
     );
 });

--- a/src/seed/index.js
+++ b/src/seed/index.js
@@ -43,7 +43,8 @@ Seeder.prototype._listAll = Promise.method(function(config) {
     .then(seeds =>
       filter(seeds, function(value) {
         const extension = path.extname(value);
-        return includes(['.co', '.coffee', '.eg', '.iced', '.js', '.litcoffee', '.ls', '.ts'], extension);
+        return includes(
+          ['.co', '.coffee', '.eg', '.iced', '.js', '.litcoffee', '.ls', '.ts'], extension);
       }).sort()
     );
 });

--- a/src/seed/stub/ts.stub
+++ b/src/seed/stub/ts.stub
@@ -4,11 +4,11 @@ exports.seed = function (knex: Knex): Promise<any> {
     // Deletes ALL existing entries
     return knex("table_name").del()
         .then(function () {
-            return Promise.all([
-                // Inserts seed entries
-                knex("table_name").insert({ id: 1, colName: "rowValue1" }),
-                knex("table_name").insert({ id: 2, colName: "rowValue2" }),
-                knex("table_name").insert({ id: 3, colName: "rowValue3" })
+            // Inserts seed entries
+            return knex("table_name").insert([
+                { id: 1, colName: "rowValue1" },
+                { id: 2, colName: "rowValue2" },
+                { id: 3, colName: "rowValue3" }
             ]);
         });
 };

--- a/src/seed/stub/ts.stub
+++ b/src/seed/stub/ts.stub
@@ -1,0 +1,14 @@
+import * as Knex from "knex";
+
+exports.seed = function (knex: Knex) {
+  // Deletes ALL existing entries
+  return knex("table_name").del()
+    .then(function () {
+      return Promise.all([
+        // Inserts seed entries
+        knex("table_name").insert({ id: 1, colName: "rowValue1" }),
+        knex("table_name").insert({ id: 2, colName: "rowValue2" }),
+        knex("table_name").insert({ id: 3, colName: "rowValue3" })
+      ]);
+    });
+};

--- a/src/seed/stub/ts.stub
+++ b/src/seed/stub/ts.stub
@@ -1,14 +1,14 @@
 import * as Knex from "knex";
 
-exports.seed = function (knex: Knex) {
-  // Deletes ALL existing entries
-  return knex("table_name").del()
-    .then(function () {
-      return Promise.all([
-        // Inserts seed entries
-        knex("table_name").insert({ id: 1, colName: "rowValue1" }),
-        knex("table_name").insert({ id: 2, colName: "rowValue2" }),
-        knex("table_name").insert({ id: 3, colName: "rowValue3" })
-      ]);
-    });
+exports.seed = function (knex: Knex): Promise<any> {
+    // Deletes ALL existing entries
+    return knex("table_name").del()
+        .then(function () {
+            return Promise.all([
+                // Inserts seed entries
+                knex("table_name").insert({ id: 1, colName: "rowValue1" }),
+                knex("table_name").insert({ id: 2, colName: "rowValue2" }),
+                knex("table_name").insert({ id: 3, colName: "rowValue3" })
+            ]);
+        });
 };


### PR DESCRIPTION
This will allow using `knex` in a TypeScript project. These commands will now work:

```bash
$ knex init -x ts
$ knex migrate:make migration_name
$ knex seed:make seed_name
```

`knex` will now generate and automatically pick up `knexfile.ts`, `migration_name.ts`, `seed_name.ts`, assuming [`ts-node`](https://github.com/TypeStrong/ts-node) is available to execute from within the project.

If you like this, I'll also update the docs to indicate that this option is now available.