### PR TITLE
fixed issue when adding "real" column type to table

### DIFF
--- a/src/schema/columncompiler.js
+++ b/src/schema/columncompiler.js
@@ -102,6 +102,7 @@ ColumnCompiler.prototype.varchar = function(length) {
 };
 ColumnCompiler.prototype.text = 'text';
 ColumnCompiler.prototype.tinyint = 'tinyint';
+ColumnCompiler.prototype.real = 'real';
 ColumnCompiler.prototype.floating = function(precision, scale) {
   return `float(${this._num(precision, 8)}, ${this._num(scale, 2)})`;
 };

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -492,6 +492,14 @@ describe("PostgreSQL SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" smallint');
   });
 
+  it("adding real", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.real('foo');
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" real');
+  });
+
   it("adding float", function() {
     tableSql = client.schemaBuilder().table('users', function(table) {
       table.float('foo', 5, 2);


### PR DESCRIPTION
Before this fix, when I would use the function `table.real(columnName)` node would throw the error `Unhandled rejection error: type "undefined" does not exist` I realized that the `ColumnCompiler` was missing the `real` prototype. After adding it, it worked fine. Test is included. I verified the test failed before my change and passed after my change.