### PR TITLE
Added decimal variable precision / scale support

### DIFF
--- a/src/dialects/oracle/schema/columncompiler.js
+++ b/src/dialects/oracle/schema/columncompiler.js
@@ -46,6 +46,11 @@ assign(ColumnCompiler_Oracle.prototype, {
     return `number(${this._num(precision, 8)}, ${this._num(scale, 2)})`;
   },
 
+  decimal(precision, scale) {
+    if (precision === null) return 'decimal';
+    return `decimal(${this._num(precision, 8)}, ${this._num(scale, 2)})`;
+  },
+
   integer(length) {
     return length ? `number(${this._num(length, 11)})` : 'integer';
   },

--- a/src/dialects/postgres/schema/columncompiler.js
+++ b/src/dialects/postgres/schema/columncompiler.js
@@ -36,7 +36,7 @@ assign(ColumnCompiler_PG.prototype, {
 
   double: 'double precision',
   decimal(precision, scale) {
-    if (!precision) return 'decimal';
+    if (precision === null) return 'decimal';
     return `decimal(${this._num(precision, 8)}, ${this._num(scale, 2)})`;
   },
   floating: 'real',

--- a/src/dialects/postgres/schema/columncompiler.js
+++ b/src/dialects/postgres/schema/columncompiler.js
@@ -35,6 +35,10 @@ assign(ColumnCompiler_PG.prototype, {
   },
 
   double: 'double precision',
+  decimal(precision, scale) {
+    if (!precision) return 'decimal';
+    return `decimal(${this._num(precision, 8)}, ${this._num(scale, 2)})`;
+  },
   floating: 'real',
   increments: 'serial primary key',
   json(jsonb) {
@@ -58,7 +62,7 @@ assign(ColumnCompiler_PG.prototype, {
   // ------
   comment(comment) {
     const columnName = this.args[0] || this.defaults('columnName');
-    
+
     this.pushAdditional(function() {
       this.pushQuery(`comment on column ${this.tableCompiler.tableName()}.` +
         this.formatter.wrap(columnName) + " is " + (comment ? `'${comment}'` : 'NULL'));

--- a/src/schema/columncompiler.js
+++ b/src/schema/columncompiler.js
@@ -29,7 +29,7 @@ ColumnCompiler.prototype._defaultMap = {
   'columnName': function() {
     if (!this.isIncrements) {
       throw new Error(`You did not specify a column name for the ${this.type} column.`);
-    } 
+    }
     return 'id';
   }
 }
@@ -72,7 +72,7 @@ ColumnCompiler.prototype.getColumnType = function() {
 ColumnCompiler.prototype.getModifiers = function() {
   const modifiers = [];
 
-  
+
   for (let i = 0, l = this.modifiers.length; i < l; i++) {
     const modifier = this.modifiers[i];
 
@@ -84,7 +84,7 @@ ColumnCompiler.prototype.getModifiers = function() {
       }
     }
   }
-  
+
   return modifiers.length > 0 ? ` ${modifiers.join(' ')}` : '';
 };
 
@@ -106,6 +106,11 @@ ColumnCompiler.prototype.floating = function(precision, scale) {
   return `float(${this._num(precision, 8)}, ${this._num(scale, 2)})`;
 };
 ColumnCompiler.prototype.decimal = function(precision, scale) {
+  if (precision === null) {
+    throw new Error(
+      'Specifying no precision on decimal columns is not supported for that SQL dialect.'
+    );
+  }
   return `decimal(${this._num(precision, 8)}, ${this._num(scale, 2)})`;
 };
 ColumnCompiler.prototype.binary = 'blob';

--- a/test/unit/schema/mssql.js
+++ b/test/unit/schema/mssql.js
@@ -397,6 +397,14 @@ describe("MSSQL SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] decimal(5, 2)');
   });
 
+  it('test adding decimal, no precision', function() {
+    expect(() => {
+      tableSql = client.schemaBuilder().table('users', function() {
+        this.decimal('foo', null);
+      }).toSQL();
+    }).to.throw('Specifying no precision on decimal columns is not supported');
+  });
+
   it('set comment to undefined', function() {
     expect(function() {
       client.schemaBuilder().table('user', function(t) {

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -422,6 +422,14 @@ describe(dialect + " SchemaBuilder", function() {
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal('alter table `users` add `foo` decimal(5, 2)');
   });
+  
+  it('test adding decimal, no precision', function() {
+    expect(() => {
+      tableSql = client.schemaBuilder().table('users', function() {
+        this.decimal('foo', null);
+      }).toSQL();
+    }).to.throw('Specifying no precision on decimal columns is not supported');
+  });
 
   it('test adding boolean', function() {
     tableSql = client.schemaBuilder().table('users', function() {

--- a/test/unit/schema/oracle.js
+++ b/test/unit/schema/oracle.js
@@ -396,6 +396,14 @@ describe("Oracle SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table "users" add "foo" decimal(5, 2)');
   });
 
+  it("adding decimal, variable precision", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.decimal('foo', null);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" decimal');
+  });
+
   it('test adding boolean', function() {
     tableSql = client.schemaBuilder().table('users', function() {
       this.boolean('foo');

--- a/test/unit/schema/oracledb.js
+++ b/test/unit/schema/oracledb.js
@@ -385,6 +385,14 @@ describe("OracleDb SchemaBuilder", function() {
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal('alter table "users" add "foo" decimal(5, 2)');
   });
+  
+  it("adding decimal, variable precision", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.decimal('foo', null);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "foo" decimal');
+  });
 
   it('test adding boolean', function() {
     tableSql = client.schemaBuilder().table('users', function() {

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -518,7 +518,7 @@ describe("PostgreSQL SchemaBuilder", function() {
 
   it("adding decimal, variable precision", function() {
     tableSql = client.schemaBuilder().table('users', function(table) {
-      table.decimal('foo');
+      table.decimal('foo', null);
     }).toSQL();
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" decimal');

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -516,6 +516,14 @@ describe("PostgreSQL SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" decimal(5, 2)');
   });
 
+  it("adding decimal, variable precision", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.decimal('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" decimal');
+  });
+
   it("adding boolean", function() {
     tableSql = client.schemaBuilder().table('users', function(table) {
       table.boolean('foo').defaultTo(false);

--- a/test/unit/schema/sqlite3.js
+++ b/test/unit/schema/sqlite3.js
@@ -347,6 +347,15 @@ describe("SQLite SchemaBuilder", function() {
     equal(tableSql[0].sql, 'alter table `users` add column `foo` float');
   });
 
+  it('test adding decimal, no precision', function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.decimal('foo', null);
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    equal(tableSql[0].sql, 'alter table `users` add column `foo` float');
+  });
+
   it("adding boolean", function() {
     tableSql = client.schemaBuilder().table('users', function(table) {
       table.boolean('foo');


### PR DESCRIPTION
The `decimal` type in postgres has the functionality, that when there is no precision and scale defined, you can store values of any precision and scale in the column. (`DECIMAL` and `NUMERIC` are identical)

> Specifying:
>
>     NUMERIC
>
> without any precision or scale creates a column in which numeric values of any precision and scale can be stored, up to the implementation limit on precision. A column of this kind will not coerce input values to any particular scale, whereas numeric columns with a declared scale will coerce input values to that scale. (The SQL standard requires a default scale of 0, i.e., coercion to integer precision. We find this a bit useless. If you're concerned about portability, always specify the precision and scale explicitly.)

Right now knex passes the default values of 8 and 2 to the field. This pull request exposes the variable precision / scale functionality for postgres when there is no precision / scale provided for the column. 

Let me know if I need to change anything or if there is a better way to add support for that. 