### PR TITLE
Changed babel preset and use latest node as target when running dev

### DIFF
--- a/.babelconfig.js
+++ b/.babelconfig.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var isDev = process.env.npm_lifecycle_event === 'dev';
+var presets = [
+  ["env", Object.assign({"loose": true}, isDev ? {"targets": {"node": "current"}} : {})]
+];
+
+module.exports = {
+  "presets": presets,
+  "plugins": [
+    "lodash",
+    "transform-runtime",
+    "add-module-exports"
+  ]
+};

--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,3 @@
 {
-  "presets": [ 
-    ["es2015", { "loose": true }] 
-  ],
-  "plugins": [
-    "lodash",
-    "transform-runtime",
-    "add-module-exports"
-  ]
+  "presets": ["./.babelconfig.js"]
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-lodash": "3.3.2",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "chai": "^4.1.2",
     "coveralls": "~3.0.0",
     "eslint": "4.16.0",


### PR DESCRIPTION
>🙌 Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!

Replaced `babel-preset-es2015` with `babel-preset-env` (https://babeljs.io/env/)

I also changed so that running `npm run dev` targets latest node so that debugging code in `lib` during development is easier as not everything gets transpiled, such as classes etc.