### PR TITLE
Add support for named unique, primary and foreign keys to SQLite3

### DIFF
--- a/src/dialects/sqlite3/schema/tablecompiler.js
+++ b/src/dialects/sqlite3/schema/tablecompiler.js
@@ -83,8 +83,12 @@ TableCompiler_SQLite3.prototype.foreign = function() {
 TableCompiler_SQLite3.prototype.primaryKeys = function() {
   const pks = filter(this.grouped.alterTable || [], {method: 'primary'});
   if (pks.length > 0 && pks[0].args.length > 0) {
-    const args = Array.isArray(pks[0].args[0]) ? pks[0].args[0] : pks[0].args;
-    return `, primary key (${this.formatter.columnize(args)})`;
+    const columns = pks[0].args[0];
+    let constraintName = pks[0].args[1] || '';
+    if (constraintName) {
+      constraintName = ' constraint ' + this.formatter.wrap(constraintName);
+    }
+    return `,${constraintName} primary key (${this.formatter.columnize(columns)})`;
   }
 };
 
@@ -96,7 +100,11 @@ TableCompiler_SQLite3.prototype.foreignKeys = function() {
     const column = this.formatter.columnize(foreign.column);
     const references = this.formatter.columnize(foreign.references);
     const foreignTable = this.formatter.wrap(foreign.inTable);
-    sql += `, foreign key(${column}) references ${foreignTable}(${references})`;
+    let constraintName = foreign.keyName || '';
+    if (constraintName) {
+      constraintName = ' constraint ' + this.formatter.wrap(constraintName);
+    }
+    sql += `,${constraintName} foreign key(${column}) references ${foreignTable}(${references})`;
     if (foreign.onDelete) sql += ` on delete ${foreign.onDelete}`;
     if (foreign.onUpdate) sql += ` on update ${foreign.onUpdate}`;
   }

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -187,8 +187,8 @@ module.exports = function(knex) {
           tester('sqlite3', [
             'create table "test_foreign_table_two" ("id" integer not null primary key autoincrement, "fkey_two" integer, "fkey_three" integer, "fkey_four" integer, ' +
             'foreign key("fkey_two") references "test_table_two"("id"), ' +
-            'foreign key("fkey_three") references "test_table_two"("id"), ' +
-            'foreign key("fkey_four") references "test_table_two"("id"))'
+            'constraint "fk_fkey_three" foreign key("fkey_three") references "test_table_two"("id"), ' +
+            'constraint "fk_fkey_four" foreign key("fkey_four") references "test_table_two"("id"))'
           ]);
           tester('oracle', [
             'create table "test_foreign_table_two" ("id" integer not null primary key, "fkey_two" integer, "fkey_three" integer, "fkey_four" integer)',

--- a/test/unit/schema/sqlite3.js
+++ b/test/unit/schema/sqlite3.js
@@ -115,6 +115,16 @@ describe("SQLite SchemaBuilder", function() {
     equal(tableSql[0].sql, 'create table "users" ("foo" varchar(255), primary key ("foo"))');
   });
 
+  it("adding primary key with specific identifier", function() {
+    tableSql = client.schemaBuilder().createTable('users', function(table) {
+      table.string('foo');
+      table.primary('foo', 'pk-users');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    equal(tableSql[0].sql, 'create table "users" ("foo" varchar(255), constraint "pk-users" primary key ("foo"))');
+  });
+
   it("adding composite primary key", function() {
     tableSql = client.schemaBuilder().createTable('users', function(table) {
       table.string('foo');
@@ -124,15 +134,17 @@ describe("SQLite SchemaBuilder", function() {
 
     equal(1, tableSql.length);
     equal(tableSql[0].sql, 'create table "users" ("foo" varchar(255), "order_id" varchar(255), primary key ("foo", "order_id"))');
+  });
 
+  it("adding composite primary key with specific identifier", function() {
     tableSql = client.schemaBuilder().createTable('users', function(table) {
       table.string('foo');
       table.string('order_id');
-      table.primary('foo', 'order_id');
+      table.primary(['foo', 'order_id'], 'pk-users');
     }).toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'create table "users" ("foo" varchar(255), "order_id" varchar(255), primary key ("foo", "order_id"))');
+    equal(tableSql[0].sql, 'create table "users" ("foo" varchar(255), "order_id" varchar(255), constraint "pk-users" primary key ("foo", "order_id"))');
   });
 
   it("adding primary key fluently", function() {
@@ -142,6 +154,15 @@ describe("SQLite SchemaBuilder", function() {
 
     equal(1, tableSql.length);
     equal(tableSql[0].sql, 'create table "users" ("foo" varchar(255), primary key ("foo"))');
+  });
+
+  it("adding primary key fluently with specific identifier", function() {
+    tableSql = client.schemaBuilder().createTable('users', function(table) {
+      table.string('foo').primary('pk-users');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    equal(tableSql[0].sql, 'create table "users" ("foo" varchar(255), constraint "pk-users" primary key ("foo"))');
   });
 
   it("adding foreign key", function() {
@@ -155,8 +176,16 @@ describe("SQLite SchemaBuilder", function() {
     equal(tableSql[0].sql, 'create table "users" ("foo" varchar(255), "order_id" varchar(255), foreign key("order_id") references "orders"("id"), primary key ("foo"))');
   });
 
-  // SQLite3 doesn't support named foreign keys
-  // it("adding foreign key with specific identifier throws an error");
+  it("adding foreign key with specific identifier", function() {
+    tableSql = client.schemaBuilder().createTable('users', function(table) {
+      table.string('foo').primary();
+      table.string('order_id');
+      table.foreign('order_id', 'fk-users-orders').references('id').on('orders');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    equal(tableSql[0].sql, 'create table "users" ("foo" varchar(255), "order_id" varchar(255), constraint "fk-users-orders" foreign key("order_id") references "orders"("id"), primary key ("foo"))');
+  });
 
   it("adding foreign key fluently", function() {
     tableSql = client.schemaBuilder().createTable('users', function(table) {


### PR DESCRIPTION
Attempt to solve #2051. Allows having named `unique`, `primary` and `foreign keys`. Both fluent and normal API should work except for `foreign keys` which have no fluent counterpart on any dialect AFAIK. This could break things for some user that might have been misusing the API. From my take on [this](https://github.com/tgriesser/knex/blob/0.13.0/test/unit/schema/sqlite3.js#L128-L135) test, in the current version of the SQLite dialect, the following code
```
table.primary('foo', 'bar')
```
Creates a primary key with two columns `foo` and `bar` when it should have created a primary key named `bar` with one column `foo` instead, as seen in other dialects like [MySQL](https://github.com/tgriesser/knex/blob/0.13.0/test/unit/schema/mysql.js#L176-L183).

Let's see if Travis likes it.