### PR TITLE
[WIP] INSERT ... ON CONFLICT support for postgres

### DIFF
--- a/src/dialects/postgres/query/compiler.js
+++ b/src/dialects/postgres/query/compiler.js
@@ -27,9 +27,9 @@ assign(QueryCompiler_PG.prototype, {
   insert() {
     const sql = QueryCompiler.prototype.insert.call(this)
     if (sql === '') return sql;
-    const { returning } = this.single;
+    const { onConflict, returning } = this.single;
     return {
-      sql: sql + this._returning(returning),
+      sql: sql + this._onConflict(onConflict) + this._returning(returning),
       returning
     };
   },
@@ -57,6 +57,22 @@ assign(QueryCompiler_PG.prototype, {
       sql: sql + this._returning(returning),
       returning
     };
+  },
+
+  _onConflict(value) {
+    if (!value) {
+      return '';
+    }
+    const { columns, updates } = value;
+    let sql = ` on conflict (${this.formatter.columnize(columns)}) do `;
+    if (updates) {
+      const updateData = this._prepUpdate(updates);
+      sql += `update set ${updateData.join(', ')}`;
+    }
+    else {
+      sql += 'nothing';
+    }
+    return sql;
   },
 
   _returning(value) {

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -853,6 +853,15 @@ assign(Builder.prototype, {
     return this;
   },
 
+  // Insert on conflict do nothing/update
+  onConflict(columns, updates) {
+    this._single.onConflict = {
+      columns,
+      updates
+    };
+    return this;
+  },
+
   // Delete
   // ------
 

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -743,26 +743,26 @@ module.exports = function(knex) {
     });
 
     it('should perform update on conflict in postgres and return conflicting row', function() {
-
-      return knex('accounts')
-        .insert({
-          email:'test8@example.com',
-          first_name: 'User',
-          last_name: 'Test'
-        }, 'id')
-        .onConflict('email', {
-          first_name: 'Testing',
-          last_name: 'Users'
-        })
-        .testSql(function(tester) {
-          tester(
-            'postgresql',
-            'insert into "accounts" ("email", "first_name", "last_name") values (?, ?, ?) on conflict ("email") do update set "first_name" = \'Testing\', "last_name" = \'Users\' returning "id"',
-            ['test8@example.com','Test','User'],
-            ['9']
-          );
-        });
-
+      if (knex.client.dialect === 'postgresql') {
+        return knex('accounts')
+          .insert({
+            email:'test8@example.com',
+            first_name: 'User',
+            last_name: 'Test'
+          }, 'id')
+          .onConflict('email', {
+            first_name: 'Testing',
+            last_name: 'Users'
+          })
+          .testSql(function(tester) {
+            tester(
+              'postgresql',
+              'insert into "accounts" ("email", "first_name", "last_name") values (?, ?, ?) on conflict ("email") do update set "first_name" = \'Testing\', "last_name" = \'Users\' returning "id"',
+              ['test8@example.com','Test','User'],
+              ['9']
+            );
+          });
+      }
     });
 
     describe('batchInsert', function() {


### PR DESCRIPTION
This is based in part on [this gist](https://gist.github.com/hayeah/1c8d642df5cfeabc2a5b) by @hayeah, and in part on the existing update method implementation.

It would affect #1633, #1351, #1121, and #54. I wrote preliminary tests for it, which I'm using the CI to run, but I'd like feedback on the them (the test files are rather hard to parse).

I don't think any consensus has been reached on a more generalized "upsert" feature, but I think supporting this in a database-specific way is reasonable and makes the API easy to understand.

Asking @elhigu (because you had input on #54), do you think a Postgres-specific approach is acceptable, or would this need to be expanded to support all clients that have some kind of `MERGE`/`ON DUPLICATE KEY UPDATE` functionality?