### PR TITLE
[WIP] Added readonly BigQuery dialect

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "v8flags": "^3.0.0"
   },
   "devDependencies": {
-    "@google-cloud/bigquery": "^0.11.1",
+    "@google-cloud/bigquery": "^0.12.0",
     "JSONStream": "^1.0.3",
     "async": "^0.9.0",
     "babel-cli": "^6.11.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "v8flags": "^3.0.0"
   },
   "devDependencies": {
+    "@google-cloud/bigquery": "^0.11.1",
     "JSONStream": "^1.0.3",
     "async": "^0.9.0",
     "babel-cli": "^6.11.4",
@@ -105,6 +106,7 @@
     "./lib/migrate/index.js": "./lib/util/noop.js",
     "./lib/bin/cli.js": "./lib/util/noop.js",
     "./lib/seed/index.js": "./lib/util/noop.js",
+    "@google-cloud/bigquery": false,
     "mssql": false,
     "mysql": false,
     "mysql2": false,

--- a/src/dialects/bigquery/index.js
+++ b/src/dialects/bigquery/index.js
@@ -6,6 +6,8 @@ import inherits from 'inherits';
 import Client from '../../client';
 import Promise from 'bluebird';
 
+import QueryCompiler from './query/compiler';
+
 import { assign } from 'lodash';
 import { makeEscape } from '../../query/string';
 
@@ -33,6 +35,10 @@ assign(Client_BigQuery.prototype, {
       BigQuery.timestamp
     ];
     return new BigQuery(this.connectionStrings);
+  },
+
+  queryCompiler() {
+    return new QueryCompiler(this, ...arguments)
   },
 
   schemaCompiler() {

--- a/src/dialects/bigquery/index.js
+++ b/src/dialects/bigquery/index.js
@@ -161,7 +161,7 @@ assign(Client_BigQuery.prototype, {
     });
 
     const out = connection.driver
-      .startQuery(query)
+      .createQueryJob(query)
       .then((results) => {
         connection.job = results[0];
         debug(`Job ${ connection.job.id } started`);

--- a/src/dialects/bigquery/index.js
+++ b/src/dialects/bigquery/index.js
@@ -1,0 +1,216 @@
+
+// BigQuery Client
+// -------
+import inherits from 'inherits';
+
+import Client from '../../client';
+import Promise from 'bluebird';
+
+import { assign } from 'lodash';
+import { makeEscape } from '../../query/string';
+
+const debug = require('debug')('knex:bigquery');
+
+function Client_BigQuery(config) {
+  Client.call(this, config);
+
+  this.useBigQueryTypes = config.useBigQueryTypes || false;
+}
+inherits(Client_BigQuery, Client);
+
+assign(Client_BigQuery.prototype, {
+
+  dialect: 'bigquery',
+
+  driverName: '@google-cloud/bigquery',
+
+  _driver() {
+    const BigQuery = require('@google-cloud/bigquery');
+    this.bigQueryTypes = [
+      BigQuery.date,
+      BigQuery.datetime,
+      BigQuery.time,
+      BigQuery.timestamp
+    ];
+    return new BigQuery(this.connectionStrings);
+  },
+
+  schemaCompiler() {
+    throw new Error("schema management not supported by BigQuery");
+  },
+
+  transaction() {
+    throw new Error("transaction not supported by BigQuery");
+  },
+
+  _escapeBinding: makeEscape(),
+
+  wrapIdentifierImpl(value) {
+    return (value !== '*' ? `\`${value.replace(/`/g, '\\`')}\`` : '*');
+  },
+
+  // wrap the driver with a connection to keep track of the currently running job on the connection
+  acquireRawConnection() {
+    return Promise.resolve({
+      driver: this.driver,
+      job: null
+    });
+  },
+
+  // destroy by cancelling running job, if exists
+  destroyRawConnection(connection) {
+    if (connection.job != null) {
+      return this.cancelQuery(connection);
+    } else {
+      return Promise.resolve();
+    }
+  },
+
+  // connection should always be valid
+  validateConnection(connection) {
+    return Promise.resolve(true);
+  },
+
+  // execute the query with pagination
+  _stream(connection, obj, stream, options) {
+    const initPageQuery = assign({
+      maxResults: 10000
+    }, options, {
+      autoPaginate: true
+    });
+
+    const query = assign({
+      query: obj.sql,
+      params: obj.bindings
+    }, obj.options);
+
+    return new Promise((resolver, rejecter) => {
+      stream.on('error', (err) => {
+        this.cancelQuery(connection);
+        rejecter(err);
+      });
+      stream.on('end', (results) => {
+        connection.job = null;
+        resolver(results);
+      });
+
+      const streamPages = (job, pageQuery) => {
+        return job.getQueryResults(pageQuery).then((results) => {
+          const rows = results[0],
+            nextQuery = results[1];
+
+          this.processResponse({
+            response: rows
+          }).forEach((row) => {
+            stream.write(row);
+          });
+
+          if (nextQuery != null) {
+            return streamPages(job, nextQuery);
+          } else {
+            return;
+          }
+        });
+      };
+
+      this._executeQuery(connection, query).then((job) => {
+        return streamPages(job, initPageQuery);
+      }).catch((err) => {
+        stream.emit('error', err);
+      }).then(() => {
+        stream.end();
+      });
+    });
+  },
+
+  // execute the query with no pagination
+  _query(connection, obj) {
+    if (!obj || typeof obj === 'string') {
+      obj = { sql: obj };
+    }
+
+    const query = assign({
+      query: obj.sql,
+      params: obj.bindings
+    }, obj.options);
+
+    return this._executeQuery(connection, query).then((job) => {
+      return job.getQueryResults({
+        autoPaginate: false
+      });
+    }).then((results) => {
+      connection.job = null;
+      obj.response = results[0];
+      return obj;
+    }, (err) => {
+      this.cancelQuery(connection);
+      throw err;
+    });
+  },
+
+  // execute a query and return the job if successful
+  _executeQuery(connection, query) {
+    query = assign(query, {
+      useLegacySql: false
+    });
+
+    const out = connection.driver
+      .startQuery(query)
+      .then((results) => {
+        connection.job = results[0];
+        debug(`Job ${ connection.job.id } started`);
+        return connection.job.promise();
+      })
+      .then(() => {
+        return connection.job.getMetadata();
+      })
+      .then((metadata) => {
+        const errors = metadata[0].status.errors;
+        if (errors != null && errors.length > 0) {
+          debug(`Job ${ connection.job.id } failed with errors`);
+          const error = new Error("Error executing query in BigQuery");
+          error.bigQueryErrors = errors;
+          throw error;
+        }
+
+        debug(`Job ${ connection.job.id } completed`);
+        return connection.job;
+      });
+
+    return Promise.resolve(out);
+  },
+
+  processResponse(obj, runner) {
+    const rows = obj.response;
+    if (!this.useBigQueryTypes) {
+      rows.forEach((row) => {
+        Object.keys(row).forEach((key) => {
+          const value = row[key];
+          if (value != null && this.bigQueryTypes.includes(value.constructor)) {
+            row[key] = value.value;
+          }
+        });
+      });
+    }
+    if (obj.output) {
+      return obj.output.call(runner, rows);
+    }
+    return rows;
+  },
+
+  canCancelQuery: true,
+
+  // cancel running job, if exists
+  cancelQuery(connectionToKill) {
+    if (connectionToKill.job == null) {
+      return Promise.resolve();
+    }
+
+    const out = connectionToKill.job.cancel();
+    connectionToKill.job = null;
+    return Promise.resolve(out);
+  }
+
+});
+
+export default Client_BigQuery;

--- a/src/dialects/bigquery/query/compiler.js
+++ b/src/dialects/bigquery/query/compiler.js
@@ -1,0 +1,36 @@
+
+// BigQuery Query Compiler
+// ------
+import inherits from 'inherits';
+import QueryCompiler from '../../../query/compiler';
+
+import { assign } from 'lodash'
+
+function QueryCompiler_BigQuery(client, builder) {
+  QueryCompiler.call(this, client, builder)
+}
+inherits(QueryCompiler_BigQuery, QueryCompiler)
+
+assign(QueryCompiler_BigQuery.prototype, {
+
+  insert() {
+    throw new Error("insert not supported by BigQuery");
+  },
+
+  update() {
+    throw new Error("update not supported by BigQuery");
+  },
+
+  del() {
+    throw new Error("del not supported by BigQuery");
+  },
+
+  columnInfo() {
+    throw new Error("columnInfo not supported by BigQuery");
+  }
+
+})
+
+// Set the QueryBuilder & QueryCompiler on the client object,
+// in case anyone wants to modify things to suit their own purposes.
+export default QueryCompiler_BigQuery;


### PR DESCRIPTION
Hi, I've added a dialect to send queries to BigQuery using `@google-cloud/bigquery`.

There are a few things I wanted to ask before continuing further with this feature:
- Since my only use case is to use knex as a query builder and executor for SELECT queries, I've really only implemented a way to execute the SELECT queries. From what I understand, the "data manipulation language" for BigQuery isn't really recommended and the schema management/migration isn't SQL but REST API calls. Is this okay?
- There is a way to get `columnInfo` from the BigQuery client but not via some SQL expressions. Are there any recommendations for how to implement this or is this even necessary given the read-only use case?
- From my understanding, the BigQuery library is just a wrapper on top of their REST endpoints. Because of this, reusing a connection from the pool is not really necessary. Is there any way I can simplify the "fake connection" object that I'm doing?
- Are there any tests I should be writing? The SELECT queries are pretty much the same as MySQL. The integration tests would require some private key to BigQuery to execute. I have manually tested it to ensure the query and stream functions work.

Thanks!