### PR TITLE
Build native sql for a dialect without to string

### DIFF
--- a/scripts/docker-for-test.sh
+++ b/scripts/docker-for-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ -n "$(which docker)" ]; then
+if [ -n "$(docker info)" ]; then
     DOCKER_IMAGES=("mysql:5.7" "postgres:9.6")
     for image in ${DOCKER_IMAGES[@]}; do
         if [ -z "$(docker images -q ${image})" ]; then

--- a/src/client.js
+++ b/src/client.js
@@ -133,6 +133,7 @@ assign(Client.prototype, {
 
   query(connection, obj) {
     if (typeof obj === 'string') obj = {sql: obj}
+    obj.sql = this.positionBindings(obj.sql);
     obj.bindings = this.prepBindings(obj.bindings)
     debugQuery(obj.sql)
     this.emit('query', assign({__knexUid: connection.__knexUid}, obj))
@@ -146,15 +147,20 @@ assign(Client.prototype, {
 
   stream(connection, obj, stream, options) {
     if (typeof obj === 'string') obj = {sql: obj}
+    obj.sql = this.positionBindings(obj.sql);
+    obj.bindings = this.prepBindings(obj.bindings)
     this.emit('query', assign({__knexUid: connection.__knexUid}, obj))
     debugQuery(obj.sql)
-    obj.bindings = this.prepBindings(obj.bindings)
     debugBindings(obj.bindings)
     return this._stream(connection, obj, stream, options)
   },
 
   prepBindings(bindings) {
     return bindings;
+  },
+
+  positionBindings(sql) {
+    return sql;
   },
 
   wrapIdentifier(value) {

--- a/src/dialects/mssql/index.js
+++ b/src/dialects/mssql/index.js
@@ -114,8 +114,6 @@ assign(Client_MSSQL.prototype, {
   _stream(connection, obj, stream, options) {
     options = options || {}
     if (!obj || typeof obj === 'string') obj = {sql: obj}
-    // convert ? params into positional bindings (@p1)
-    obj.sql = this.positionBindings(obj.sql);
     return new Promise((resolver, rejecter) => {
       stream.on('error', (err) => {
         rejecter(err)
@@ -142,8 +140,6 @@ assign(Client_MSSQL.prototype, {
   _query(connection, obj) {
     const client = this;
     if (!obj || typeof obj === 'string') obj = {sql: obj}
-    // convert ? params into positional bindings (@p1)
-    obj.sql = this.positionBindings(obj.sql);
     return new Promise((resolver, rejecter) => {
       const { sql } = obj
       if (!sql) return resolver()

--- a/src/dialects/oracle/index.js
+++ b/src/dialects/oracle/index.js
@@ -116,7 +116,6 @@ assign(Client_Oracle.prototype, {
   },
 
   _stream(connection, obj, stream, options) {
-    obj.sql = this.positionBindings(obj.sql);
     return new Promise(function (resolver, rejecter) {
       stream.on('error', (err) => {
         if (isConnectionError(err)) {
@@ -133,9 +132,6 @@ assign(Client_Oracle.prototype, {
   // Runs the query on the specified connection, providing the bindings
   // and any other necessary prep work.
   _query(connection, obj) {
-
-    // convert ? params into positional bindings (:1)
-    obj.sql = this.positionBindings(obj.sql);
 
     if (!obj.sql) throw new Error('The query is empty');
 

--- a/src/dialects/oracledb/index.js
+++ b/src/dialects/oracledb/index.js
@@ -233,10 +233,6 @@ Client_Oracledb.prototype.destroyRawConnection = function(connection) {
 // Runs the query on the specified connection, providing the bindings
 // and any other necessary prep work.
 Client_Oracledb.prototype._query = function(connection, obj) {
-  // Convert ? params into positional bindings (:1)
-  obj.sql = this.positionBindings(obj.sql);
-  obj.bindings = this.prepBindings(obj.bindings) || [];
-
   return new Promise(function(resolver, rejecter) {
     if (!obj.sql) {
       return rejecter(new Error('The query is empty'));

--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -173,7 +173,7 @@ assign(Client_PG.prototype, {
 
   _stream(connection, obj, stream, options) {
     const PGQueryStream = process.browser ? undefined : require('pg-query-stream');
-    const sql = obj.sql = this.positionBindings(obj.sql)
+    const sql = obj.sql;
     return new Promise(function(resolver, rejecter) {
       const queryStream = connection.query(new PGQueryStream(sql, obj.bindings, options));
       queryStream.on('error', function(error) { stream.emit('error', error); });
@@ -192,7 +192,7 @@ assign(Client_PG.prototype, {
   // Runs the query on the specified connection, providing the bindings
   // and any other necessary prep work.
   _query(connection, obj) {
-    let sql = obj.sql = this.positionBindings(obj.sql)
+    let sql = obj.sql;
     if (obj.options) sql = extend({text: sql}, obj.options);
     return new Promise(function(resolver, rejecter) {
       connection.query(sql, obj.bindings, function(err, response) {

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -73,7 +73,15 @@ assign(QueryCompiler.prototype, {
       );
     }
 
-    return assign(defaults, val);
+    const query = assign(defaults, val);
+    query.toNative = () => {
+      return {
+        sql: this.client.positionBindings(query.sql),
+        bindings: this.client.prepBindings(query.bindings)
+      };
+    };
+
+    return query;
   },
 
   // Compiles the `select` statement, or nested sub-selects by calling each of

--- a/test/docker/index.js
+++ b/test/docker/index.js
@@ -21,9 +21,9 @@ function canRunDockerTests() {
   const isLinux   = os.platform() === 'linux';
   const isDarwin  = os.platform() === 'darwin'
   // dont even try on windows / osx for now
-  let hasDocker = false;
+  let hasDockerStarted = false;
   if (isLinux || isDarwin) {
-    hasDocker = proc.execSync('docker -v 1>/dev/null 2>&1 ; echo $?').toString('utf-8') === '0\n';
+    hasDockerStarted = proc.execSync('docker info 1>/dev/null 2>&1 ; echo $?').toString('utf-8') === '0\n';
   }
-  return hasDocker;
+  return hasDockerStarted;
 }

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -69,6 +69,17 @@ function testsql(chain, valuesToCheck, selectedClients) {
   })
 }
 
+function testNativeSql(chain, valuesToCheck, selectedClients) {
+  selectedClients = selectedClients || clients;
+  Object.keys(valuesToCheck).forEach(function(key) {
+    var newChain = chain.clone();
+    newChain.client = selectedClients[key];
+    var sqlAndBindings = newChain.toSQL().toNative();
+    var checkValue = valuesToCheck[key];
+    verifySqlResult(key, checkValue, sqlAndBindings);
+  })
+}
+
 function testquery(chain, valuesToCheck, selectedClients) {
   selectedClients = selectedClients || clients;
   Object.keys(valuesToCheck).forEach(function(key) {
@@ -4314,6 +4325,35 @@ describe("QueryBuilder", function() {
           sql: 'with "withClause" as (with "withSubClause" as (select "foo" as "baz" from "users" where "baz" > ? and "baz" < ?) select * from "withSubClause") select * from "withClause" where "id" = ?',
           bindings: [1, 20, 10]
         }
+    });
+  });
+
+  it("should return dialect specific sql and bindings with  toSQL().toNative()", function() {
+    testNativeSql(qb().from('table').where('isIt', true), {
+      mssql: {
+        sql: 'select * from [table] where [isIt] = @p0',
+        bindings: [true]
+      },
+      mysql: {
+        sql: 'select * from `table` where `isIt` = ?',
+        bindings: [true]
+      },
+      sqlite3: {
+        sql: 'select * from `table` where `isIt` = ?',
+        bindings: [true]
+      },
+      postgres: {
+        sql: 'select * from "table" where "isIt" = $1',
+        bindings: [true]
+      },
+      oracledb: {
+        sql: 'select * from "table" where "isIt" = :1',
+        bindings: [1]
+      },
+      oracle: {
+        sql: 'select * from "table" where "isIt" = :1',
+        bindings: [1]
+      }
     });
   });
 


### PR DESCRIPTION
There has been a problem that knex hasn't been able to be used as a just query builder, except with SQL where all values are interpolated to one string, which has been passed as a string to driver.

This PR adds a way to get toSQL() result also in native SQL dialects format, where bindings are given separately and SQL string with dialects replacements are provided separately. 

For example with postgresql dialalect query would be like:

```js
{
  sql: `select * from "table" where id = $1`,
  bindings: [1]
}
```

Feature is implemented to the result of `toSQL()`as a getter function to prevent memory overhead of storing SQL strings and bindings always in two different format.

Here is also one related issue, where this was first requested https://github.com/tgriesser/knex/issues/1286
