### PR TITLE
Revert "Ensure that 'client' is provided in knex config object (#1822)"

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -37,14 +37,6 @@ function clientId() {
 // for a dialect specific client object.
 function Client(config = {}) {
   this.config = config
-
-  //Client is a required field, so throw error if it's not supplied.
-  //If 'this.dialect' is set, then this is a 'super()' call, in which case
-  //'client' does not have to be set as it's already assigned on the client prototype.
-  if(!this.config.client && !this.dialect) {
-    throw new Error(`knex: Required configuration option 'client' is missing.`)
-  }
-
   this.connectionSettings = cloneDeep(config.connection || {})
   if (this.driverName && config.connection) {
     this.initializeDriver()

--- a/test/tape/knex.js
+++ b/test/tape/knex.js
@@ -65,13 +65,3 @@ test('it should use knex supported dialect', function(t) {
   })
   knexObj.destroy()
 })
-
-test('it should throw error if client is omitted in config', function(t) {
-  t.plan(1);
-  try {
-    var knexObj = knex({});
-    t.deepEqual(true, false); //Don't reach this point
-  } catch(error) {
-    t.deepEqual(error.message, 'knex: Required configuration option \'client\' is missing.');
-  }
-})

--- a/test/tape/query-builder.js
+++ b/test/tape/query-builder.js
@@ -14,7 +14,7 @@ tape('accumulates multiple update calls #647', function(t) {
 
 tape('allows for object syntax in join', function(t) {
   t.plan(1)
-  var qb = new QueryBuilder(new Client({client: 'mysql'}))
+  var qb = new QueryBuilder(new Client())
   var sql = qb.table('users').innerJoin('accounts', {
     'accounts.id': 'users.account_id',
     'accounts.owner_id': 'users.id'
@@ -24,7 +24,7 @@ tape('allows for object syntax in join', function(t) {
 })
 
 tape('clones correctly', function(t) {
-  var qb = new QueryBuilder(new Client({client: 'mysql'}))
+  var qb = new QueryBuilder(new Client())
   var original = qb.table('users').debug().innerJoin('accounts', {
     'accounts.id': 'users.account_id',
     'accounts.owner_id': 'users.id'

--- a/test/tape/raw.js
+++ b/test/tape/raw.js
@@ -5,7 +5,7 @@ var Client = require('../../lib/client')
 var test   = require('tape')
 var _      = require('lodash');
 
-var client = new Client({client: 'mysql'})
+var client = new Client()
 function raw(sql, bindings) {
   return new Raw(client).set(sql, bindings)
 }


### PR DESCRIPTION
This reverts **some** of commit a4bfee77513d000cf0fddf130a370071c240f93d (PR #1822).  It leaves the fixes to `this.modifiers` for the base schema columncompiler, the oracle columncompiler, and the sqlite3 columncompiler.

The pull request in question fixed a bug in Knex, but also removed a documented (and quite useful) feature of the Knex library, which is to be able to initialize a Knex instance without a client/dialect.

This change leaves the bugfix, and re-enables the ability to initialize Knex without a specific client.

From the documentation:

> You can even use knex without a connection, just for its query building features. Just pass in an empty object when initializing the library. Specify a client if you are interested in a particular flavour of SQL.
```javascript
var knex = require('knex')({});
var pg = require('knex')({client: 'pg'});
knex('table').insert({a: 'b'}).returning('*').toString();
// "insert into "table" ("a") values ('b')"

pg('table').insert({a: 'b'}).returning('*').toString();
// "insert into "table" ("a") values ('b') returning *"
```