### PR TITLE
fixed table alter attributes order. (first, after)

### DIFF
--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -9,7 +9,7 @@ import { assign } from 'lodash'
 
 function ColumnCompiler_MySQL() {
   ColumnCompiler.apply(this, arguments);
-  this.modifiers = ['unsigned', 'nullable', 'defaultTo', 'first', 'after', 'comment', 'collate']
+  this.modifiers = ['unsigned', 'nullable', 'defaultTo', 'comment', 'first', 'after', 'collate']
 }
 inherits(ColumnCompiler_MySQL, ColumnCompiler);
 
@@ -95,19 +95,19 @@ assign(ColumnCompiler_MySQL.prototype, {
     return 'unsigned'
   },
 
+  comment(comment) {
+    if (comment && comment.length > 255) {
+      helpers.warn('Your comment is longer than the max comment length for MySQL')
+    }
+    return comment && `comment '${comment}'`
+  },
+
   first() {
     return 'first'
   },
 
   after(column) {
     return `after ${this.formatter.wrap(column)}`
-  },
-
-  comment(comment) {
-    if (comment && comment.length > 255) {
-      helpers.warn('Your comment is longer than the max comment length for MySQL')
-    }
-    return comment && `comment '${comment}'`
   },
 
   collate(collation) {

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -471,6 +471,10 @@ module.exports = function(knex) {
 
     describe('addColumn', function() {
       describe('mysql only', function() {
+        if(!knex || !knex.client || (!(/mysql/i.test(knex.client.dialect)) && !(/maria/i.test(knex.client.dialect)))) {
+          return Promise.resolve();
+        }
+
         before(function() {
           return knex.schema.createTable('add_column_test_mysql', function (tbl) {
             tbl.integer('field_foo');
@@ -490,10 +494,6 @@ module.exports = function(knex) {
         });
 
         it('should columns order be correctly with after and first', function() {
-          if(!knex || !knex.client | !(/mysql/i.test(knex.client.dialect))) {
-            return Promise.resolve();
-          }
-
           return knex.raw('SHOW CREATE TABLE `add_column_test_mysql`').then(function(schema) {
             // .columnInfo() keys does not guaranteed fields order.
             var fields = schema[0][0]['Create Table'].split('\n')

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -271,6 +271,15 @@ describe(dialect + " SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table `users` add `name` varchar(255) after `foo`');
   });
 
+  it('test adding column after another column with comment', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.string('name').after('foo').comment('bar');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table `users` add `name` varchar(255) comment \'bar\' after `foo`');
+  });
+
   it('test adding column on the first place', function() {
     tableSql = client.schemaBuilder().table('users', function() {
       this.string('first_name').first();
@@ -278,6 +287,15 @@ describe(dialect + " SchemaBuilder", function() {
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal('alter table `users` add `first_name` varchar(255) first');
+  });
+
+  it('test adding column on the first place with comment', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.string('first_name').first().comment('bar');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table `users` add `first_name` varchar(255) comment \'bar\' first');
   });
 
   it('test adding string', function() {


### PR DESCRIPTION
Fixed issue, #1946

Should first and after attributes are placed after comment attribute.