### PR TITLE
Fix: Escape table name in SQLite columnInfo call

### DIFF
--- a/src/dialects/sqlite3/query/compiler.js
+++ b/src/dialects/sqlite3/query/compiler.js
@@ -102,7 +102,7 @@ assign(QueryCompiler_SQLite3.prototype, {
   columnInfo() {
     const column = this.single.columnInfo
     return {
-      sql: `PRAGMA table_info(${this.single.table})`,
+      sql: `PRAGMA table_info(\`${this.single.table}\`)`,
       output(resp) {
         const maxLengthRegex = /.*\((\d+)\)/
         const out = reduce(resp, function (columns, val) {

--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -166,7 +166,7 @@ module.exports = function(knex) {
             "type": "uuid"
           }
         });
-        tester('sqlite3', 'PRAGMA table_info(datatype_test)', [], {
+        tester('sqlite3', 'PRAGMA table_info(\`datatype_test\`)', [], {
           "enum_value": {
             "defaultValue": null,
             "maxLength": null,
@@ -233,7 +233,7 @@ module.exports = function(knex) {
           "nullable": false,
           "type": "uuid"
         });
-        tester('sqlite3', 'PRAGMA table_info(datatype_test)', [], {
+        tester('sqlite3', 'PRAGMA table_info(\`datatype_test\`)', [], {
           "defaultValue": null,
           "maxLength": "36",
           "nullable": false,
@@ -258,6 +258,32 @@ module.exports = function(knex) {
             "type": "uniqueidentifier"
           });
       });
+    });
+
+    it('#2184 - should properly escape table name for SQLite columnInfo', function() {
+      if (knex.client.dialect !== 'sqlite3') {
+        return;
+      }
+
+      return knex.schema.dropTableIfExists('group')
+        .then(function() {
+          return knex.schema.createTable('group', function(table) {
+            table.integer('foo');
+          });
+        })
+        .then(function() {
+          return knex('group').columnInfo();
+        })
+        .then(function(columnInfo) {
+          expect(columnInfo).to.deep.equal({
+            foo: {
+              type: 'integer',
+              maxLength: null,
+              nullable: true,
+              defaultValue: null,
+            },
+          });
+        });
     });
 
     it('should allow renaming a column', function() {


### PR DESCRIPTION
Fixes #2184. Not escaping the table name could lead to errors with some table names (group, for example)