### PR TITLE
Pass rollback errors through to transaction promise in mssql dialect …

### DIFF
--- a/src/dialects/mssql/transaction.js
+++ b/src/dialects/mssql/transaction.js
@@ -31,7 +31,13 @@ export default class Transaction_MSSQL extends Transaction {
     this._completed = true
     debug('%s: rolling back', this.txid)
     return conn.tx_.rollback()
-      .then(() => this._rejecter(error))
+      .then(
+        () => this._rejecter(error),
+        err => {
+          if (error) err.originalError = error;
+          return this._rejecter(err);
+        }
+      )
   }
 
   rollbackTo(conn, error) {


### PR DESCRIPTION
…(#1884)

Check for rollback failures on mssql and pass them through to the transaction promise-- attaching the underlying cause as an 'originalError' property.  This fixes a hang when mssql server aborts a transaction and the client issues a rollback.