### PR TITLE
Mysql should set empty comment for non-string args

### DIFF
--- a/src/dialects/mysql/schema/tablecompiler.js
+++ b/src/dialects/mysql/schema/tablecompiler.js
@@ -56,7 +56,7 @@ assign(TableCompiler_MySQL.prototype, {
 
   // Compiles the comment on the table.
   comment(comment) {
-    this.pushQuery(`alter table ${this.tableName()} comment = '${comment}'`);
+    this.pushQuery(`alter table ${this.tableName()} comment = '${comment || ''}'`);
   },
 
   changeType() {


### PR DESCRIPTION
In MySQL If I use ```comment(null)```, ```comment(false)``` or just ```comment()```
I expect that Mysql will set comment to empty string not to ```'null'```, ```'false'``` or ```'undefined'```.