### PR TITLE
Configuration option to allow override/hook to identifier wrapping code

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -158,6 +158,13 @@ assign(Client.prototype, {
   },
 
   wrapIdentifier(value) {
+    if (this.config.wrapIdentifier) {
+      return this.config.wrapIdentifier(value, this.wrapIdentifierImpl);
+    }
+    return this.wrapIdentifierImpl(value);
+  },
+
+  wrapIdentifierImpl(value) {
     return (value !== '*' ? `"${value.replace(/"/g, '""')}"` : '*')
   },
 

--- a/src/dialects/mssql/index.js
+++ b/src/dialects/mssql/index.js
@@ -66,7 +66,7 @@ assign(Client_MSSQL.prototype, {
     return new ColumnCompiler(this, ...arguments)
   },
 
-  wrapIdentifier(value) {
+  wrapIdentifierImpl(value) {
     return (value !== '*' ? `[${value.replace(/\[/g, '\[')}]` : '*')
   },
 

--- a/src/dialects/mysql/index.js
+++ b/src/dialects/mysql/index.js
@@ -56,7 +56,7 @@ assign(Client_MySQL.prototype, {
 
   _escapeBinding: makeEscape(),
 
-  wrapIdentifier(value) {
+  wrapIdentifierImpl(value) {
     return (value !== '*' ? `\`${value.replace(/`/g, '``')}\`` : '*')
   },
 

--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -91,10 +91,10 @@ assign(Client_PG.prototype, {
     }
   }),
 
-  wrapIdentifier(value) {
+  wrapIdentifierImpl(value) {
     if (value === '*') return value;
     const matched = value.match(/(.*?)(\[[0-9]\])/);
-    if (matched) return this.wrapIdentifier(matched[1]) + matched[2];
+    if (matched) return this.wrapIdentifierImpl(matched[1]) + matched[2];
     return `"${value.replace(/"/g, '""')}"`;
   },
 

--- a/src/dialects/sqlite3/index.js
+++ b/src/dialects/sqlite3/index.js
@@ -57,7 +57,7 @@ assign(Client_SQLite3.prototype, {
     return new SQLite3_DDL(this, compiler, pragma, connection)
   },
 
-  wrapIdentifier(value) {
+  wrapIdentifierImpl(value) {
     return (value !== '*' ? `\`${value.replace(/`/g, '``')}\`` : '*')
   },
 

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -80,6 +80,34 @@ function testquery(chain, valuesToCheck, selectedClients) {
   })
 }
 
+describe("Custom identifier wrapping", function() {
+  var customWrapperConfig = {
+    wrapIdentifier: (value, clientImpl) => {
+      return clientImpl(value + '_wrapper_was_here');
+    }
+  };
+
+  var clientsWithCustomIdentifierWrapper = {
+    mysql: new MySQL_Client(customWrapperConfig),
+    postgres: new PG_Client(customWrapperConfig),
+    oracle: new Oracle_Client(customWrapperConfig),
+    oracledb: new Oracledb_Client(customWrapperConfig),
+    sqlite3: new SQLite3_Client(customWrapperConfig),
+    mssql: new MSSQL_Client(customWrapperConfig),
+  };
+
+  it('should use custom wrapper', () => {
+    testsql(qb().withSchema('schema').select('users.foo as bar').from('users'), {
+      mysql: 'select `users_wrapper_was_here`.`foo_wrapper_was_here` as `bar_wrapper_was_here` from `schema_wrapper_was_here`.`users_wrapper_was_here`',
+      oracle: 'select "users_wrapper_was_here"."foo_wrapper_was_here" "bar_wrapper_was_here" from "schema_wrapper_was_here"."users_wrapper_was_here"',
+      mssql: 'select [users_wrapper_was_here].[foo_wrapper_was_here] as [bar_wrapper_was_here] from [schema_wrapper_was_here].[users_wrapper_was_here]',
+      oracledb: 'select "users_wrapper_was_here"."foo_wrapper_was_here" "bar_wrapper_was_here" from "schema_wrapper_was_here"."users_wrapper_was_here"',
+      postgres: 'select "users_wrapper_was_here"."foo_wrapper_was_here" as "bar_wrapper_was_here" from "schema_wrapper_was_here"."users_wrapper_was_here"',
+      sqlite3: 'select `users_wrapper_was_here`.`foo_wrapper_was_here` as `bar_wrapper_was_here` from `schema_wrapper_was_here`.`users_wrapper_was_here`'
+    }, clientsWithCustomIdentifierWrapper);
+  })
+});
+
 describe("QueryBuilder", function() {
 
   it("basic select", function() {


### PR DESCRIPTION
First part of https://github.com/tgriesser/knex/issues/2084 and https://github.com/tgriesser/knex/issues/929 feature, which allows to write custom identifier wrapper methods. 

So effectively you can describe function how each identifier name are treated, like for example id replacement in `knex.raw('??', ['MyTable.myCol'])` will behave. This is pretty nice feature for ORMs which would like to allow for example different naming scheme for database tables/columns and on javascript side.

Documentation PR is here https://github.com/knex/documentation/pull/51