### PR TITLE
Fix drop of multiple columns in sqlite3

### DIFF
--- a/src/dialects/sqlite3/schema/tablecompiler.js
+++ b/src/dialects/sqlite3/schema/tablecompiler.js
@@ -118,12 +118,13 @@ TableCompiler_SQLite3.prototype.renameColumn = function(from, to) {
   });
 };
 
-TableCompiler_SQLite3.prototype.dropColumn = function(column) {
+TableCompiler_SQLite3.prototype.dropColumn = function() {
   const compiler = this;
+  const columns = Object.values(arguments);
   this.pushQuery({
     sql: `PRAGMA table_info(${this.tableName()})`,
     output(pragma) {
-      return compiler.client.ddl(compiler, pragma, this.connection).dropColumn(column);
+      return compiler.client.ddl(compiler, pragma, this.connection).dropColumn(columns);
     }
   });
 };


### PR DESCRIPTION
* Bugfix for issue #1979 
* The problem was that dropColumn method in sqlite3
  Compiler was using only first argument it got from
  apply
* Reworked to use 'arguments' instead