### PR TITLE
Added ability to use certain bluebird functions

### DIFF
--- a/src/dialects/websql/transaction.js
+++ b/src/dialects/websql/transaction.js
@@ -34,7 +34,8 @@ function makeClient(trx, client) {
 const promiseInterface = [
   'then', 'bind', 'catch', 'finally', 'asCallback',
   'spread', 'map', 'reduce', 'tap', 'thenReturn',
-  'return', 'yield', 'ensure', 'exec', 'reflect'
+  'return', 'yield', 'ensure', 'exec', 'reflect',
+  'get', 'mapSeries', 'delay'
 ]
 
 // Creates a method which "coerces" to a promise, by calling a

--- a/src/interface.js
+++ b/src/interface.js
@@ -1,6 +1,6 @@
 
 import * as helpers from './helpers';
-import { isArray, map, clone, each } from 'lodash'
+import { isArray, map, clone, each, identity } from 'lodash'
 
 export default function(Target) {
 
@@ -64,11 +64,11 @@ export default function(Target) {
   // "then" method on the current `Target`
   each(['bind', 'catch', 'finally', 'asCallback',
     'spread', 'map', 'reduce', 'tap', 'thenReturn',
-    'return', 'yield', 'ensure', 'reflect'], function(method) {
+    'return', 'yield', 'ensure', 'reflect',
+    'get', 'mapSeries', 'delay'], function(method) {
     Target.prototype[method] = function() {
-      let then = this.then();
-      then = then[method].apply(then, arguments);
-      return then;
+      const promise = this.then(identity);
+      return promise[method].apply(promise, arguments);
     };
   });
 

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -218,6 +218,23 @@ assign(Builder.prototype, {
       return this.where(1, '=', column ? 1 : 0)
     }
 
+    // Allow a Query Builder to be passed in
+    if (column instanceof Builder){
+      if (column._single.table){
+        throw new Error('You passed a query builder into appendWhere() that has a table ('+
+          column._single.table+') specified for it');
+      }
+      column._statements.map((function(_this){
+        return function(statement){
+          if(statement.grouping != 'where')
+            throw new Error('You passed a query builder into appendWhere() that had'+
+              ' a non-where clause on it.');
+          _this._statements.push(statement);
+        };
+      })(this));
+      return this;
+    }
+
     // Check if the column is a function, in which case it's
     // a where statement wrapped in parens.
     if (typeof column === 'function') {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -243,7 +243,8 @@ function completedError(trx, obj) {
 const promiseInterface = [
   'then', 'bind', 'catch', 'finally', 'asCallback',
   'spread', 'map', 'reduce', 'tap', 'thenReturn',
-  'return', 'yield', 'ensure', 'exec', 'reflect'
+  'return', 'yield', 'ensure', 'exec', 'reflect',
+  'get', 'mapSeries', 'delay'
 ]
 
 // Creates a method which "coerces" to a promise, by calling a

--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -10,6 +10,46 @@ module.exports = function(knex) {
 
   describe('Additional', function () {
 
+    it('should forward the .get() function from bluebird', function() {
+      return knex('accounts').select().limit(1).then(function(accounts){
+        var firstAccount = accounts[0];
+        return knex('accounts').select().limit(1).get(0).then(function(account){
+          expect(account.id == firstAccount.id);
+        });
+      });
+    });
+
+    it('should forward the .mapSeries() function from bluebird', function() {
+      var asyncTask = function(){
+        return new Promise(function(resolve, reject){
+          var output = asyncTask.num++;
+          setTimeout(function(){
+            resolve(output);
+          }, Math.random()*200);
+        });
+      };
+      asyncTask.num = 1;
+
+      var returnedValues = [];
+      return knex('accounts').select().limit(3).mapSeries(function(account){
+        return asyncTask().then(function(number){
+          returnedValues.push(number);
+        });
+      })
+      .then(function(){
+        expect(returnedValues[0] == 1);
+        expect(returnedValues[1] == 2);
+        expect(returnedValues[2] == 3);
+      });
+    });
+
+    it('should forward the .delay() function from bluebird', function() {
+      var startTime = (new Date()).valueOf();
+      return knex('accounts').select().limit(1).delay(300).then(function(accounts){
+        expect((new Date()).valueOf() - startTime > 300);
+      });
+    });
+
     it('should truncate a table with truncate', function() {
 
       return knex('test_table_two')

--- a/test/integration/builder/selects.js
+++ b/test/integration/builder/selects.js
@@ -540,6 +540,45 @@ module.exports = function(knex) {
           });
       });
 
+      it.only('allows parameter to be a query builder', function() {
+        var whereClause = knex.where({'id': 0});
+        return knex('accounts')
+          .where(whereClause)
+          .select()
+          .testSql(function(tester) {
+            tester(
+              'mysql',
+              'select * from `accounts` where `id` = ?',
+              [0],
+              []
+            );
+            tester(
+              'postgresql',
+              'select * from "accounts" where "id" = ?',
+              [0],
+              []
+            );
+            tester(
+              'sqlite3',
+              'select * from "accounts" where "id" = ?',
+              [0],
+              []
+            );
+            tester(
+              'oracle',
+              'select * from "accounts" where "id" = ?',
+              [0],
+              []
+            );
+            tester(
+              'mssql',
+              'select * from [accounts] where [id] = ?',
+              [0],
+              []
+            );
+          });
+      });
+
     });
 
     it('has a "distinct" clause', function() {


### PR DESCRIPTION
Added the `.get`, `.mapSeries`, and `.delay` bluebird functions. The most significant omission from the current release would probably be `.get`. If you're selecting a single row from the database, it's reasonable to want to just write `knex.select().from('users').where({username: 'Jim'}).limit(1).get(0)`.