### PR TITLE
Quick-fix for truncate() on sqlite3 dialect

### DIFF
--- a/src/dialects/sqlite3/query/compiler.js
+++ b/src/dialects/sqlite3/query/compiler.js
@@ -87,12 +87,12 @@ assign(QueryCompiler_SQLite3.prototype, {
 
   // Compile a truncate table statement into SQL.
   truncate() {
-    const table = this.tableName
+    const { table } = this.single
     return {
-      sql: `delete from ${table}`,
+      sql: `delete from ${this.tableName}`,
       output() {
         return this.query({
-          sql: `delete from sqlite_sequence where name = ${table}`
+          sql: `delete from sqlite_sequence where name = '${table}'`
         }).catch(noop)
       }
     }


### PR DESCRIPTION
As discussed in https://github.com/tgriesser/knex/issues/2312#issuecomment-346549966, here the first commit as a  quick fix restoring previous functionality. A full fix for the other observed issues will follow later.
