### PR TITLE
Allow PostgreSQL connections to EnterpriseDB

### DIFF
--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -132,7 +132,7 @@ assign(Client_PG.prototype, {
     return new Promise(function(resolver, rejecter) {
       connection.query('select version();', function(err, resp) {
         if (err) return rejecter(err);
-        resolver(/^PostgreSQL (.*?)( |$)/.exec(resp.rows[0].version)[1]);
+        resolver(/^(?:PostgreSQL|EnterpriseDB) (.*?)( |$)/.exec(resp.rows[0].version)[1]);
       });
     });
   },

--- a/test/index.js
+++ b/test/index.js
@@ -39,6 +39,13 @@ if (config.oracle) {
   });
 }
 
+if (config.postgres) {
+  describe('Postgres Tests', function() {
+    this.timeout(process.env.KNEX_TEST_TIMEOUT || 5000);
+    require('./unit/dialects/postgres');
+  });
+}
+
 describe('Integration Tests', function() {
   this.timeout(process.env.KNEX_TEST_TIMEOUT || 5000);
   require('./integration')

--- a/test/unit/dialects/postgres.js
+++ b/test/unit/dialects/postgres.js
@@ -1,0 +1,71 @@
+/* global it, describe */
+
+'use strict';
+var expect = require('chai').expect;
+var knex   = require('../../../knex');
+var knexInstance = knex({
+  client: 'pg',
+  connection: {
+    connectString: 'connect-string',
+    database: 'database',
+    externalAuth: true,
+    host: 'host',
+    password: 'password',
+    user: 'user',
+  },
+});
+
+describe('PostgreSQL client', function() {
+  describe('checkVersion()', function() {
+    function createFakeConnection(err, resp) {
+      return {
+        query: function(sql, cb) {
+          cb(err, resp);
+        }
+      }
+    }
+
+    it('should reject on error', function() {
+      var error = new Error('error');
+      var fakeConnection = createFakeConnection(error);
+
+      function onSuccess() {
+        throw new Error('expected test to fail');
+      }
+      function onError(err) {
+        expect(err).to.equal(error);
+      }
+
+      return knexInstance.client.checkVersion(fakeConnection)
+        .then(onSuccess, onError);
+    });
+
+    it('should resolve valid for PostgreSQL', function() {
+      var resp = {
+        rows: [{
+          version: 'PostgreSQL 9.3.13 on x86_64-unknown, compiled by compiler 0.0.0, 64-bit',
+        }]
+      };
+      var fakeConnection = createFakeConnection(null, resp);
+
+      return knexInstance.client.checkVersion(fakeConnection)
+        .then(function(version) {
+          expect(version).to.equal('9.3.13');
+        });
+    });
+
+    it('should resolve valid for EnterpriseDB', function() {
+      var resp = {
+        rows: [{
+          version: 'EnterpriseDB 9.3.13.37 on x86_64-unknown, compiled by compiler 0.0.0, 64-bit',
+        }]
+      };
+      var fakeConnection = createFakeConnection(null, resp);
+
+      return knexInstance.client.checkVersion(fakeConnection)
+        .then(function(version) {
+          expect(version).to.equal('9.3.13.37');
+        });
+    });
+  });
+});


### PR DESCRIPTION
This PR allows the `pg` client to connect to an EnterpriseDB instance. I've been using a local modification for this for a couple months, and haven't encountered any issues yet. It's been brought up before (#1176), but didn't receive any follow-up.

- [x] Tests - Tried to replicate existing tests. Happy to make suggested changes, as necessary!
- [x] Coding Style - Couldn't find any specific documentation. I can switch the `var` to `const` (`prefer-const`) in tests, but kept it for backwards-compatibility with older Node versions.
- [x] PR on master
- [x] Documentation - No updates, unless EnterpriseDB should be added.
- [x] Passing Tests - Everything, with the exception of `batchInsert` currently failing on `master`. Verified this PR does not affect those tests.

I couldn't figure out any patterns in the tests, so wasn't sure if additional tests are needed. Adding another database (EnterpriseDB) to the testing list seemed excessive, so I've only added a few unit tests to cover the specific functionality.