### PR TITLE
Fix erroneous float to integer conversion of decimal fields in MSSQL

### DIFF
--- a/src/dialects/mssql/index.js
+++ b/src/dialects/mssql/index.js
@@ -165,15 +165,15 @@ assign(Client_MSSQL.prototype, {
   // sets a request input parameter. Detects bigints and decimals and sets type appropriately.
   _setReqInput(req, i, binding) {
     if (typeof binding == 'number') {
-      if (binding % 1 != 0) {
-        req.input(`p${i}`, this.driver.Decimal(38,10), binding);
+      if (binding % 1 !== 0) {
+        req.input(`p${i}`, this.driver.Decimal(38, 10), binding)
       } else if (binding < SQL_INT4.MIN || binding > SQL_INT4.MAX) {
         if (binding < SQL_BIGINT_SAFE.MIN || binding > SQL_BIGINT_SAFE.MAX) {
           throw new Error(`Bigint must be safe integer or must be passed as string, saw ${binding}`)
         }
-        req.input(`p${i}`, this.driver.BigInt, binding);
+        req.input(`p${i}`, this.driver.BigInt, binding)
       } else {
-        req.input(`p${i}`, this.driver.Int, binding);
+        req.input(`p${i}`, this.driver.Int, binding)
       }
     } else {
       req.input(`p${i}`, binding)

--- a/test/integration/datatype/bigint.js
+++ b/test/integration/datatype/bigint.js
@@ -70,4 +70,29 @@ module.exports = function (knex) {
             expect(err).to.be.undefined;
         });
     });
+
+    it('#1781 - decimal value must not be converted to integer', function () {
+        if (!/mssql/i.test(knex.client.dialect)) {
+            return
+        }
+
+        var tableName = 'decimal_test'
+        var value = 123.4567
+
+        return knex.transaction(function (tr) {
+            return tr.schema.dropTableIfExists(tableName)
+                .then(function () {
+                    return tr.schema.createTable(tableName, function (table) {
+                        table.increments()
+                        table.decimal('value', 14, 4).notNullable()
+                    })
+                })
+        }).then(function () {
+            return knex(tableName).insert({ value: value })
+        }).then(function () {
+            return knex(tableName).first('value')
+        }).then(function (response) {
+            expect(response.value).to.be.eql(value)
+        })
+    })
 };


### PR DESCRIPTION
Essentially, this is a fix for #1604 (also, relates to https://github.com/patriksimek/node-mssql/issues/341).

When using Knex with MSSQL dialect, float values get truncated and, as a result, integer values get saved in decimal fields. This pull request fixes this invalid behaviour.

Feel free to comment or to suggest better solution 😉 