### PR TITLE
Fixed a bug when using .returning (OUTPUT) in an update query with joins in MSSQL

### DIFF
--- a/src/dialects/mssql/query/compiler.js
+++ b/src/dialects/mssql/query/compiler.js
@@ -87,8 +87,8 @@ assign(QueryCompiler_MSSQL.prototype, {
     return {
       sql: this.with() + `update ${top ? top + ' ' : ''}${this.tableName}` +
         ' set ' + updates.join(', ') +
+        (returning ? ` ${this._returning('update', returning)}` : '') +		
         (join ? ` from ${this.tableName} ${join}` : '') +
-        (returning ? ` ${this._returning('update', returning)}` : '') +
         (where ? ` ${where}` : '') +
         (order ? ` ${order}` : '') +
         (!returning ? this._returning('rowcount', '@@rowcount') : ''),


### PR DESCRIPTION
When using OUTPUT with updates and a join in MSSQL the OUTPUT needs to come before
the joins.

https://stackoverflow.com/questions/4170389/inner-join-within-update-output-in-one-t-sql-query