### PR TITLE
Ensure that 'client' is provided in knex config object

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -37,6 +37,14 @@ function clientId() {
 // for a dialect specific client object.
 function Client(config = {}) {
   this.config = config
+
+  //Client is a required field, so throw error if it's not supplied.
+  //If 'this.dialect' is set, then this is a 'super()' call, in which case
+  //'client' does not have to be set as it's already assigned on the client prototype.
+  if(!this.config.client && !this.dialect) {
+    throw new Error(`knex: Required configuration option 'client' is missing.`)
+  }
+
   this.connectionSettings = cloneDeep(config.connection || {})
   if (this.driverName && config.connection) {
     this.initializeDriver()

--- a/src/dialects/oracle/schema/columncompiler.js
+++ b/src/dialects/oracle/schema/columncompiler.js
@@ -9,8 +9,8 @@ import Trigger from './trigger';
 // -------
 
 function ColumnCompiler_Oracle() {
-  this.modifiers = ['defaultTo', 'checkIn', 'nullable', 'comment'];
   ColumnCompiler.apply(this, arguments);
+  this.modifiers = ['defaultTo', 'checkIn', 'nullable', 'comment'];
 }
 inherits(ColumnCompiler_Oracle, ColumnCompiler);
 

--- a/src/dialects/sqlite3/schema/columncompiler.js
+++ b/src/dialects/sqlite3/schema/columncompiler.js
@@ -6,8 +6,8 @@ import ColumnCompiler from '../../../schema/columncompiler';
 // -------
 
 function ColumnCompiler_SQLite3() {
-  this.modifiers = ['nullable', 'defaultTo'];
   ColumnCompiler.apply(this, arguments);
+  this.modifiers = ['nullable', 'defaultTo'];
 }
 inherits(ColumnCompiler_SQLite3, ColumnCompiler);
 

--- a/src/schema/columncompiler.js
+++ b/src/schema/columncompiler.js
@@ -18,6 +18,7 @@ function ColumnCompiler(client, tableCompiler, columnBuilder) {
   this.isIncrements = (this.type.indexOf('increments') !== -1);
   this.formatter = client.formatter();
   this.sequence = [];
+  this.modifiers = [];
 }
 
 ColumnCompiler.prototype.pushQuery = helpers.pushQuery

--- a/test/tape/knex.js
+++ b/test/tape/knex.js
@@ -65,3 +65,13 @@ test('it should use knex supported dialect', function(t) {
   })
   knexObj.destroy()
 })
+
+test('it should throw error if client is omitted in config', function(t) {
+  t.plan(1);
+  try {
+    var knexObj = knex({});
+    t.deepEqual(true, false); //Don't reach this point
+  } catch(error) {
+    t.deepEqual(error.message, 'knex: Required configuration option \'client\' is missing.');
+  }
+})

--- a/test/tape/query-builder.js
+++ b/test/tape/query-builder.js
@@ -14,7 +14,7 @@ tape('accumulates multiple update calls #647', function(t) {
 
 tape('allows for object syntax in join', function(t) {
   t.plan(1)
-  var qb = new QueryBuilder(new Client())
+  var qb = new QueryBuilder(new Client({client: 'mysql'}))
   var sql = qb.table('users').innerJoin('accounts', {
     'accounts.id': 'users.account_id',
     'accounts.owner_id': 'users.id'
@@ -24,7 +24,7 @@ tape('allows for object syntax in join', function(t) {
 })
 
 tape('clones correctly', function(t) {
-  var qb = new QueryBuilder(new Client())
+  var qb = new QueryBuilder(new Client({client: 'mysql'}))
   var original = qb.table('users').debug().innerJoin('accounts', {
     'accounts.id': 'users.account_id',
     'accounts.owner_id': 'users.id'

--- a/test/tape/raw.js
+++ b/test/tape/raw.js
@@ -5,7 +5,7 @@ var Client = require('../../lib/client')
 var test   = require('tape')
 var _      = require('lodash');
 
-var client = new Client()
+var client = new Client({client: 'mysql'})
 function raw(sql, bindings) {
   return new Raw(client).set(sql, bindings)
 }


### PR DESCRIPTION
The option is documented as required, but it's currently not being validated. This leads to strange side effects such as ones describe in #1628.

I also took the liberty of adding `modifiers` to the base columpcompiler as it currently does not have this property, but it should. 