### PR TITLE
Fix connection error propagation when streaming

### DIFF
--- a/test/integration/builder/selects.js
+++ b/test/integration/builder/selects.js
@@ -179,19 +179,36 @@ module.exports = function(knex) {
       });
     });
 
-    it('emits error on the stream, if not passed a function, and connecting fails', function(done) {
+    it('emits error on the stream, if not passed a function, and connecting fails', function() {
       var expected = new Error();
       var original = Runner.prototype.ensureConnection;
       Runner.prototype.ensureConnection = function() {
         return Promise.reject(expected);
       };
-      var stream = knex('accounts').stream();
-      stream.on('error', function(actual) {
-        if (actual === expected) {
-          Runner.prototype.ensureConnection = original;
-          done();
-        }
+
+      var restore = () => {
+        Runner.prototype.ensureConnection = original;
+      };
+
+      var promise = new Promise((resolve, reject) => {
+        var timeout = setTimeout(() => {
+          reject(new Error('Timeout'));
+        }, 5000);
+
+        var stream = knex('accounts').stream();
+        stream.on('error', function(actual) {
+          clearTimeout(timeout);
+
+          if (actual === expected) {
+            resolve();
+          } else {
+            reject(new Error('Stream emitted unexpected error'));
+          }
+        });
       });
+
+      promise.then(restore, restore);
+      return promise;
     });
 
     it('properly escapes postgres queries on streaming', function() {

--- a/test/integration/builder/selects.js
+++ b/test/integration/builder/selects.js
@@ -3,6 +3,7 @@
 
 var assert  = require('assert')
 var Promise = testPromise;
+var Runner = require('../../../lib/runner');
 
 module.exports = function(knex) {
 
@@ -175,6 +176,21 @@ module.exports = function(knex) {
       stream.on('data', function() {
         count++;
         if (count === 6) done();
+      });
+    });
+
+    it('emits error on the stream, if not passed a function, and connecting fails', function(done) {
+      var expected = new Error();
+      var original = Runner.prototype.ensureConnection;
+      Runner.prototype.ensureConnection = function() {
+        return Promise.reject(expected);
+      };
+      var stream = knex('accounts').stream();
+      stream.on('error', function(actual) {
+        if (actual === expected) {
+          Runner.prototype.ensureConnection = original;
+          done();
+        }
       });
     });
 


### PR DESCRIPTION
If stream() is used without a handler, make sure to emit connection errors on the stream itself.

This might fix #948, but I've only verified the patch when using Postgres.