### PR TITLE
Change the way that MySQL verifies if a table exists (hasTable)

### DIFF
--- a/src/dialects/mysql/schema/compiler.js
+++ b/src/dialects/mysql/schema/compiler.js
@@ -20,9 +20,20 @@ assign(SchemaCompiler_MySQL.prototype, {
 
   // Check whether a table exists on the query.
   hasTable(tableName) {
+    let sql = 'select * from information_schema.tables where table_name = ?';
+    const bindings = [ tableName ];
+
+    if (this.schema) {
+      sql += ' and table_schema = ?';
+      bindings.push(this.schema);
+    } else {
+      sql += ' and table_schema = database()';
+    }
+
     this.pushQuery({
-      sql: `show tables like ${this.formatter.parameter(tableName)}`,
-      output(resp) {
+      sql,
+      bindings,
+      output: function output(resp) {
         return resp.length > 0;
       }
     });

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -441,6 +441,12 @@ module.exports = function(knex) {
         });
       });
 
+      it('should be false whether a parameter is not specified', function() {
+        return knex.schema.hasTable('').then(function(resp) {
+          expect(resp).to.equal(false);
+        });
+      });
+
     });
 
     describe('renameTable', function() {


### PR DESCRIPTION
Hi, on MySQL dialect, the method **hasTable** uses the following query to verify if a table exists:

```sql
SHOW TABLES LIKE ?
```

This, could represent an issue if no parameter is defined ([check this issue](https://github.com/tgriesser/knex/issues/2065)).

I've changed the way to verify the existence of the table, as @elhigu said in the same issue, the best way to accomplish this is checking [MySQL's Information Schema](https://dev.mysql.com/doc/refman/5.7/en/tables-table.html)

I've also added a new test passing an empty parameter on **hasTable** returning *false*.

With this PR, you can close the issue https://github.com/tgriesser/knex/issues/2065.

Edited: The PR has not passed successfully the tests. This is not related with my changes, attached you can find a screenshot of the approved test that I've added.

![screen shot 2017-06-02 at 10 44 55 pm](https://cloud.githubusercontent.com/assets/3170758/26750669/856b0846-47e5-11e7-81c6-16650edf5ceb.png)
