### PR TITLE
Must always clear the timeout for handling 'acquireConnectionTimeout'…

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -239,10 +239,10 @@ assign(Client.prototype, {
         ))
       }, this.config.acquireConnectionTimeout || 60000)
       this.pool.acquire((err, connection) => {
+        clearTimeout(t)
         if (err) {
           return rejecter(err)
         }
-        clearTimeout(t)
         if (wasRejected) {
           this.pool.release(connection)
         } else {


### PR DESCRIPTION
…, even if an error occurs. Fixes #1973