### PR TITLE
fix: escapeObject parameter order for Postgres dialect.

### DIFF
--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -74,7 +74,7 @@ assign(Client_PG.prototype, {
       }
       return escaped
     },
-    escapeObject(val, timezone, prepareValue, seen = []) {
+    escapeObject(val, prepareValue, timezone, seen = []) {
       if (val && typeof val.toPostgres === 'function') {
         seen = seen || [];
         if (seen.indexOf(val) !== -1) {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -4182,4 +4182,13 @@ describe("QueryBuilder", function() {
     });
   })
 
+  it('#2003, properly escapes objects with toPostgres specialization', function () {
+    function TestObject() { }
+    TestObject.prototype.toPostgres = function() {
+      return 'foobar'
+    }
+    testquery(qb().table('sometable').insert({ id: new TestObject() }), {
+      postgres: "insert into \"sometable\" (\"id\") values ('foobar')"
+    });
+  })
 });


### PR DESCRIPTION
Found this bug when I added support for writing `moment` instances (which in turn I did to fix timezone issues I had when writing `DATE` types).

```javascript
const moment = require('moment')

moment.fn.toPostgres = function () {
  return this.format()
}
```