### PR TITLE
Implement query cancellation in sqlite3 dialect

### DIFF
--- a/src/dialects/sqlite3/index.js
+++ b/src/dialects/sqlite3/index.js
@@ -161,7 +161,8 @@ assign(Client_SQLite3.prototype, {
     try {
       connectionToKill.interrupt();
     } catch (e) {
-      // node-sqlite3 interrupt() throws when there's no real connection acquired or it's being closed; both cases are ignorable
+      // node-sqlite3 interrupt() throws when there's no real connection acquired
+      // or it's being closed; both cases are ignorable
     }
     return Promise.resolve();
   }

--- a/src/dialects/sqlite3/index.js
+++ b/src/dialects/sqlite3/index.js
@@ -153,8 +153,18 @@ assign(Client_SQLite3.prototype, {
       min: 1,
       max: 1
     })
-  }
+  },
 
+  canCancelQuery: true,
+
+  cancelQuery(connectionToKill) {
+    try {
+      connectionToKill.interrupt();
+    } catch (e) {
+      // node-sqlite3 interrupt() throws when there's no real connection acquired or it's being closed; both cases are ignorable
+    }
+    return Promise.resolve();
+  }
 })
 
 export default Client_SQLite3


### PR DESCRIPTION
node-sqlite3 provides an interface to sqlite3_interrupt() since 3.1.4, though not mentioned in the documentation; it can be used as-is for Knex query cancellation interface