### PR TITLE
Properly close PG query stream on error

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -1,4 +1,4 @@
-import { assign, isArray } from 'lodash'
+import { assign, isArray, noop } from 'lodash'
 import Promise from 'bluebird';
 import * as helpers from './helpers';
 
@@ -98,6 +98,10 @@ assign(Runner.prototype, {
       handler(stream);
       return promise;
     }
+
+    // This promise is unreachable since no handler was given, so noop any
+    // exceptions. Errors should be handled in the stream's 'error' event.
+    promise.catch(noop);
     return stream;
   },
 


### PR DESCRIPTION
Without calling `close()`, the `queryStream` will continue to execute a
query meaning there was no way to halt a long running query due to an
unrecoverable downstream error. I ran into this issue while streaming
IDs from a very large table as part of an ETL process. An error would
occur downstream in the transformation or loading step and I needed to
cancel the long-running extract stream, but there was no way to do so
and I'd eventually run out of connections in the pool.

This commit also handles the case when the non-callback version of
stream API was used and an exception was thrown. The issue was that the
promise was not reachable and therefore there was no way to add a
rejection handler. This resulted in an unavoidable `Unhandled Promise
Rejection` error.