### PR TITLE
Allow calling lock procedures (such as forUpdate) outside of transact…

### DIFF
--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -425,11 +425,7 @@ assign(QueryCompiler.prototype, {
   // Compiles the "locks".
   lock() {
     if (this.single.lock) {
-      if (!this.client.transacting) {
-        helpers.warn('You are attempting to perform a "lock" command outside of a transaction.')
-      } else {
-        return this[this.single.lock]()
-      }
+      return this[this.single.lock]()
     }
   },
 

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -3988,22 +3988,18 @@ describe("QueryBuilder", function() {
   //   });
   // });
 
-  it("should warn when trying to use forUpdate outside of a transaction", function() {
+  it("should allow lock (such as forUpdate) outside of a transaction", function() {
     testsql(qb().select('*').from('foo').where('bar', '=', 'baz').forUpdate(), {
       mysql: {
-        sql: 'select * from `foo` where `bar` = ?',
+        sql: 'select * from `foo` where `bar` = ? for update',
         bindings: ['baz']
       },
       mssql: {
-        sql: 'select * from [foo] where [bar] = ?',
+        sql: 'select * from [foo] with (READCOMMITTEDLOCK) where [bar] = ?',
         bindings: ['baz']
       },
       postgres: {
-        sql: 'select * from "foo" where "bar" = ?',
-        bindings: ['baz']
-      },
-      redshift: {
-        sql: 'select * from "foo" where "bar" = ?',
+        sql: 'select * from "foo" where "bar" = ? for update',
         bindings: ['baz']
       },
     });


### PR DESCRIPTION
…ion. Fixes #2403.

This is primarly intended for when using knex to only generate sql strings.

Arguable whether or not to keep the warning message. I opted to delete it because I feel its enough that the database itself throws an error about this.