### PR TITLE
Allow casting when using named bindings.

### DIFF
--- a/src/raw.js
+++ b/src/raw.js
@@ -150,7 +150,7 @@ function replaceKeyBindings(raw, formatter) {
 
   let { sql } = raw
 
-  const regex = /\\?(:(\w+):(?!:)|:(\w+):??)/g
+  const regex = /\\?(:(\w+):(?!:)|:(\w+))/g
   sql = raw.sql.replace(regex, function(match, p1, p2, p3) {
     if (match !== p1) {
       return p1

--- a/src/raw.js
+++ b/src/raw.js
@@ -146,20 +146,30 @@ function replaceRawArrBindings(raw, formatter) {
 }
 
 function replaceKeyBindings(raw, formatter) {
+  const values = raw.bindings
+
   let { sql } = raw
 
-  sql = raw.sql.replace(/\\?(:(\w+):(?!:)|:(\w+):??)/g, function(match, p1, p2, p3) {
+  const regex = /\\?(:(\w+):(?!:)|:(\w+):??)/g
+  sql = raw.sql.replace(regex, function(match, p1, p2, p3) {
     if (match !== p1) {
       return p1
     }
 
+    const part = p2 || p3
     const key = match.trim();
     const isIdentifier = key[key.length - 1] === ':'
-    const value = raw.bindings[p2 || p3]
+    const value = values[part]
 
     if (value === undefined) {
+      if (values.hasOwnProperty(part)) {
+        formatter.bindings.push(value);
+      }
+
       return match
-    } else if (isIdentifier) {
+    }
+
+    if (isIdentifier) {
       return match.replace(p1, formatter.columnize(value))
     }
 

--- a/src/raw.js
+++ b/src/raw.js
@@ -150,13 +150,13 @@ function replaceKeyBindings(raw, formatter) {
 
   let { sql } = raw
 
-  const regex = /\\?(:(\w+):(?!:)|:(\w+))/g
-  sql = raw.sql.replace(regex, function(match, p1, p2, p3) {
+  const regex = /\\?(:(\w+):(?=::)|:(\w+):(?!:)|:(\w+))/g
+  sql = raw.sql.replace(regex, function(match, p1, p2, p3, p4) {
     if (match !== p1) {
       return p1
     }
 
-    const part = p2 || p3
+    const part = p2 || p3 || p4
     const key = match.trim();
     const isIdentifier = key[key.length - 1] === ':'
     const value = values[part]

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -3876,6 +3876,7 @@ describe("QueryBuilder", function() {
       [raw(':a: = :b::TEXT OR :c', namedBindings), '"foo" = ?::TEXT OR ?', [namedBindings.b, namedBindings.c]],
       [raw(':a: = :b::TEXT OR :c::TEXT', namedBindings), '"foo" = ?::TEXT OR ?::TEXT', [namedBindings.b, namedBindings.c]],
       [raw(":a: = 'bar'::TEXT OR :b OR :c::TEXT", namedBindings), '"foo" = \'bar\'::TEXT OR ? OR ?::TEXT', [namedBindings.b, namedBindings.c]],
+      [raw(":a:::TEXT = OR :b::TEXT OR :c", namedBindings), '"foo"::TEXT = OR ?::TEXT OR ?', [namedBindings.b, namedBindings.c]],
       [raw('\\:a: = :b::TEXT OR :c', namedBindings), ':a: = ?::TEXT OR ?', [namedBindings.b, namedBindings.c]],
       [raw(':a: = \\:b::TEXT OR \\:c', namedBindings), '"foo" = :b::TEXT OR :c', []],
       [raw('\\:a: = \\:b::TEXT OR \\:c', namedBindings), ':a: = :b::TEXT OR :c', []]

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -3875,7 +3875,7 @@ describe("QueryBuilder", function() {
     var raws = [
       [raw(':a: = :b::TEXT OR :c', namedBindings), '"foo" = ?::TEXT OR ?', [namedBindings.b, namedBindings.c]],
       [raw(':a: = :b::TEXT OR :c::TEXT', namedBindings), '"foo" = ?::TEXT OR ?::TEXT', [namedBindings.b, namedBindings.c]],
-      [raw(":a: = 'bar'::TEXT OR :b OR :c::TEXT", namedBindings), `"foo" = 'bar'::TEXT OR ? OR ?::TEXT`, [namedBindings.b, namedBindings.c]],
+      [raw(":a: = 'bar'::TEXT OR :b OR :c::TEXT", namedBindings), '"foo" = \'bar\'::TEXT OR ? OR ?::TEXT', [namedBindings.b, namedBindings.c]],
       [raw('\\:a: = :b::TEXT OR :c', namedBindings), ':a: = ?::TEXT OR ?', [namedBindings.b, namedBindings.c]],
       [raw(':a: = \\:b::TEXT OR \\:c', namedBindings), '"foo" = :b::TEXT OR :c', []],
       [raw('\\:a: = \\:b::TEXT OR \\:c', namedBindings), ':a: = :b::TEXT OR :c', []]

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -3869,6 +3869,25 @@ describe("QueryBuilder", function() {
     })
   })
 
+  it('Respect casting with named bindings', function() {
+    var namedBindings = { a: 'foo', b: 'bar', c: 'baz' };
+
+    var raws = [
+      [raw(':a: = :b::TEXT OR :c', namedBindings), '"foo" = ?::TEXT OR ?', [namedBindings.b, namedBindings.c]],
+      [raw(':a: = :b::TEXT OR :c::TEXT', namedBindings), '"foo" = ?::TEXT OR ?::TEXT', [namedBindings.b, namedBindings.c]],
+      [raw(":a: = 'bar'::TEXT OR :b OR :c::TEXT", namedBindings), `"foo" = 'bar'::TEXT OR ? OR ?::TEXT`, [namedBindings.b, namedBindings.c]],
+      [raw('\\:a: = :b::TEXT OR :c', namedBindings), ':a: = ?::TEXT OR ?', [namedBindings.b, namedBindings.c]],
+      [raw(':a: = \\:b::TEXT OR \\:c', namedBindings), '"foo" = :b::TEXT OR :c', []],
+      [raw('\\:a: = \\:b::TEXT OR \\:c', namedBindings), ':a: = :b::TEXT OR :c', []]
+    ];
+
+    raws.forEach(function(raw) {
+      var result = raw[0].toSQL();
+      expect(result.sql).to.equal(raw[1]);
+      expect(result.bindings).to.deep.equal(raw[2]);
+    });
+  });
+
   it("query \\\\? escaping", function() {
     testquery(qb().select('*').from('users').where('id', '=', 1).whereRaw('?? \\? ?', ['jsonColumn', 'jsonKey?']), {
       mysql: 'select * from `users` where `id` = 1 and `jsonColumn` ? \'jsonKey?\'',


### PR DESCRIPTION
I have had lots of trouble using named bindings when writing raw queries in the past but recently I found that most of my trouble occurs if I am casting. This PR expands the regex used for searching for identifies and values and adds a little bit of logic around it.

This may be a naive approach but I'm open to critique.

## Before Examples:

```sql
SELECT foo::TEXT 
FROM <table>
WHERE bar = :bar;
```

Currently, this will yield an error complaining about undefined bindings. What's happening behind the scenes is `::TEXT` is being picked up as a named binding but of course it is missing from the given bindings object.

```sql
SELECT :foo::TEXT 
FROM <table>;
```

Currently, this will result in `:foo:` being thought of as an identifier instead of a value being given and casted.

After some digging I found that this undocumented approach works in the current version:

```sql
SELECT foo:\:TEXT 
FROM <table>
WHERE bar = :bar;
```

While this does not:

```sql
SELECT :foo:\:TEXT 
FROM <table>
```

## After Examples:

These work as expected.

```sql
SELECT foo::TEXT 
FROM <table>
WHERE bar = :bar;

SELECT :foo::TEXT 
FROM <table>;
```

I mostly work on Postgres and so my knowledge of other RDBMS's is very limited. As I mentioned above I am open to suggestions for improvement.
