### PR TITLE
Skip destroyRawConnection when __knex__disposed is set

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -228,7 +228,7 @@ assign(Client.prototype, {
             .catch(err => {
               // Acquire connection must never reject, because generic-pool
               // will retry trying to get connection until acquireConnectionTimeout is
-              // reached. acquireConnectionTimeout should trigger in knex only 
+              // reached. acquireConnectionTimeout should trigger in knex only
               // in that case if aquiring connection waits because pool is full
               // https://github.com/coopernurse/node-pool/pull/184
               // https://github.com/tgriesser/knex/issues/2325
@@ -242,7 +242,10 @@ assign(Client.prototype, {
             });
         },
         destroy: (connection) => {
-          if (connection.genericPoolMissingRetryCountHack) {
+          if (
+            connection.genericPoolMissingRetryCountHack ||
+            connection.__knex__disposed
+          ) {
             return;
           }
           if (poolConfig.beforeDestroy) {


### PR DESCRIPTION
I recently upgraded to knex 14.1 and found that calling client.destroy would sometimes hang. Traced it down to the `end` callback never being called when using the postgres dialect here: https://github.com/tgriesser/knex/blob/master/src/dialects/postgres/index.js#L134. Checking for `__knex__disposed` seemed to resolve the issue - though it's not clear to me if it's correct for all dialects, or even generally correct for postgres.