### PR TITLE
Fixed passing connection errors directly to the query

### DIFF
--- a/test/tape/index.js
+++ b/test/tape/index.js
@@ -12,6 +12,7 @@ require('./seed')
 require('./migrate')
 require('./pool')
 require('./knex')
+require('./invalid-db-setup')(knexfile)
 
 Object.keys(knexfile).forEach(function(key) {
 
@@ -23,7 +24,7 @@ Object.keys(knexfile).forEach(function(key) {
   // Tear down the knex connection
   tape(knex.client.driverName + ' - transactions: after', function(t) {
     knex.destroy(function() {
-      t.ok(true, 'Knex client destroyed')
+      t.pass('Knex client destroyed')
       t.end()
     })
   })

--- a/test/tape/invalid-db-setup.js
+++ b/test/tape/invalid-db-setup.js
@@ -1,0 +1,94 @@
+const tape = require('tape')
+const _ = require('lodash');
+const makeKnex = require('../../knex')
+const pool = require('generic-pool');
+const Bluebird = require('bluebird');
+
+module.exports = (knexfile) => {
+  Object.keys(knexfile).forEach((key) => {
+    const dialect = knexfile[key].dialect;
+
+    if (dialect !== 'sqlite3') {
+      const knexConf = _.cloneDeep(knexfile[key]);
+      knexConf.connection.database = knexConf.connection.db = 'I-refuse-to-exist';
+      knexConf.acquireConnectionTimeout = 4000;
+      const knex = makeKnex(knexConf);
+
+      tape(dialect + ' - propagate error when DB does not exist', t => {
+        t.plan(1);
+        t.timeoutAfter(1000);
+        knex.select(1)
+          .then(res => {
+            t.fail(`Query should have failed, got: ${JSON.stringify(res)}`);
+          })
+          .catch(Bluebird.TimeoutError, e => {
+            t.fail(`Query should have failed with non timeout error`);
+          })
+          .catch(e => {
+            t.ok(e.message.indexOf('I-refuse-to-exist') > 0, `all good, failed as expected with msg: ${e.message}`);
+          });
+      });
+
+      tape(dialect + ' - propagate error when DB does not exist for stream', t => {
+        t.plan(1);
+        t.timeoutAfter(1000);
+
+        knex.select(1)
+          .stream(stream => {})
+          .then(res => {
+            t.fail(`Stream query should have failed, got: ${JSON.stringify(res)}`);
+          })
+          .catch(Bluebird.TimeoutError, e => {
+            t.fail(`Stream query should have failed with non timeout error`);
+          })
+          .catch(e => {
+            t.ok(e.message.indexOf('I-refuse-to-exist') > 0, `all good, failed as expected with msg: ${e.message}`);
+          });
+      });
+
+      tape.onFinish(() => {
+        knex.destroy();
+      });
+    }
+
+    if (dialect !== 'sqlite3') {
+      const knexConf = _.cloneDeep(knexfile[key]);
+      knexConf.acquireConnectionTimeout = 10;
+      knexConf.pool = { max: 1 };
+      const knex = makeKnex(knexConf);
+
+      tape(dialect + ' - acquireConnectionTimeout works', t => {
+        t.plan(2);
+        t.timeoutAfter(1000);
+
+        let hoggerTrx;
+        knex.transaction(trx => {
+          // just hog the only connection.
+          hoggerTrx = trx;
+        }).then(() => {
+          t.pass('transaction was resolved');
+          t.end();
+        });
+
+        knex.select(1)
+          .then(() => {
+            t.fail('query should have stalled');
+          })
+          .catch(Bluebird.TimeoutError, e => {
+            t.pass('Got acquireTimeout error');
+          })
+          .catch(e => {
+            t.fail(`should have got acquire timeout error, but got ${e.message} instead.`);
+          })
+          .finally(() => {
+            hoggerTrx.commit(); // release stuff
+          });
+      });
+
+      tape.onFinish(() => {
+        knex.destroy();
+      });
+    }
+
+  });
+};

--- a/test/tape/invalid-db-setup.js
+++ b/test/tape/invalid-db-setup.js
@@ -10,7 +10,7 @@ module.exports = (knexfile) => {
   Object.keys(knexfile).forEach((key) => {
     const dialect = knexfile[key].dialect || knexfile[key].client;
 
-    if (dialect !== 'sqlite3') {
+    if (dialect !== 'sqlite3' && dialect !== 'oracledb') {
       const knexConf = _.cloneDeep(knexfile[key]);
       knexConf.connection.database = knexConf.connection.db = 'I-refuse-to-exist';
       knexConf.acquireConnectionTimeout = 4000;

--- a/test/tape/invalid-db-setup.js
+++ b/test/tape/invalid-db-setup.js
@@ -8,7 +8,7 @@ const Bluebird = require('bluebird');
 
 module.exports = (knexfile) => {
   Object.keys(knexfile).forEach((key) => {
-    const dialect = knexfile[key].dialect;
+    const dialect = knexfile[key].dialect || knexfile[key].client;
 
     if (dialect !== 'sqlite3') {
       const knexConf = _.cloneDeep(knexfile[key]);
@@ -19,7 +19,7 @@ module.exports = (knexfile) => {
       tape(dialect + ' - propagate error when DB does not exist', t => {
         t.plan(1);
         t.timeoutAfter(1000);
-        knex.select(1)
+        knex('accounts').select(1)
           .then(res => {
             t.fail(`Query should have failed, got: ${JSON.stringify(res)}`);
           })

--- a/test/tape/invalid-db-setup.js
+++ b/test/tape/invalid-db-setup.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const tape = require('tape')
 const _ = require('lodash');
 const makeKnex = require('../../knex')
@@ -70,7 +72,7 @@ module.exports = (knexfile) => {
           t.end();
         });
 
-        knex.select(1)
+        knex('accounts').select(1)
           .then(() => {
             t.fail('query should have stalled');
           })


### PR DESCRIPTION
Fixes https://github.com/tgriesser/knex/issues/2325

Problem was that pools create callback must never reject or pool tries to get the resource until acquireConnectionTimeout is triggered.

Sadly generic-pool doesn't allow to change that functionality so I had to write small workaround for it.