### PR TITLE
Fix: ES6 Template literals in migration stubs

### DIFF
--- a/src/migrate/index.js
+++ b/src/migrate/index.js
@@ -261,7 +261,7 @@ export default class Migrator {
     const stubPath = this.config.stub ||
       path.join(__dirname, 'stub', this.config.extension + '.stub');
     return Promise.promisify(fs.readFile, {context: fs})(stubPath).then(stub =>
-      template(stub.toString(), {variable: 'd'})
+      template(stub.toString(), {variable: 'd', interpolate: /<%=([\s\S]+?)%>/g})
     );
   }
 


### PR DESCRIPTION
Override lodash templateSettings.interpolate because by default it interpolates ${variable} syntax.

For example:
```js
> console.log(_.template('foo(`${DBP}`) <%= d.foo %>', { variable: 'd' }).source)
function(d) {
var __t, __p = '';
__p += 'foo(`' +
((__t = (DBP)) == null ? '' : __t) +
'`) ' +
((__t = ( d.foo )) == null ? '' : __t);
return __p
}
```

But if we don't use the default RegExp instance, but a clone instead, it works: 
```js
> console.log(_.template('foo(`${DBP}`) <%= d.foo %>', { variable: 'd', interpolate: /<%=([\s\S]+?)%>/g }).source)
function(d) {
var __t, __p = '';
__p += 'foo(`${DBP}`) ' +
((__t = ( d.foo )) == null ? '' : __t);
return __p
}
```

Due to:
https://github.com/lodash/lodash/blob/4.17.2/lodash.js#L14754