### PR TITLE
Add unit test for cross-join

### DIFF
--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -1893,6 +1893,48 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it("cross join", function() {
+    testsql(qb().select('*').from('users').crossJoin('contracts').crossJoin('photos'), {
+      mysql: {
+        sql: 'select * from `users` cross join `contracts` cross join `photos`',
+        bindings: []
+      },
+      mssql: {
+        sql: 'select * from [users] cross join [contracts] cross join [photos]',
+        bindings: []
+      },
+      postgres: {
+        sql: 'select * from "users" cross join "contracts" cross join "photos"',
+        bindings: []
+      },
+      sqlite3: {
+        sql: 'select * from `users` cross join `contracts` cross join `photos`',
+        bindings: []
+      },
+      oracle: {
+        sql: 'select * from "users" cross join "contracts" cross join "photos"',
+        bindings: []
+      },
+      oracledb: {
+        sql: 'select * from "users" cross join "contracts" cross join "photos"',
+        bindings: []
+      }
+    });
+  });
+
+  it("cross join on", function() {
+    testsql(qb().select('*').from('users').crossJoin('contracts', 'users.contractId', 'contracts.id'), {
+      mysql: {
+        sql: 'select * from `users` cross join `contracts` on `users`.`contractId` = `contracts`.`id`',
+        bindings: []
+      },
+      sqlite3: {
+        sql: 'select * from `users` cross join `contracts` on `users`.`contractId` = `contracts`.`id`',
+        bindings: []
+      },
+    });
+  });
+
   it("basic joins", function() {
     testsql(qb().select('*').from('users').join('contacts', 'users.id', '=', 'contacts.id').leftJoin('photos', 'users.id', '=', 'photos.id'), {
       mysql: {


### PR DESCRIPTION
Add unit test for cross-join as there was no one currently.
In the first test-case I test composition of two cross-joins.
In the second test-case I test cross-join with ```on``` statement.
I found out that cross-join with ```on``` is only valid for MySQL
and sqlite3 so the test includes only these (it is weird to use
cross-join with ```on``` anyhow).

