### PR TITLE
Use new safe buffer allocation to conform with deprecation of `new Buffer(size)`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "node-uuid": "^1.4.7",
     "pg-connection-string": "^0.1.3",
     "readable-stream": "^1.1.12",
+    "safe-buffer": "^5.0.1",
     "tildify": "~1.0.0",
     "v8flags": "^2.0.2"
   },

--- a/src/dialects/oracledb/index.js
+++ b/src/dialects/oracledb/index.js
@@ -13,6 +13,7 @@ const helpers = require('../../helpers');
 const Transaction = require('./transaction');
 const Client_Oracle = require('../oracle');
 const Oracle_Formatter = require('../oracle/formatter');
+const Buffer = require('safe-buffer').Buffer;
 
 function Client_Oracledb() {
   Client_Oracle.apply(this, arguments);
@@ -305,7 +306,7 @@ function readStream(stream, cb) {
   if (stream.iLob.type === oracledb.CLOB) {
     stream.setEncoding('utf-8');
   } else {
-    data = new Buffer(0);
+    data = Buffer.alloc(0);
   }
   stream.on('error', function(err) {
     cb(err);


### PR DESCRIPTION
Use of 'new Buffer' has been deprecated in node v6. This swaps the only
deprecated buffer creation in knex with a safe new way of doing allocation. It uses the
safe-buffer module to stay backwards compatible with node < v4. For the full story see [here](https://github.com/AlexTes/buffer-deprecation)

I'd also be totally open to switching out the safe-buffer shim with a ponyfill.

The deprecated method of buffer creation concerns the oracle dialect. I tried to run the tests but failed to do so. If someone who can run the `DB='oracle' npm test` command would try it I'd be very grateful.

To be clear, this doesn't fix #1763. That issue is with knex' dependencies still. In particular node-postgres. However now that `new Buffer(size)` has also been deprecated this should be merged.