### PR TITLE
Allow raw expressions in query builder aggregate methods

### DIFF
--- a/src/dialects/mssql/query/compiler.js
+++ b/src/dialects/mssql/query/compiler.js
@@ -126,6 +126,9 @@ assign(QueryCompiler_MSSQL.prototype, {
         if (stmt.type === 'aggregate') {
           sql.push(this.aggregate(stmt))
         }
+        else if (stmt.type === 'aggregateRaw') {
+          sql.push(this.aggregateRaw(stmt))
+        }
         else if (stmt.value && stmt.value.length > 0) {
           sql.push(this.formatter.columnize(stmt.value))
         }

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -966,7 +966,7 @@ assign(Builder.prototype, {
   _aggregate(method, column, aggregateDistinct) {
     this._statements.push({
       grouping: 'columns',
-      type: 'aggregate',
+      type: column instanceof Raw ? 'aggregateRaw' : 'aggregate',
       method,
       value: column,
       aggregateDistinct: aggregateDistinct || false

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -166,6 +166,9 @@ assign(QueryCompiler.prototype, {
         if (stmt.type === 'aggregate') {
           sql.push(this.aggregate(stmt))
         }
+        else if (stmt.type === 'aggregateRaw') {
+          sql.push(this.aggregateRaw(stmt))
+        }
         else if (stmt.value && stmt.value.length > 0) {
           sql.push(this.formatter.columnize(stmt.value))
         }
@@ -192,6 +195,11 @@ assign(QueryCompiler.prototype, {
       );
     }
     return `${stmt.method}(${distinct + this.formatter.wrap(val)})`;
+  },
+
+  aggregateRaw(stmt) {
+    const distinct = stmt.aggregateDistinct ? 'distinct ' : '';
+    return `${stmt.method}(${distinct + this.formatter.unwrapRaw(stmt.value)})`;
   },
 
   // Compiles all each of the `join` clauses on the query,

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -2405,6 +2405,40 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it("count with raw values", function() {
+    testsql(qb().from('users').count(raw('??', 'name')), {
+      mysql: {
+        sql: 'select count(`name`) from `users`',
+        bindings: []
+      },
+      mssql: {
+        sql: 'select count([name]) from [users]',
+        bindings: []
+      },
+      postgres: {
+        sql: 'select count("name") from "users"',
+        bindings: []
+      }
+    });
+  });
+
+  it("count distinct with raw values", function() {
+    testsql(qb().from('users').countDistinct(raw('??', 'name')), {
+      mysql: {
+        sql: 'select count(distinct `name`) from `users`',
+        bindings: []
+      },
+      mssql: {
+        sql: 'select count(distinct [name]) from [users]',
+        bindings: []
+      },
+      postgres: {
+        sql: 'select count(distinct "name") from "users"',
+        bindings: []
+      }
+    });
+  });
+
   it("max", function() {
     testsql(qb().from('users').max('id'), {
       mysql: {
@@ -2417,6 +2451,23 @@ describe("QueryBuilder", function() {
       },
       postgres: {
         sql: 'select max("id") from "users"',
+        bindings: []
+      }
+    });
+  });
+
+  it("max with raw values", function() {
+    testsql(qb().from('users').max(raw('??', ['name'])), {
+      mysql: {
+        sql: 'select max(`name`) from `users`',
+        bindings: []
+      },
+      mssql: {
+        sql: 'select max([name]) from [users]',
+        bindings: []
+      },
+      postgres: {
+        sql: 'select max("name") from "users"',
         bindings: []
       }
     });
@@ -2439,6 +2490,23 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it("min with raw values", function() {
+    testsql(qb().from('users').min(raw('??', ['name'])), {
+      mysql: {
+        sql: 'select min(`name`) from `users`',
+        bindings: []
+      },
+      mssql: {
+        sql: 'select min([name]) from [users]',
+        bindings: []
+      },
+      postgres: {
+        sql: 'select min("name") from "users"',
+        bindings: []
+      }
+    });
+  });
+
   it("sum", function() {
     testsql(qb().from('users').sum('id'), {
       mysql: {
@@ -2456,6 +2524,23 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it("sum with raw values", function() {
+    testsql(qb().from('users').sum(raw('??', ['name'])), {
+      mysql: {
+        sql: 'select sum(`name`) from `users`',
+        bindings: []
+      },
+      mssql: {
+        sql: 'select sum([name]) from [users]',
+        bindings: []
+      },
+      postgres: {
+        sql: 'select sum("name") from "users"',
+        bindings: []
+      }
+    });
+  });
+
   it("sum distinct", function() {
     testsql(qb().from('users').sumDistinct('id'), {
       mysql: {
@@ -2468,6 +2553,74 @@ describe("QueryBuilder", function() {
       },
       postgres: {
         sql: 'select sum(distinct "id") from "users"',
+        bindings: []
+      }
+    });
+  });
+
+  it("sum distinct with raw values", function() {
+    testsql(qb().from('users').sumDistinct(raw('??', ['name'])), {
+      mysql: {
+        sql: 'select sum(distinct `name`) from `users`',
+        bindings: []
+      },
+      mssql: {
+        sql: 'select sum(distinct [name]) from [users]',
+        bindings: []
+      },
+      postgres: {
+        sql: 'select sum(distinct "name") from "users"',
+        bindings: []
+      }
+    });
+  });
+
+  it("avg", function() {
+    testsql(qb().from('users').avg('id'), {
+      mysql: {
+        sql: 'select avg(`id`) from `users`',
+        bindings: []
+      },
+      mssql: {
+        sql: 'select avg([id]) from [users]',
+        bindings: []
+      },
+      postgres: {
+        sql: 'select avg("id") from "users"',
+        bindings: []
+      }
+    });
+  });
+
+  it("avg with raw values", function() {
+    testsql(qb().from('users').avg(raw('??', ['name'])), {
+      mysql: {
+        sql: 'select avg(`name`) from `users`',
+        bindings: []
+      },
+      mssql: {
+        sql: 'select avg([name]) from [users]',
+        bindings: []
+      },
+      postgres: {
+        sql: 'select avg("name") from "users"',
+        bindings: []
+      }
+    });
+  });
+
+  it("avg distinct with raw values", function() {
+    testsql(qb().from('users').avgDistinct(raw('??', ['name'])), {
+      mysql: {
+        sql: 'select avg(distinct `name`) from `users`',
+        bindings: []
+      },
+      mssql: {
+        sql: 'select avg(distinct [name]) from [users]',
+        bindings: []
+      },
+      postgres: {
+        sql: 'select avg(distinct "name") from "users"',
         bindings: []
       }
     });


### PR DESCRIPTION
The aggregate methods include `count`, `min`, `max`, `sum`, `avg`, `countDistinct`, `sumDistinct`, and `avgDistinct`, all of which can now receive raw expressions, e.g.

```js
knex('users').count(knex.raw("data->'active'"));
```

There seems to be some demand for this  (https://github.com/tgriesser/knex/issues/238, https://github.com/tgriesser/knex/issues/1606, https://github.com/tgriesser/knex/issues/935), and I think it's cleaner than the alternative of

```js
knex('users').select(knex.raw("count(data->'active')"));
```