### PR TITLE
Update v8flags to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "safe-buffer": "^5.0.1",
     "tildify": "~1.0.0",
     "uuid": "^3.0.0",
-    "v8flags": "^2.0.2"
+    "v8flags": "^3.0.0"
   },
   "devDependencies": {
     "JSONStream": "^1.0.3",


### PR DESCRIPTION
The v8flags dependency got updated so that it follows the OS cache location conventions. See [the PR](https://github.com/js-cli/js-v8flags/pull/38) for more information.