### PR TITLE
Fix falsly setting autoTransaction

### DIFF
--- a/src/util/batchInsert.js
+++ b/src/util/batchInsert.js
@@ -11,9 +11,11 @@ export default function batchInsert(client, tableName, batch, chunkSize = 1000) 
 
   const getTransaction = () => new Promise((resolve, reject) => {
     if(transaction) {
+      autoTransaction = false;
       return resolve(transaction);
     }
 
+    autoTransaction = true;
     client.transaction(resolve)
     .catch(reject);
   });
@@ -65,7 +67,6 @@ export default function batchInsert(client, tableName, batch, chunkSize = 1000) 
     },
     transacting(tr) {
       transaction = tr;
-      autoTransaction = false;
 
       return this;
     }


### PR DESCRIPTION
When passing a falsy value to transacting a new transaction is created but `autoTransaction` is set to false so the transaction is never committed or rolled back.

This is a problem because this means `batchInsert` works different then `insert` here.
So passing `null` into `transacting` works for `insert`
```js
knex.insert(rows)
    .into('TableName')
    .transacting(null)
```
but it doesn't for `batchInsert`
```js
knex.batchInsert('TableName', rows, chunkSize)
    .transacting(null)
```