### PR TITLE
Upgrade generic-pool to v3.1.7 (Test)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "chalk": "^1.0.0",
     "commander": "^2.2.0",
     "debug": "^2.1.3",
-    "generic-pool": "^2.4.2",
+    "generic-pool": "^3.1.7",
     "inherits": "~2.0.1",
     "interpret": "^0.6.5",
     "liftoff": "~2.2.0",

--- a/test/integration/suite.js
+++ b/test/integration/suite.js
@@ -30,7 +30,7 @@ module.exports = function(knex) {
 
     describe('knex.destroy', function() {
       it('should allow destroying the pool with knex.destroy', function() {
-        var spy = sinon.spy(knex.client.pool, 'destroyAllNow');
+        var spy = sinon.spy(knex.client.pool, 'clear');
         return knex.destroy().then(function() {
           expect(spy).to.have.callCount(1);
           expect(knex.client.pool).to.equal(undefined);


### PR DESCRIPTION
Testing compatibility of upgrading `generic-pool` to 3.1.7. Contains some breaking changes that would require probably 0.12.X -> 0.13.0.