### PR TITLE
Add json support to the query builder for mysql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 # Master (Unreleased)
 - Add more having* methods / join clause on* methods  #1674
+- MySQL versions greater than 5.7.8 now use the `json` data type instead of `text` when a schema builder migration is run. 
 
 # 0.12.6 - 19 Oct, 2016
 - Address warnings mentioned in #1388 (#1740)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "pg-connection-string": "^0.1.3",
     "readable-stream": "^1.1.12",
     "safe-buffer": "^5.0.1",
+    "semver": "^5.3.0",
     "tildify": "~1.0.0",
     "uuid": "^3.0.0",
     "v8flags": "^2.0.2"

--- a/src/dialects/maria/index.js
+++ b/src/dialects/maria/index.js
@@ -6,7 +6,7 @@ import Client_MySQL from '../mysql';
 import Promise from 'bluebird';
 import * as helpers from '../../helpers';
 import Transaction from './transaction';
-
+import ColumnCompiler from './schema/columncompiler';
 import { assign, map } from 'lodash'
 
 function Client_MariaSQL(config) {
@@ -26,6 +26,10 @@ assign(Client_MariaSQL.prototype, {
 
   _driver() {
     return require('mariasql')
+  },
+
+  columnCompiler() {
+    return new ColumnCompiler(this, ...arguments)
   },
 
   // Get a raw connection, called by the `pool` whenever a new

--- a/src/dialects/maria/schema/columncompiler.js
+++ b/src/dialects/maria/schema/columncompiler.js
@@ -1,0 +1,23 @@
+// MariaDB Column Compiler
+// -------
+import inherits from 'inherits';
+import ColumnCompiler_MySQL from '../../mysql/schema/columncompiler';
+
+import { assign } from 'lodash'
+
+function ColumnCompiler_MariaDB() {
+  ColumnCompiler_MySQL.apply(this, arguments);
+  this.modifiers = ['unsigned', 'nullable', 'defaultTo', 'first', 'after', 'comment', 'collate']
+}
+
+inherits(ColumnCompiler_MariaDB, ColumnCompiler_MySQL);
+
+assign(ColumnCompiler_MariaDB.prototype, {
+    // mariadb doesn't support json as of yet. 
+    // see https://jira.mariadb.org/browse/MDEV-9056 for issue status.
+  json () {
+    return 'text';
+  }
+});
+
+export default ColumnCompiler_MariaDB;

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -121,8 +121,11 @@ assign(ColumnCompiler_MySQL.prototype, {
   
 })
 
+const MIN_JSON_VERSION = semver.SemVer('5.7.8');
 function jsonColumn(client) {
-  if(!client.version || semver.gte(client.version, '5.7.8')) {
+  if(!client.version) {
+    return 'json'; // this is here jsut for tests
+  } else if(semver.valid(client.version) && semver.gte(client.version, MIN_JSON_VERSION)) {
     return 'json';
   } else {
     return 'text';

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -4,6 +4,7 @@
 import inherits from 'inherits';
 import ColumnCompiler from '../../../schema/columncompiler';
 import * as helpers from '../../../helpers';
+import * as semver from 'semver';
 
 import { assign } from 'lodash'
 
@@ -80,6 +81,10 @@ assign(ColumnCompiler_MySQL.prototype, {
     return length ? `varbinary(${this._num(length)})` : 'blob'
   },
 
+  json() {
+    return jsonColumn(this.client);
+  },
+
   // Modifiers
   // ------
 
@@ -113,7 +118,15 @@ assign(ColumnCompiler_MySQL.prototype, {
   collate(collation) {
     return collation && `collate '${collation}'`
   }
-
+  
 })
+
+function jsonColumn(client) {
+  if(!client.version || semver.gte(client.version, '5.7.8')) {
+    return 'json';
+  } else {
+    return 'text';
+  }
+}
 
 export default ColumnCompiler_MySQL;

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -124,7 +124,7 @@ assign(ColumnCompiler_MySQL.prototype, {
 const MIN_JSON_VERSION = semver.SemVer('5.7.8');
 function jsonColumn(client) {
   if(!client.version) {
-    return 'json'; // this is here jsut for tests
+    return 'json'; // this is here just for tests
   } else if(semver.valid(client.version) && semver.gte(client.version, MIN_JSON_VERSION)) {
     return 'json';
   } else {

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -53,6 +53,13 @@ describe(dialect + " SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table `users` add `id` int unsigned not null auto_increment primary key, add `email` varchar(255)');
   });
 
+  it('adding json', function() {
+    tableSql = client.schemaBuilder().table('user', function(t) {
+      t.json('preferences');
+    }).toSQL();
+    expect(tableSql[0].sql).to.equal('alter table `user` add `preferences` json');
+  });
+
   it('test drop table', function() {
     tableSql = client.schemaBuilder().dropTable('users').toSQL();
 

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -53,12 +53,14 @@ describe(dialect + " SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table `users` add `id` int unsigned not null auto_increment primary key, add `email` varchar(255)');
   });
 
-  it('adding json', function() {
-    tableSql = client.schemaBuilder().table('user', function(t) {
-      t.json('preferences');
-    }).toSQL();
-    expect(tableSql[0].sql).to.equal('alter table `user` add `preferences` json');
-  });
+  if(dialect !== "maria") {
+    it('adding json', function() {
+      tableSql = client.schemaBuilder().table('user', function(t) {
+        t.json('preferences');
+      }).toSQL();
+      expect(tableSql[0].sql).to.equal('alter table `user` add `preferences` json');
+    });
+  }
 
   it('test drop table', function() {
     tableSql = client.schemaBuilder().dropTable('users').toSQL();


### PR DESCRIPTION
This is a minimal amount of work to make the `json(COLUMN_NAME)` method on the query builder do the right thing for versions of MySQL greater than or equal to 5.7.8, when the json data type first came into being.

It follows most of the patterns put forth for the postgres json support, including retrieving the version from the target server and using that to determine support levels.

I've included tests patterned after the postgres tests which pass on my local mysql instance.

Anything else I should do?

Fixes #1036 for mysql only.