### PR TITLE
Guarding commit and rollback in case they get called explicitly

### DIFF
--- a/src/dialects/mssql/transaction.js
+++ b/src/dialects/mssql/transaction.js
@@ -17,6 +17,7 @@ export default class Transaction_MSSQL extends Transaction {
   }
 
   commit(conn, value) {
+    if ( this._completed ) return;
     this._completed = true
     debug('%s: commit', this.txid)
     return conn.tx_.commit()
@@ -28,6 +29,7 @@ export default class Transaction_MSSQL extends Transaction {
   }
 
   rollback(conn, error) {
+    if ( this._completed ) return;
     this._completed = true
     debug('%s: rolling back', this.txid)
     return conn.tx_.rollback()
@@ -41,6 +43,8 @@ export default class Transaction_MSSQL extends Transaction {
   }
 
   rollbackTo(conn, error) {
+    if ( this._completed ) return;
+    this._completed = true
     debug('%s: rolling backTo', this.txid)
     return Promise.resolve()
       .then(() => this.query(conn, `ROLLBACK TRANSACTION ${this.txid}`, 2, error))


### PR DESCRIPTION
For mssql dialects, when you call `trx.commit()` explicitly, an error will be thrown later when it tries to first commit against a null `conn.tx_`, which throws an uncaught exception, which later gets caught somewhere in knex, at which point it tries to do a rollback, which again fails because the transaction is null.

If we just check to see if the transaction is already complete first before trying to commit, we shouldn't get these errors.

tl;dr calling `.commit` explicitly on mssql transactions throws an uncaught exception when knex later tries to autocommit.