### PR TITLE
Incorrectly set UV_THREADPOOL_SIZE

### DIFF
--- a/src/dialects/oracledb/index.js
+++ b/src/dialects/oracledb/index.js
@@ -20,7 +20,7 @@ function Client_Oracledb() {
   // Node.js only have 4 background threads by default, oracledb needs one by connection
   if (this.driver) {
     process.env.UV_THREADPOOL_SIZE = process.env.UV_THREADPOOL_SIZE || 1;
-    process.env.UV_THREADPOOL_SIZE += this.driver.poolMax;
+    process.env.UV_THREADPOOL_SIZE = parseInt(process.env.UV_THREADPOOL_SIZE) + this.driver.poolMax;
   }
 }
 inherits(Client_Oracledb, Client_Oracle);


### PR DESCRIPTION
Incorrectly set UV_THREADPOOL_SIZE when passed from system variables. It's recognized as string (windows).