### PR TITLE
Use wrapIdentifier in columnInfo. fixes #2402

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -171,10 +171,14 @@ assign(Client.prototype, {
   },
 
   wrapIdentifier(value) {
+    return this.customWrapIdentifier(value, this.wrapIdentifierImpl);
+  },
+
+  customWrapIdentifier(value, origImpl) {
     if (this.config.wrapIdentifier) {
-      return this.config.wrapIdentifier(value, this.wrapIdentifierImpl);
+      return this.config.wrapIdentifier(value, origImpl);
     }
-    return this.wrapIdentifierImpl(value);
+    return origImpl(value);
   },
 
   wrapIdentifierImpl(value) {

--- a/src/dialects/mssql/query/compiler.js
+++ b/src/dialects/mssql/query/compiler.js
@@ -4,7 +4,7 @@
 import inherits from 'inherits';
 import QueryCompiler from '../../../query/compiler';
 
-import { assign, isEmpty, compact } from 'lodash'
+import { assign, isEmpty, compact, identity } from 'lodash'
 
 function QueryCompiler_MSSQL(client, builder) {
   QueryCompiler.call(this, client, builder)
@@ -175,12 +175,23 @@ assign(QueryCompiler_MSSQL.prototype, {
   // Compiles a `columnInfo` query.
   columnInfo() {
     const column = this.single.columnInfo;
-    let sql =`select * from information_schema.columns where table_name = ? and table_catalog = ?`;
-    const bindings = [this.single.table, this.client.database()];
+    let schema = this.single.schema;
 
-    if (this.single.schema) {
+    // The user may have specified a custom wrapIdentifier function in the config. We
+    // need to run the identifiers through that function, but not format them as
+    // identifiers otherwise.
+    const table = this.client.customWrapIdentifier(this.single.table, identity);
+
+    if (schema) {
+      schema = this.client.customWrapIdentifier(schema, identity);
+    }
+
+    let sql =`select * from information_schema.columns where table_name = ? and table_catalog = ?`;
+    const bindings = [table, this.client.database()];
+
+    if (schema) {
       sql += ' and table_schema = ?';
-      bindings.push(this.single.schema);
+      bindings.push(schema);
     } else {
       sql += ` and table_schema = 'dbo'`;
     }

--- a/src/dialects/mysql/query/compiler.js
+++ b/src/dialects/mysql/query/compiler.js
@@ -4,7 +4,7 @@
 import inherits from 'inherits';
 import QueryCompiler from '../../../query/compiler';
 
-import { assign } from 'lodash'
+import { assign, identity } from 'lodash'
 
 function QueryCompiler_MySQL(client, builder) {
   QueryCompiler.call(this, client, builder)
@@ -41,9 +41,15 @@ assign(QueryCompiler_MySQL.prototype, {
   // Compiles a `columnInfo` query.
   columnInfo() {
     const column = this.single.columnInfo;
+
+    // The user may have specified a custom wrapIdentifier function in the config. We
+    // need to run the identifiers through that function, but not format them as
+    // identifiers otherwise.
+    const table = this.client.customWrapIdentifier(this.single.table, identity);
+
     return {
       sql: 'select * from information_schema.columns where table_name = ? and table_schema = ?',
-      bindings: [this.single.table, this.client.database()],
+      bindings: [table, this.client.database()],
       output(resp) {
         const out = resp.reduce(function(columns, val) {
           columns[val.COLUMN_NAME] = {

--- a/src/dialects/oracle/query/compiler.js
+++ b/src/dialects/oracle/query/compiler.js
@@ -2,7 +2,7 @@
 
 // Oracle Query Builder & Compiler
 // ------
-import { assign, isPlainObject, isEmpty, isString, map, reduce, compact } from 'lodash'
+import { assign, isPlainObject, isEmpty, isString, map, reduce, compact, identity } from 'lodash'
 import inherits from 'inherits';
 import QueryCompiler from '../../../query/compiler';
 import * as helpers from '../../../helpers';
@@ -146,11 +146,17 @@ assign(QueryCompiler_Oracle.prototype, {
   // Compiles a `columnInfo` query.
   columnInfo() {
     const column = this.single.columnInfo;
+
+    // The user may have specified a custom wrapIdentifier function in the config. We
+    // need to run the identifiers through that function, but not format them as
+    // identifiers otherwise.
+    const table = this.client.customWrapIdentifier(this.single.table, identity);
+
     // Node oracle drivers doesn't support LONG type (which is data_default type)
     const sql = `select * from xmltable( '/ROWSET/ROW'
       passing dbms_xmlgen.getXMLType('
       select char_col_decl_length, column_name, data_type, data_default, nullable
-      from user_tab_columns where table_name = ''${this.single.table}'' ')
+      from user_tab_columns where table_name = ''${table}'' ')
       columns
       CHAR_COL_DECL_LENGTH number, COLUMN_NAME varchar2(200), DATA_TYPE varchar2(106),
       DATA_DEFAULT clob, NULLABLE varchar2(1))`;

--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -94,9 +94,16 @@ assign(Client_PG.prototype, {
 
   wrapIdentifierImpl(value) {
     if (value === '*') return value;
-    const matched = value.match(/(.*?)(\[[0-9]\])/);
-    if (matched) return this.wrapIdentifierImpl(matched[1]) + matched[2];
-    return `"${value.replace(/"/g, '""')}"`;
+
+    let arrayAccessor = '';
+    const arrayAccessorMatch = value.match(/(.*?)(\[[0-9]+\])/);
+
+    if (arrayAccessorMatch) {
+      value = arrayAccessorMatch[1];
+      arrayAccessor = arrayAccessorMatch[2];
+    }
+
+    return `"${value.replace(/"/g, '""')}"${arrayAccessor}`;
   },
 
   // Get a raw connection, called by the `pool` whenever a new

--- a/src/dialects/postgres/query/compiler.js
+++ b/src/dialects/postgres/query/compiler.js
@@ -5,7 +5,7 @@ import inherits from 'inherits';
 
 import QueryCompiler from '../../../query/compiler';
 
-import { assign, reduce } from 'lodash'
+import { assign, reduce, identity } from 'lodash'
 
 function QueryCompiler_PG(client, builder) {
   QueryCompiler.call(this, client, builder);
@@ -74,13 +74,23 @@ assign(QueryCompiler_PG.prototype, {
   // Compiles a columnInfo query
   columnInfo() {
     const column = this.single.columnInfo;
+    let schema = this.single.schema;
+
+    // The user may have specified a custom wrapIdentifier function in the config. We
+    // need to run the identifiers through that function, but not format them as
+    // identifiers otherwise.
+    const table = this.client.customWrapIdentifier(this.single.table, identity);
+
+    if (schema) {
+      schema = this.client.customWrapIdentifier(schema, identity);
+    }
 
     let sql = 'select * from information_schema.columns where table_name = ? and table_catalog = ?';
-    const bindings = [this.single.table, this.client.database()];
+    const bindings = [table, this.client.database()];
 
-    if (this.single.schema) {
+    if (schema) {
       sql += ' and table_schema = ?';
-      bindings.push(this.single.schema);
+      bindings.push(schema);
     } else {
       sql += ' and table_schema = current_schema';
     }

--- a/src/dialects/sqlite3/query/compiler.js
+++ b/src/dialects/sqlite3/query/compiler.js
@@ -3,7 +3,7 @@
 
 import inherits from 'inherits';
 import QueryCompiler from '../../../query/compiler';
-import { assign, each, isEmpty, isString, noop, reduce } from 'lodash'
+import { assign, each, isEmpty, isString, noop, reduce, identity } from 'lodash'
 
 function QueryCompiler_SQLite3(client, builder) {
   QueryCompiler.call(this, client, builder)
@@ -100,9 +100,15 @@ assign(QueryCompiler_SQLite3.prototype, {
 
   // Compiles a `columnInfo` query
   columnInfo() {
-    const column = this.single.columnInfo
+    const column = this.single.columnInfo;
+
+    // The user may have specified a custom wrapIdentifier function in the config. We
+    // need to run the identifiers through that function, but not format them as
+    // identifiers otherwise.
+    const table = this.client.customWrapIdentifier(this.single.table, identity);
+
     return {
-      sql: `PRAGMA table_info(\`${this.single.table}\`)`,
+      sql: `PRAGMA table_info(\`${table}\`)`,
       output(resp) {
         const maxLengthRegex = /.*\((\d+)\)/
         const out = reduce(resp, function (columns, val) {


### PR DESCRIPTION
Hi,

currently `columnInfo` doesn't respect the `wrapIdentifier` function if one is provided in the configuration. This PR fixes that.

fixes #2402 