### PR TITLE
Added editorconfig generated out of eslint config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.js]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+insert_final_newline = false
+max_line_length = 100


### PR DESCRIPTION
I wish to add [editorconfig](http://editorconfig.org/) to the project which should help in mitigating some of the issues in many PRs where primarly the correct indentation has not been used (myself included).

This config is generated out of our eslint config using [eslint-to-editorconfig](https://www.npmjs.com/package/eslint-to-editorconfig)

Instead of arguing for using tabs I figured this is the way to go.. 😄 