### PR TITLE
Fix multiple thens running query builder multiple times

### DIFF
--- a/src/interface.js
+++ b/src/interface.js
@@ -14,8 +14,10 @@ export default function(Target) {
 
   // Create a new instance of the `Runner`, passing in the current object.
   Target.prototype.then = function(/* onFulfilled, onRejected */) {
-    const result = this.client.runner(this).run()
-    return result.then.apply(result, arguments);
+    if (!this._runInstance) {
+      this._runInstance = this.client.runner(this).run();
+    }
+    return this._runInstance.then.apply(this._runInstance, arguments);
   };
 
   // Add additional "options" to the builder. Typically used for client specific

--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -19,6 +19,24 @@ module.exports = function(knex) {
       });
     });
 
+    it('should run the query once after calling the .then() function', function() {
+      var p = knex('accounts').insert({
+        first_name: 'Test',
+        last_name: 'Multithen',
+        email:'test@example.com',
+      }, 'id');
+
+      return Promise.resolve().then(function(){
+        return p;
+      }).then(function(){
+        return p;
+      }).then(function(){
+        return knex('accounts').where('last_name', 'Multithen').select('*');
+      }).then(function(multithenAccounts){
+        expect(multithenAccounts.length == 1);
+      });
+    });
+
     it('should forward the .mapSeries() function from bluebird', function() {
       var asyncTask = function(){
         return new Promise(function(resolve, reject){


### PR DESCRIPTION
The knex documentation has the following under the `then` method (emphasis mine):
> Coerces the current query builder chain into a promise state, accepting the resolve and reject handlers as specified by the Promises/A+ spec. As stated in the spec, more than one call to the then method for the current query chain will resolve with the same value, in the order they were called; **the query will not be executed multiple times**.

This PR adds a test showing that the bolded statement is not correctly implemented by knex and fixes the bug.