### PR TITLE
Add unit test for renaming column in postgresql

### DIFF
--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -245,6 +245,14 @@ describe("PostgreSQL SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table "users" rename to "foo"');
   });
 
+  it("rename column", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.renameColumn('foo', 'bar');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" rename "foo" to "bar"');
+  });
+
   it("adding primary key", function() {
     tableSql = client.schemaBuilder().table('users', function(table) {
       table.primary('foo');


### PR DESCRIPTION
There are already unit tests for renaming column but only for oracle.
I figured out that unit testing sqlite, mssql and mysql can not be
done nicely using only ```toSQL``` method but is implemented
in ```test/integration/builder/additional.js```. However test for
postgresql can be done similarly to oracle using no dirty checks
so maybe it can be added.
