### PR TITLE
Add fullOuterJoin unit test

### DIFF
--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -1922,6 +1922,27 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it("full outer join", function() {
+    testsql(qb().select('*').from('users').fullOuterJoin('contacts', 'users.id', '=', 'contacts.id'), {
+      mssql: {
+        sql: 'select * from [users] full outer join [contacts] on [users].[id] = [contacts].[id]',
+        bindings: []
+      },
+      oracle: {
+        sql: 'select * from "users" full outer join "contacts" on "users"."id" = "contacts"."id"',
+        bindings: []
+      },
+      oracledb: {
+        sql: 'select * from "users" full outer join "contacts" on "users"."id" = "contacts"."id"',
+        bindings: []
+      },
+      postgres: {
+        sql: 'select * from "users" full outer join "contacts" on "users"."id" = "contacts"."id"',
+        bindings: []
+      }
+    });
+  });
+
   it("cross join on", function() {
     testsql(qb().select('*').from('users').crossJoin('contracts', 'users.contractId', 'contracts.id'), {
       mysql: {


### PR DESCRIPTION
Add unit test for ```fullOuterJoin```. No unitTest for MySQL and sqlite3 because they do not support it. Btw I found out that there is also ```outerJoin``` function which however will not work for any dialect. The issue is that it translates to ```OUTER JOIN ON ...``` which is not supported anywhere but ```FULL JOIN ON``` is supported in mssql, postgres and oracle so that is probably a bug.
