### PR TITLE
Updated oprator list and allow operator transformation for e.g. escaping ?

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -8,12 +8,21 @@ const orderBys = ['asc', 'desc'];
 
 // Turn this into a lookup map
 const operators = transform([
-  '=', '<', '>', '<=', '>=', '<>', '!=', 'like',
-  'not like', 'between', 'ilike', 'not ilike', '&', '|', '^', '<<', '>>',
-  'rlike', 'regexp', 'not regexp', '~', '~*', '!~', '!~*',
-  '#', '&&', '@>', '<@', '||'
+  '=', '<', '>', '<=', '>=', '<>', '!=',
+  'like', 'not like', 'between', 'not between',
+  'ilike', 'not ilike', 'exists', 'not exist',
+  'rlike', 'not rlike', 'regexp', 'not regexp',
+  '&', '|', '^', '<<', '>>', '~', '~*', '!~', '!~*',
+  '#', '&&', '@>', '<@', '||', '&<', '&>', '-|-', '@@', '!!',
+  ['?', '\\?'],
+  ['?|', '\\?|'],
+  ['?&', '\\?&'],
 ], (result, key) => {
-  result[key] = true
+  if (Array.isArray(key)) {
+    result[key[0]] = key[1];
+  } else {
+    result[key] = key;
+  }
 }, {});
 
 export default class Formatter {
@@ -105,14 +114,14 @@ export default class Formatter {
     return first + ' as ' + second;
   }
 
-  // The operator method takes a value and returns something or other.
   operator(value) {
     const raw = this.unwrapRaw(value);
     if (raw) return raw;
-    if (operators[(value || '').toLowerCase()] !== true) {
+    const operator = operators[(value || '').toLowerCase()];
+    if (!operator) {
       throw new TypeError(`The operator "${value}" is not permitted`);
     }
-    return value;
+    return operator;
   }
 
   // Specify the direction of the ordering.

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -3363,15 +3363,15 @@ describe("QueryBuilder", function() {
   it('supports capitalized operators', function() {
     testsql(qb().select('*').from('users').where('name', 'LIKE', '%test%'), {
       mysql: {
-        sql: 'select * from `users` where `name` LIKE ?',
+        sql: 'select * from `users` where `name` like ?',
         bindings: ['%test%']
       },
       mssql: {
-        sql: 'select * from [users] where [name] LIKE ?',
+        sql: 'select * from [users] where [name] like ?',
         bindings: ['%test%']
       },
       postgres: {
-        sql: 'select * from "users" where "name" LIKE ?',
+        sql: 'select * from "users" where "name" like ?',
         bindings: ['%test%']
       }
     });
@@ -4174,6 +4174,19 @@ describe("QueryBuilder", function() {
     testquery(qb().select('*').from('users').where('id', '=', 1).whereRaw('?? \\? ?', ['jsonColumn', 'jsonKey?']), {
       mysql: 'select * from `users` where `id` = 1 and `jsonColumn` ? \'jsonKey?\'',
       postgres: 'select * from "users" where "id" = 1 and "jsonColumn" ? \'jsonKey?\''
+    });
+  });
+
+  it("operator transformation", function() {
+    // part of common base code, no need to test on every dialect
+    testsql(qb().select('*').from('users').where('id', '?', 1), {
+      postgres: 'select * from "users" where "id" \\? ?'
+    });
+    testsql(qb().select('*').from('users').where('id', '?|', 1), {
+      postgres: 'select * from "users" where "id" \\?| ?'
+    });
+    testsql(qb().select('*').from('users').where('id', '?&', 1), {
+      postgres: 'select * from "users" where "id" \\?& ?'
     });
   });
 


### PR DESCRIPTION
Actually this is slightly breaking change, since now original format how operator was written is not preserved anymore. for example `iLiKe` transforms to `ilike`.

mainly added support for `.where('col', '?', something)`