### PR TITLE
Support for bind_out parameter to return values  of functions oracle dialect

### DIFF
--- a/src/dialects/oracledb/index.js
+++ b/src/dialects/oracledb/index.js
@@ -247,6 +247,11 @@ Client_Oracledb.prototype._query = function(connection, obj) {
       obj.response = response.rows || [];
       obj.rowsAffected = response.rows ? response.rows.rowsAffected : response.rowsAffected;
 
+      if (obj.method === 'raw' && outBinds.length > 0 ) {
+          obj.response = outBinds
+          resolver(obj);
+      }
+      
       if (obj.method === 'update') {
         const modifiedRowsCount = obj.rowsAffected.length || obj.rowsAffected;
         const updatedObjOutBinding = [];


### PR DESCRIPTION
Knex execute with success a oracle query function using knex.raw, but not return the value ":v_gru".
I read the code and it is necessary make a change in dialect oracle to return this value.

```sql
var sql_query = `
BEGIN
        :v_gru := myschema.pkg_gru.func_create_gru(
                :codigo,
                sysdate,
                :tipo_contribuinte,
               :valor,
                SYSDATE +5 ,
                TO_DATE(sysdate, 'dd/mm/rrrr'));
    END;
`
```
```javascript
const knex = require('knex');
const oracle = require('oracledb');

 args.v_gru = {dir: oracle.BIND_OUT, type: oracle.NUMBER}; //or the referent numbers
 var query = knex.raw(sql_query,args);
 return query.then((data, erro) => {
      return new Promise(resolve => {
           return resolve({v_gru: data[0]});
      });
 });
`

