### PR TITLE
Add unit tests for table comment

### DIFF
--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -504,6 +504,24 @@ describe(dialect + " SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table `users` add `foo` decimal(2, 6)');
   });
 
+  it('test set comment', function() {
+    tableSql = client.schemaBuilder().table('users', function(t) {
+      t.comment('Custom comment');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table `users` comment = \'Custom comment\'');
+  });
+
+  it('test set empty comment', function() {
+    tableSql = client.schemaBuilder().table('users', function(t) {
+      t.comment('');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table `users` comment = \'\'');
+  });
+
   it('should alter columns with the alter flag', function() {
     tableSql = client.schemaBuilder().table('users', function() {
       this.string('foo').alter();

--- a/test/unit/schema/oracle.js
+++ b/test/unit/schema/oracle.js
@@ -497,6 +497,24 @@ describe("Oracle SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table "users" add "foo" decimal(2, 6)');
   });
 
+  it('test set comment', function() {
+    tableSql = client.schemaBuilder().table('users', function(t) {
+      t.comment('Custom comment');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('comment on table "users" is \'Custom comment\'');
+  });
+
+  it('test set empty comment', function() {
+    tableSql = client.schemaBuilder().table('users', function(t) {
+      t.comment('');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('comment on table "users" is \'\'');
+  });
+
   it('is possible to set raw statements in defaultTo, #146', function() {
     tableSql = client.schemaBuilder().createTable('default_raw_test', function(t) {
       t.timestamp('created_at').defaultTo(client.raw('CURRENT_TIMESTAMP'));

--- a/test/unit/schema/oracledb.js
+++ b/test/unit/schema/oracledb.js
@@ -487,6 +487,24 @@ describe("OracleDb SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table "users" add "foo" decimal(2, 6)');
   });
 
+  it('test set comment', function() {
+    tableSql = client.schemaBuilder().table('users', function(t) {
+      t.comment('Custom comment');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('comment on table "users" is \'Custom comment\'');
+  });
+
+  it('test set empty comment', function() {
+    tableSql = client.schemaBuilder().table('users', function(t) {
+      t.comment('');
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('comment on table "users" is \'\'');
+  });
+
   it('is possible to set raw statements in defaultTo, #146', function() {
     tableSql = client.schemaBuilder().createTable('default_raw_test', function(t) {
       t.timestamp('created_at').defaultTo(client.raw('CURRENT_TIMESTAMP'));

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -595,6 +595,22 @@ describe("PostgreSQL SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table "user" add column "preferences" jsonb');
   });
 
+  it('set comment', function() {
+    tableSql = client.schemaBuilder().table('user', function(t) {
+      t.comment('Custom comment');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('comment on table "user" is \'Custom comment\'');
+  });
+
+  it('set empty comment', function() {
+    tableSql = client.schemaBuilder().table('user', function(t) {
+      t.comment('');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('comment on table "user" is \'\'');
+  });
+
   it('allows adding default json objects when the column is json', function() {
     tableSql = client.schemaBuilder().table('user', function(t) {
       t.json('preferences').defaultTo({}).notNullable();


### PR DESCRIPTION
I created tests to add table comment. These are for postgresql, mysql and oracle as it seems to me that ```.comment()``` function is not supported for sqlite.
I test setting the comment and setting it back to empty string. I assume that many users will expect that ```.comment(null)``` or simply ```.comment()``` will work the same as ```.comment('')``` I also made tests for these cases. However ```.comment(null)``` and ```.comment()``` does not work that way in mysql so these tests are only for postgresql and oracle.