### PR TITLE
Use the schema when dropping indices in Postgres.

### DIFF
--- a/src/dialects/postgres/schema/tablecompiler.js
+++ b/src/dialects/postgres/schema/tablecompiler.js
@@ -113,6 +113,7 @@ TableCompiler_PG.prototype.dropPrimary = function(constraintName) {
 };
 TableCompiler_PG.prototype.dropIndex = function(columns, indexName) {
   indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
+  indexName = this.schemaNameRaw ? `${this.formatter.wrap(this.schemaNameRaw)}.${indexName}` : indexName;
   this.pushQuery(`drop index ${indexName}`);
 };
 TableCompiler_PG.prototype.dropUnique = function(columns, indexName) {

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -215,6 +215,14 @@ describe("PostgreSQL SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('drop index "foo"');
   });
 
+  it("drop index, with schema", function() {
+    tableSql = client.schemaBuilder().withSchema('mySchema').table('users', function(table) {
+      table.dropIndex('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index "mySchema"."users_foo_index"');
+  });
+
   it("drop foreign", function() {
     tableSql = client.schemaBuilder().table('users', function(table) {
       table.dropForeign('foo');


### PR DESCRIPTION
Ran into an issue where indices created using `withSchema` could not be dropped correctly since dropping couldn't take the schema into account.

Note that the name can optionally be schema qualified according to the documentation: https://www.postgresql.org/docs/9.6/static/sql-dropindex.html