### PR TITLE
allow to use `first` method as aliased select

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -142,7 +142,10 @@ export default class Formatter {
   outputQuery(compiled, isParameter) {
     let sql = compiled.sql || '';
     if (sql) {
-      if (compiled.method === 'select' && (isParameter || compiled.as)) {
+      if (
+        (compiled.method === 'select' || compiled.method === 'first') &&
+        (isParameter || compiled.as)
+      ) {
         sql = `(${sql})`;
         if (compiled.as) return this.alias(sql, this.wrap(compiled.as))
       }

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -59,7 +59,7 @@ assign(QueryCompiler.prototype, {
 
     defaults.bindings = defaults.bindings || [];
 
-    if (method === 'select') {
+    if (method === 'select' || method === 'first') {
       if(this.single.as) {
         defaults.as = this.single.as;
       }


### PR DESCRIPTION
allow to write something like this

```js
let subselect = knex.first('column').from('table2 as t2')
  .where(knex.raw('t2.ref_id = t1.id'))
  .orderBy('t2.created_at', 'desc').as('column');

let query = knex('table1 as t1')
  .first('t1.*', subselect)
  .where({'t1.id': id, 't1.removed_at': null});
```

without necessity to do `knex.select().limit().as('alias')`