### PR TITLE
Fix issue where table can be created with a hyphen

### DIFF
--- a/src/schema/tablebuilder.js
+++ b/src/schema/tablebuilder.js
@@ -206,6 +206,9 @@ TableBuilder.prototype.foreign = function(column, keyName) {
             if (typeof tableName !== 'string') {
               throw new TypeError(`Expected tableName to be a string, got: ${typeof tableName}`);
             }
+            if (tableName.indexOf('-') > -1) {
+              throw new TypeError(`Table names cannot contain hyphens, got: '-'`);
+            }
             foreignData.inTable = tableName;
             return returnObj;
           },


### PR DESCRIPTION
New to the library, I created a table in Postgres with a hyphen, ran into (obvious) issues later on when trying to work with the table. Throwing an error on table creation would help prevent folks from running into the same problem.