### PR TITLE
Add support for enum columns to SQlite3 dialect

### DIFF
--- a/src/dialects/sqlite3/schema/columncompiler.js
+++ b/src/dialects/sqlite3/schema/columncompiler.js
@@ -18,5 +18,8 @@ ColumnCompiler_SQLite3.prototype.double =
 ColumnCompiler_SQLite3.prototype.decimal =
 ColumnCompiler_SQLite3.prototype.floating = 'float';
 ColumnCompiler_SQLite3.prototype.timestamp = 'datetime';
+ColumnCompiler_SQLite3.prototype.enu = function(allowed) {
+  return `text check (${this.formatter.wrap(this.args[0])} in ('${allowed.join("', '")}'))`;
+};
 
 export default ColumnCompiler_SQLite3;

--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -135,7 +135,7 @@ module.exports = function(knex) {
             "defaultValue": null,
             "maxLength": null,
             "nullable": true,
-            "type": "varchar"
+            "type": "text"
           },
           "uuid": {
             "defaultValue": null,

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -150,7 +150,7 @@ module.exports = function(knex) {
           }).testSql(function(tester) {
             tester('mysql', ['create table `datatype_test` (`enum_value` enum(\'a\', \'b\', \'c\'), `uuid` char(36) not null) default character set utf8']);
             tester('pg', ['create table "datatype_test" ("enum_value" text check ("enum_value" in (\'a\', \'b\', \'c\')), "uuid" uuid not null)']);
-            tester('sqlite3', ['create table "datatype_test" ("enum_value" varchar, "uuid" char(36) not null)']);
+            tester('sqlite3', ['create table "datatype_test" ("enum_value" text check ("enum_value" in (\'a\', \'b\', \'c\')), "uuid" char(36) not null)']);
             tester('oracle', ['create table "datatype_test" ("enum_value" varchar2(1) check ("enum_value" in (\'a\', \'b\', \'c\')), "uuid" char(36) not null)']);
             tester('mssql', ['CREATE TABLE [datatype_test] ([enum_value] nvarchar(100), [uuid] uniqueidentifier not null)']);
           });

--- a/test/unit/schema/sqlite3.js
+++ b/test/unit/schema/sqlite3.js
@@ -362,7 +362,7 @@ describe("SQLite SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'alter table "users" add column "foo" varchar');
+    equal(tableSql[0].sql, 'alter table "users" add column "foo" text check ("foo" in (\'bar\', \'baz\'))');
   });
 
   it("adding date", function() {


### PR DESCRIPTION
Adds support for enum columns in SQLite using a check constraint. Based on the current PostgreSQL implementation. If I missed anything please let me know.