### PR TITLE
Throw error on non-string table comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-preset-es2015": "^6.13.2",
     "chai": "^3.5.0",
     "coveralls": "~2.11.1",
-    "dockerode": "^2.4.3",
+    "dockerode": "2.4.3",
     "eslint": "2.2.0",
     "eslint-plugin-import": "^1.8.0",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-preset-es2015": "^6.13.2",
     "chai": "^3.5.0",
     "coveralls": "~2.11.1",
-    "dockerode": "2.4.3",
+    "dockerode": "^2.4.3",
     "eslint": "2.2.0",
     "eslint-plugin-import": "^1.8.0",
     "istanbul": "^0.4.5",

--- a/src/dialects/mssql/schema/tablecompiler.js
+++ b/src/dialects/mssql/schema/tablecompiler.js
@@ -25,7 +25,7 @@ assign(TableCompiler_MSSQL.prototype, {
     const sql = createStatement + this.tableName() + (this._formatting ? ' (\n    ' : ' (') + columns.sql.join(this._formatting ? ',\n    ' : ', ') + ')';
 
     if (this.single.comment) {
-      const comment = (this.single.comment || '');
+      const {comment} = this.single;
       if (comment.length > 60) helpers.warn('The max length for a table comment is 60 characters');
     }
 

--- a/src/dialects/oracle/schema/tablecompiler.js
+++ b/src/dialects/oracle/schema/tablecompiler.js
@@ -67,7 +67,7 @@ assign(TableCompiler_Oracle.prototype, {
 
   // Compiles the comment on the table.
   comment(comment) {
-    this.pushQuery(`comment on table ${this.tableName()} is '${comment || ''}'`);
+    this.pushQuery(`comment on table ${this.tableName()} is '${comment}'`);
   },
 
   addColumnsPrefix: 'add ',

--- a/src/dialects/postgres/schema/tablecompiler.js
+++ b/src/dialects/postgres/schema/tablecompiler.js
@@ -87,7 +87,7 @@ TableCompiler_PG.prototype.addColumns = function(columns, prefix, colCompilers) 
 
 // Compiles the comment on the table.
 TableCompiler_PG.prototype.comment = function(comment) {
-  this.pushQuery(`comment on table ${this.tableName()} is '${this.single.comment || ''}'`);
+  this.pushQuery(`comment on table ${this.tableName()} is '${this.single.comment}'`);
 };
 
 // Indexes:

--- a/src/schema/tablebuilder.js
+++ b/src/schema/tablebuilder.js
@@ -180,6 +180,9 @@ TableBuilder.prototype.timestamps = function timestamps() {
 // Set the comment value for a table, they're only allowed to be called
 // once per table.
 TableBuilder.prototype.comment = function(value) {
+  if (typeof value !== 'string') {
+    throw new TypeError('Table comment must be string');
+  }
   this._single.comment = value;
 };
 

--- a/test/unit/schema/mssql.js
+++ b/test/unit/schema/mssql.js
@@ -397,6 +397,24 @@ describe("MSSQL SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] decimal(5, 2)');
   });
 
+  it('set comment to undefined', function() {
+    expect(function() {
+      client.schemaBuilder().table('user', function(t) {
+        t.comment();
+      }).toSQL();
+    })
+    .to.throw(TypeError);
+  });
+
+  it('set comment to null', function() {
+    expect(function() {
+      client.schemaBuilder().table('user', function(t) {
+        t.comment(null);
+      }).toSQL();
+    })
+    .to.throw(TypeError);
+  });
+
   it('test adding boolean', function() {
     tableSql = client.schemaBuilder().table('users', function() {
       this.boolean('foo');

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -522,6 +522,24 @@ describe(dialect + " SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table `users` comment = \'\'');
   });
 
+  it('set comment to undefined', function() {
+    expect(function() {
+      client.schemaBuilder().table('user', function(t) {
+        t.comment();
+      }).toSQL();
+    })
+    .to.throw(TypeError);
+  });
+
+  it('set comment to null', function() {
+    expect(function() {
+      client.schemaBuilder().table('user', function(t) {
+        t.comment(null);
+      }).toSQL();
+    })
+    .to.throw(TypeError);
+  });
+
   it('should alter columns with the alter flag', function() {
     tableSql = client.schemaBuilder().table('users', function() {
       this.string('foo').alter();

--- a/test/unit/schema/oracle.js
+++ b/test/unit/schema/oracle.js
@@ -515,6 +515,24 @@ describe("Oracle SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('comment on table "users" is \'\'');
   });
 
+  it('set comment to undefined', function() {
+    expect(function() {
+      client.schemaBuilder().table('user', function(t) {
+        t.comment();
+      }).toSQL();
+    })
+    .to.throw(TypeError);
+  });
+
+  it('set comment to null', function() {
+    expect(function() {
+      client.schemaBuilder().table('user', function(t) {
+        t.comment(null);
+      }).toSQL();
+    })
+    .to.throw(TypeError);
+  });
+
   it('is possible to set raw statements in defaultTo, #146', function() {
     tableSql = client.schemaBuilder().createTable('default_raw_test', function(t) {
       t.timestamp('created_at').defaultTo(client.raw('CURRENT_TIMESTAMP'));

--- a/test/unit/schema/oracledb.js
+++ b/test/unit/schema/oracledb.js
@@ -505,6 +505,24 @@ describe("OracleDb SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('comment on table "users" is \'\'');
   });
 
+  it('set comment to undefined', function() {
+    expect(function() {
+      client.schemaBuilder().table('user', function(t) {
+        t.comment();
+      }).toSQL();
+    })
+    .to.throw(TypeError);
+  });
+
+  it('set comment to null', function() {
+    expect(function() {
+      client.schemaBuilder().table('user', function(t) {
+        t.comment(null);
+      }).toSQL();
+    })
+    .to.throw(TypeError);
+  });
+
   it('is possible to set raw statements in defaultTo, #146', function() {
     tableSql = client.schemaBuilder().createTable('default_raw_test', function(t) {
       t.timestamp('created_at').defaultTo(client.raw('CURRENT_TIMESTAMP'));

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -611,6 +611,24 @@ describe("PostgreSQL SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('comment on table "user" is \'\'');
   });
 
+  it('set comment to undefined', function() {
+    expect(function() {
+      client.schemaBuilder().table('user', function(t) {
+        t.comment();
+      }).toSQL();
+    })
+    .to.throw(TypeError);
+  });
+
+  it('set comment to null', function() {
+    expect(function() {
+      client.schemaBuilder().table('user', function(t) {
+        t.comment(null);
+      }).toSQL();
+    })
+    .to.throw(TypeError);
+  });
+
   it('allows adding default json objects when the column is json', function() {
     tableSql = client.schemaBuilder().table('user', function(t) {
       t.json('preferences').defaultTo({}).notNullable();


### PR DESCRIPTION
According to discussion in #2101 

When setting table comment to be empty, knex will throw error on non string args

* add unit tests for all dialects
* removed retyping to empty string

All the unit tests are the same. Do you handle this type of redundancy somehow or is it ok with unit tests? Theoretically it might be used as integration test, but I do not think this will be right because these comment tests test only single unit of functionality.
