### PR TITLE
Bluebird promise cancellation for sqlite3

### DIFF
--- a/src/dialects/sqlite3/index.js
+++ b/src/dialects/sqlite3/index.js
@@ -161,7 +161,8 @@ assign(Client_SQLite3.prototype, {
     try {
       connectionToKill.interrupt();
     } catch (e) {
-      // node-sqlite3 interrupt() throws when there's no real connection acquired or it's being closed; both cases are ignorable
+      // node-sqlite3 interrupt() throws when there's no real connection acquired
+      // or it's being closed; both cases are ignorable
     }
     return Promise.resolve();
   }

--- a/src/dialects/sqlite3/index.js
+++ b/src/dialects/sqlite3/index.js
@@ -94,9 +94,16 @@ assign(Client_SQLite3.prototype, {
       default:
         callMethod = 'all';
     }
-    return new Promise(function(resolver, rejecter) {
+    return new Promise(function(resolver, rejecter, onCancel) {
       if (!connection || !connection[callMethod]) {
         return rejecter(new Error(`Error calling ${callMethod} on connection.`))
+      }
+      if (onCancel) {
+        onCancel(() => {
+          try {
+            connection.interrupt();
+          } catch (e) {}
+        })
       }
       connection[callMethod](obj.sql, obj.bindings, function(err, response) {
         if (err) return rejecter(err)

--- a/src/dialects/sqlite3/index.js
+++ b/src/dialects/sqlite3/index.js
@@ -102,7 +102,10 @@ assign(Client_SQLite3.prototype, {
         onCancel(() => {
           try {
             connection.interrupt();
-          } catch (e) {}
+          } catch (e) {
+            // see cancelQuery() for why it can be ignored
+            // (also, onCancel() exceptions are thrown away)
+          }
         })
       }
       connection[callMethod](obj.sql, obj.bindings, function(err, response) {

--- a/src/dialects/sqlite3/index.js
+++ b/src/dialects/sqlite3/index.js
@@ -153,8 +153,18 @@ assign(Client_SQLite3.prototype, {
       min: 1,
       max: 1
     })
-  }
+  },
 
+  canCancelQuery: true,
+
+  cancelQuery(connectionToKill) {
+    try {
+      connectionToKill.interrupt();
+    } catch (e) {
+      // node-sqlite3 interrupt() throws when there's no real connection acquired or it's being closed; both cases are ignorable
+    }
+    return Promise.resolve();
+  }
 })
 
 export default Client_SQLite3


### PR DESCRIPTION
Implement query cancellation for sqlite3 driver according to Bluebird promise cancellation semantics:

1. Timeout cancellation in _sqlite3_ driver according to Knex API (available as a separate PR https://github.com/tgriesser/knex/pull/1834 ). E.g. `knexQueryPromise.timeout(5000, { cancel: true })` would actually stop the query execution
2. A fix for Bluebird issue https://github.com/petkaantonov/bluebird/issues/1303 , which requires resource allocator to handle onCancel event if promise cancellation is used. E.g. it ensures `knexQueryPromise.cancel()` doesn't leak the allocated connection if cancellation happens before the allocator promise returns
3. The query cancellation itself in _sqlite3_ driver. E.g. `knexQueryPromise.cancel()` would stop the query execution.

Note that while _mysql_ driver also provides a cancellation API (3) is implemented for _sqlite3_ driver only as the custom query promise is created on the driver level - if such functionality is needed for other drivers, it could either be implemented inside the driver (reusing `cancelQuery()` code) or by wrapping the per-driver query promise in the custom promise in the generic layer, where `onCancel` is handled by calling `cancelQuery()` (though i have no idea about performance and memory use implication of such an extra wrapping)