### PR TITLE
Descriptive log when renaming non existing column

### DIFF
--- a/src/schema/builder.js
+++ b/src/schema/builder.js
@@ -9,6 +9,7 @@ import { each, toArray } from 'lodash'
 // knex instance.
 function SchemaBuilder(client) {
   this.client = client
+  this.mustExistColumnsInfo = null
   this._sequence = []
   this._debug = client.config && client.config.debug
 }

--- a/src/schema/compiler.js
+++ b/src/schema/compiler.js
@@ -66,6 +66,12 @@ function buildTable(type) {
     for (let i = 0, l = sql.length; i < l; i++) {
       this.sequence.push(sql[i]);
     }
+    if (builder._mustExistColumns.length) {
+      this.builder.mustExistColumnsInfo = {
+        table: builder._tableName,
+        columns: builder._mustExistColumns,
+      };
+    }
   };
 }
 

--- a/src/schema/tablebuilder.js
+++ b/src/schema/tablebuilder.js
@@ -18,6 +18,7 @@ function TableBuilder(client, method, tableName, fn) {
   this._tableName = tableName;
   this._statements = [];
   this._single = {};
+  this._mustExistColumns = [];
 
   if(!isFunction(this._fn)) {
     throw new TypeError(
@@ -244,6 +245,7 @@ const AlterMethods = {
   // Renames the current column `from` the current
   // TODO: this.column(from).rename(to)
   renameColumn(from, to) {
+    this._mustExistColumns.push(from);
     this._statements.push({
       grouping: 'alterTable',
       method: 'renameColumn',


### PR DESCRIPTION
Fix for issue #1903 

When renaming column that does not exist migration fails and from the stack trace in console it might not be clear what is the problem.

I added check for column existence, and when the column does not exist it logs meaningful error to console and stack trace also.

There are however more ways to solve this issue. One would probably be to add some check for each dialect (db server) but that is a lot of redundancy. The other approach might be to somehow check column existence in Builder however all builder and compiler stuff is synchronous. The check for column would be asynchronous that results in lot of changes. So in Runner I first compile the query and during the compilation I remember the columns that must exist in array that belongs to Builder. Before running the query I just check If all columns that will be referenced exist. Then the original query is run if no errors were found otherwise error message is logged and exception thrown.


