### PR TITLE
2351 CLI sets exit-code 1 if the command supplied was not parseable

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,9 +13,9 @@ var cliPkg = require('../package');
 
 function exit(text) {
   if (text instanceof Error) {
-    chalk.red(console.error(text.stack));
+    console.error(chalk.red(text.stack));
   } else {
-    chalk.red(console.error(text));
+    console.error(chalk.red(text));
   }
   process.exit(1);
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -186,7 +186,8 @@ function invoke(env) {
   commander.parse(process.argv);
 
   Promise.resolve(pending).then(function() {
-    commander.help();
+    commander.outputHelp();
+    exit('Unknown command-line options, exiting');
   });
 }
 


### PR DESCRIPTION
See issue #2351.

Sorry, I haven't found tests for the `bin/cli.js` file.

[Reference to a stack exchange question, that is somewhat related ☺](https://unix.stackexchange.com/questions/405783/why-does-man-print-gimme-gimme-gimme-at-0030).