### PR TITLE
Remove sorting of statements from update queries (#2169)

### DIFF
--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -592,13 +592,13 @@ assign(QueryCompiler.prototype, {
   _prepUpdate(data) {
     data = omitBy(data, isUndefined)
     const vals = []
-    const sorted = Object.keys(data).sort()
+    const columns = Object.keys(data)
     let i = -1
-    while (++i < sorted.length) {
+    while (++i < columns.length) {
       vals.push(
-        this.formatter.wrap(sorted[i]) +
+        this.formatter.wrap(columns[i]) +
         ' = ' +
-        this.formatter.parameter(data[sorted[i]])
+        this.formatter.parameter(data[columns[i]])
       );
     }
     return vals;

--- a/test/integration/builder/updates.js
+++ b/test/integration/builder/updates.js
@@ -16,26 +16,26 @@ module.exports = function(knex) {
         }).testSql(function(tester) {
           tester(
             'mysql',
-            'update `accounts` set `email` = ?, `first_name` = ?, `last_name` = ? where `id` = ?',
-            ['test100@example.com','User','Test',1],
+            'update `accounts` set `first_name` = ?, `last_name` = ?, `email` = ? where `id` = ?',
+            ['User','Test','test100@example.com',1],
             1
           );
           tester(
             'postgresql',
-            'update "accounts" set "email" = ?, "first_name" = ?, "last_name" = ? where "id" = ?',
-            ['test100@example.com','User','Test',1],
+            'update "accounts" set "first_name" = ?, "last_name" = ?, "email" = ? where "id" = ?',
+            ['User','Test','test100@example.com',1],
             1
           );
           tester(
             'sqlite3',
-            'update `accounts` set `email` = ?, `first_name` = ?, `last_name` = ? where `id` = ?',
-            ['test100@example.com','User','Test',1],
+            'update `accounts` set `first_name` = ?, `last_name` = ?, `email` = ? where `id` = ?',
+            ['User','Test','test100@example.com',1],
             1
           );
           tester(
             'mssql',
-            'update [accounts] set [email] = ?, [first_name] = ?, [last_name] = ? where [id] = ?;select @@rowcount',
-            ['test100@example.com','User','Test',1],
+            'update [accounts] set [first_name] = ?, [last_name] = ?, [email] = ? where [id] = ?;select @@rowcount',
+            ['User','Test','test100@example.com',1],
             1
           );
         });
@@ -45,9 +45,9 @@ module.exports = function(knex) {
       return knex('accounts')
         .where('id', 1000)
         .update({
+          email:'test100@example.com',
           first_name: null,
-          last_name: 'Test',
-          email:'test100@example.com'
+          last_name: 'Test'
         }).testSql(function(tester) {
           tester(
             'mysql',
@@ -111,9 +111,9 @@ module.exports = function(knex) {
     it('should allow returning for updates in postgresql', function() {
 
       return knex('accounts').where('id', 1).update({
+        email:'test100@example.com',
         first_name: 'UpdatedUser',
-        last_name: 'UpdatedTest',
-        email:'test100@example.com'
+        last_name: 'UpdatedTest'
       }, '*').testSql(function(tester) {
         tester(
           'mysql',


### PR DESCRIPTION
Consistent updates where a new field value depends on an another field that gets updated in the same query are impossible across different databases unless the original update order is maintained.

The problem is with MySQL not following the SQL spec as described here: https://dev.mysql.com/doc/refman/5.7/en/ansi-diff-update.html. This causes the value used for calculating another value sometimes already be updated and sometimes not, depending on which database is used and what the names of the fields are if the statements are sorted alphabetically.

This PR removes sorting of statements when building an UPDATE query. A possible future issue is that the key order of an object is not defined in the spec while all known JS engines keep non-integer-like keys in insertion order so this should work correctly across all engines. The order might thus be different with an engine in the future. More info on ordering here: https://bugs.chromium.org/p/v8/issues/detail?id=164