### PR TITLE
Mssql update query generates invalid syntax

### DIFF
--- a/src/dialects/mssql/query/compiler.js
+++ b/src/dialects/mssql/query/compiler.js
@@ -73,8 +73,8 @@ assign(QueryCompiler_MSSQL.prototype, {
     const { returning } = this.single;
     return {
       sql: this.with() + `update ${top ? top + ' ' : ''}${this.tableName}` +
-        (join ? ` ${join}` : '') +
         ' set ' + updates.join(', ') +
+        (join ? ` from ${this.tableName} ${join}` : '') +
         (returning ? ` ${this._returning('update', returning)}` : '') +
         (where ? ` ${where}` : '') +
         (order ? ` ${order}` : '') +

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -3032,7 +3032,7 @@ describe("QueryBuilder", function() {
         bindings: ['Boonesville', 1, 5]
       },
       mssql: {
-        sql: 'update [tblPerson] inner join [tblPersonData] on [tblPersonData].[PersonId] = [tblPerson].[PersonId] set [tblPerson].[City] = ? where [tblPersonData].[DataId] = ? and [tblPerson].[PersonId] = ?;select @@rowcount',
+        sql: 'update [tblPerson] set [tblPerson].[City] = ? from [tblPerson] inner join [tblPersonData] on [tblPersonData].[PersonId] = [tblPerson].[PersonId] where [tblPersonData].[DataId] = ? and [tblPerson].[PersonId] = ?;select @@rowcount',
         bindings: ['Boonesville', 1, 5]
       },
       postgres: {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -2630,7 +2630,7 @@ describe("QueryBuilder", function() {
         bindings: ['foo', 'bar', 1]
       },
       mssql: {
-        sql: 'update [users] set [email] = ?, [name] = ? inner join [orders] on [users].[id] = [orders].[user_id] where [users].[id] = ?;select @@rowcount',
+        sql: 'update [users] set [email] = ?, [name] = ? from [users] inner join [orders] on [users].[id] = [orders].[user_id] where [users].[id] = ?;select @@rowcount',
         bindings: ['foo', 'bar', 1]
       },
       postgres: {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -2630,7 +2630,7 @@ describe("QueryBuilder", function() {
         bindings: ['foo', 'bar', 1]
       },
       mssql: {
-        sql: 'update [users] inner join [orders] on [users].[id] = [orders].[user_id] set [email] = ?, [name] = ? where [users].[id] = ?;select @@rowcount',
+        sql: 'update [users] set [email] = ?, [name] = ? inner join [orders] on [users].[id] = [orders].[user_id] where [users].[id] = ?;select @@rowcount',
         bindings: ['foo', 'bar', 1]
       },
       postgres: {


### PR DESCRIPTION
The update query for SQL Server requires `from` when doing a join. The join must also be after the `set`. See [here](http://stackoverflow.com/questions/982919/sql-update-query-using-joins).