### PR TITLE
Update with no values should produce a noop

### DIFF
--- a/src/dialects/mssql/query/compiler.js
+++ b/src/dialects/mssql/query/compiler.js
@@ -78,6 +78,15 @@ assign(QueryCompiler_MSSQL.prototype, {
 
   // Compiles an `update` query, allowing for a return value.
   update() {
+    const updateValues = this.single.update || [];
+    if (Array.isArray(updateValues)) {
+      if (updateValues.length === 0) {
+        return '';
+      }
+    } else if (typeof updateValues === 'object' && isEmpty(updateValues)) {
+      return '';
+    }
+
     const top = this.top();
     const updates = this._prepUpdate(this.single.update);
     const join = this.join();

--- a/src/dialects/mysql/query/compiler.js
+++ b/src/dialects/mysql/query/compiler.js
@@ -4,7 +4,7 @@
 import inherits from 'inherits';
 import QueryCompiler from '../../../query/compiler';
 
-import { assign } from 'lodash'
+import { assign, isEmpty } from 'lodash'
 
 function QueryCompiler_MySQL(client, builder) {
   QueryCompiler.call(this, client, builder)
@@ -17,6 +17,15 @@ assign(QueryCompiler_MySQL.prototype, {
 
   // Update method, including joins, wheres, order & limits.
   update() {
+    const updateValues = this.single.update || [];
+    if (Array.isArray(updateValues)) {
+      if (updateValues.length === 0) {
+        return '';
+      }
+    } else if (typeof updateValues === 'object' && isEmpty(updateValues)) {
+      return '';
+    }
+
     const join = this.join();
     const updates = this._prepUpdate(this.single.update);
     const where = this.where();

--- a/src/dialects/oracle/query/compiler.js
+++ b/src/dialects/oracle/query/compiler.js
@@ -108,6 +108,15 @@ assign(QueryCompiler_Oracle.prototype, {
 
   // Update method, including joins, wheres, order & limits.
   update() {
+    const updateValues = this.single.update || [];
+    if (Array.isArray(updateValues)) {
+      if (updateValues.length === 0) {
+        return '';
+      }
+    } else if (typeof updateValues === 'object' && isEmpty(updateValues)) {
+      return '';
+    }
+
     const updates = this._prepUpdate(this.single.update);
     const where = this.where();
     let { returning } = this.single;

--- a/src/dialects/oracledb/query/compiler.js
+++ b/src/dialects/oracledb/query/compiler.js
@@ -226,6 +226,15 @@ _.assign(Oracledb_Compiler.prototype, {
   },
 
   update: function() {
+    const updateValues = this.single.update || [];
+    if (Array.isArray(updateValues)) {
+      if (updateValues.length === 0) {
+        return '';
+      }
+    } else if (typeof updateValues === 'object' && _.isEmpty(updateValues)) {
+      return '';
+    }
+
     const self = this;
     const sql = {};
     const outBindPrep = this._prepOutbindings(this.single.update, this.single.returning);

--- a/src/dialects/postgres/query/compiler.js
+++ b/src/dialects/postgres/query/compiler.js
@@ -5,7 +5,7 @@ import inherits from 'inherits';
 
 import QueryCompiler from '../../../query/compiler';
 
-import { assign, reduce } from 'lodash'
+import { assign, isEmpty, reduce } from 'lodash'
 
 function QueryCompiler_PG(client, builder) {
   QueryCompiler.call(this, client, builder);
@@ -36,6 +36,15 @@ assign(QueryCompiler_PG.prototype, {
 
   // Compiles an `update` query, allowing for a return value.
   update() {
+    const updateValues = this.single.update || [];
+    if (Array.isArray(updateValues)) {
+      if (updateData.length === 0) {
+        return '';
+      }
+    } else if (typeof updateValues === 'object' && isEmpty(updateValues)) {
+      return '';
+    }
+
     const updateData = this._prepUpdate(this.single.update);
     const wheres = this.where();
     const { returning } = this.single;

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -826,7 +826,11 @@ assign(Builder.prototype, {
     let ret;
     const obj = this._single.update || {};
     this._method = 'update';
-    if (isString(values)) {
+    if (isUndefined(values)) {
+      ret = null;
+    } else if (typeof values === 'object' && isEmpty(values)) {
+      ret = null;
+    } else if (isString(values)) {
       obj[values] = returning;
       if (arguments.length > 2) {
         ret = arguments[2];

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -137,6 +137,15 @@ assign(QueryCompiler.prototype, {
 
   // Compiles the "update" query.
   update() {
+    const updateValues = this.single.update || [];
+    if (Array.isArray(updateValues)) {
+      if (updateData.length === 0) {
+        return '';
+      }
+    } else if (typeof updateValues === 'object' && isEmpty(updateValues)) {
+      return '';
+    }
+
     // Make sure tableName is processed by the formatter first.
     const { tableName } = this;
     const updateData = this._prepUpdate(this.single.update);

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -2885,6 +2885,64 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it("empty update should be a noop", function() {
+    testsql(qb().update().table('users').where('id', '=', 1), {
+      mysql: {
+        sql: '',
+        bindings: []
+      },
+      oracle: {
+        sql: '',
+        bindings: []
+      },
+      mssql: {
+        sql: '',
+        bindings: []
+      },
+      oracledb: {
+        sql: '',
+        bindings: []
+      },
+      postgres: {
+        sql: '',
+        bindings: []
+      },
+      sqlite3: {
+        sql: '',
+        bindings: []
+      }
+    });
+  });
+
+  it("empty object update should be a noop", function() {
+    testsql(qb().update({}).table('users').where('id', '=', 1), {
+      mysql: {
+        sql: '',
+        bindings: []
+      },
+      oracle: {
+        sql: '',
+        bindings: []
+      },
+      mssql: {
+        sql: '',
+        bindings: []
+      },
+      oracledb: {
+        sql: '',
+        bindings: []
+      },
+      postgres: {
+        sql: '',
+        bindings: []
+      },
+      sqlite3: {
+        sql: '',
+        bindings: []
+      }
+    });
+  });
+
   it("delete method", function() {
     testsql(qb().from('users').where('email', '=', 'foo').delete(), {
       mysql: {


### PR DESCRIPTION
Update with no values should produce a noop (rather than `update my_table set where ...`, which is malformed SQL).