### PR TITLE
Changed rm to rimraf in 'npm run dev'

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "debug_test": "node-debug _mocha -t 0 test/index.js",
     "babel": "rimraf ./lib && babel src --out-dir lib --copy-files",
     "coveralls": "cat ./test/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
-    "dev": "rm -rf ./lib && babel -w src --out-dir lib --copy-files",
+    "dev": "rimraf ./lib && babel -w src --out-dir lib --copy-files",
     "lint": "eslint src/**",
     "plaintest": "mocha --check-leaks -b -R spec test/index.js && npm run tape",
     "prepublish": "npm run babel",


### PR DESCRIPTION
This is primarly for environments where `rm` is not available, such as Windows without Git Bash.

`rimraf` is already a devDependecy so there is no extra cost in that department.