### PR TITLE
fix incorrect parameter name

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -98,8 +98,8 @@ assign(Client.prototype, {
     return new ColumnCompiler(this, tableBuilder, columnBuilder)
   },
 
-  runner(connection) {
-    return new Runner(this, connection)
+  runner(builder) {
+    return new Runner(this, builder)
   },
 
   transaction(container, config, outerTx) {


### PR DESCRIPTION
fix incorrect parameter name in Client:runner() method