### PR TITLE
Recognize fatal mysql2 connection errors

### DIFF
--- a/src/dialects/mysql2/index.js
+++ b/src/dialects/mysql2/index.js
@@ -29,8 +29,8 @@ assign(Client_MySQL2.prototype, {
     return require('mysql2')
   },
 
-  validateConnection() {
-    return true
+  validateConnection(connection) {
+    return !connection._fatalError
   },
 
   // Get a raw connection, called by the `pool` whenever a new
@@ -48,6 +48,10 @@ assign(Client_MySQL2.prototype, {
         resolver(connection)
       })
     })
+  },
+
+  destroyRawConnection(connection) {
+    if (!connection._fatalError) return Client_MySQL.prototype.destroyRawConnection(connection)
   },
 
   processResponse(obj, runner) {


### PR DESCRIPTION
Connections created by MySQL2 driver transition to broken state when
network errors or timeouts occur. This condition is not visible to the
connection pool in Knex.

If Knex detects a timeout and tries to close a connection, this causes
an uncaught exception from MySQL2. Similarly the connection pool never
realizes the connection is in a broken state, and thus will never
replace it.

Unfortunately the MySQL2 connection does not expose a state, but it can
be inferred by checking for `connection._fatalError`.

Fixes #1798

---

This is an alternative to #1853. I believe the issue is specific to the `mysql2`dialect, however (see https://github.com/tgriesser/knex/issues/1798#issuecomment-263025502 which shows the `mysql2` client being used). The workaround proposed in #1853 likely fights only the symptoms, but does not solve the underlying problem.

Ideally https://github.com/sidorares/node-mysql2 would expose the connection state, but it's probably worth fixing the problem in Knex even for current releases of `mysql2`.

It's not clear to me if there are tests for this dialect. To be quite frank though I'm planning to switch my (business) client's project to the `mysql` dialect once https://github.com/mysqljs/mysql/pull/1776 lands there, so unfortunately I can't justify spending a lot of effort on fixing issues with `mysql2`.