### PR TITLE
fix for #2500

### DIFF
--- a/src/interface.js
+++ b/src/interface.js
@@ -14,7 +14,19 @@ export default function(Target) {
 
   // Create a new instance of the `Runner`, passing in the current object.
   Target.prototype.then = function(/* onFulfilled, onRejected */) {
-    const result = this.client.runner(this).run()
+    let result = this.client.runner(this).run()
+
+    if (this.client.config.asyncStackTraces) {
+      result = result.catch((err) => {
+        err.originalStack = err.stack
+        const firstLine = err.stack.split('\n')[0]
+        this._asyncStack.unshift(firstLine)
+        // put the fake more helpful "async" stack on the thrown error
+        err.stack = this._asyncStack.join('\n')
+        throw err
+      })
+    }
+
     return result.then.apply(result, arguments);
   };
 

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -12,6 +12,7 @@ import {
   assign, clone, each, isBoolean, isEmpty, isFunction, isNumber, isObject,
   isString, isUndefined, tail, toArray, reject, includes
 } from 'lodash';
+import saveAsyncStack from '../util/save-async-stack';
 
 // Typically called from `knex.builder`,
 // start a new query building chain.
@@ -21,8 +22,10 @@ function Builder(client) {
   this._single = {};
   this._statements = [];
   this._method = 'select'
-  this._debug = client.config && client.config.debug;
-
+  if (client.config) {
+    saveAsyncStack(this, 5)
+    this._debug = client.config.debug;
+  }
   // Internal flags used in the builder.
   this._joinFlag = 'inner';
   this._boolFlag = 'and';

--- a/src/raw.js
+++ b/src/raw.js
@@ -8,7 +8,7 @@ import debug from 'debug'
 
 import { assign, reduce, isPlainObject, isObject, isUndefined, isNumber } from 'lodash'
 import Formatter from './formatter'
-
+import saveAsyncStack from './util/save-async-stack';
 import uuid from 'uuid';
 
 const debugBindings = debug('knex:bindings')
@@ -28,7 +28,10 @@ function Raw(client = fakeClient) {
   // Todo: Deprecate
   this._wrappedBefore = undefined
   this._wrappedAfter = undefined
-  this._debug = client && client.config && client.config.debug
+  if (client && client.config) {
+    this._debug = client.config.debug
+    saveAsyncStack(this, 4)
+  }
 }
 inherits(Raw, EventEmitter)
 

--- a/src/schema/builder.js
+++ b/src/schema/builder.js
@@ -3,6 +3,7 @@ import inherits from 'inherits';
 import { EventEmitter } from 'events';
 import { each, toArray } from 'lodash'
 import { addQueryContext, warn } from '../helpers';
+import saveAsyncStack from '../util/save-async-stack';
 
 // Constructor for the builder instance, typically called from
 // `knex.builder`, accepting the current `knex` instance,
@@ -11,7 +12,12 @@ import { addQueryContext, warn } from '../helpers';
 function SchemaBuilder(client) {
   this.client = client
   this._sequence = []
-  this._debug = client.config && client.config.debug
+
+  if (client.config) {
+    this._debug = client.config.debug
+    saveAsyncStack(this, 4)
+  }
+
 }
 inherits(SchemaBuilder, EventEmitter)
 

--- a/src/util/save-async-stack.js
+++ b/src/util/save-async-stack.js
@@ -1,0 +1,9 @@
+export default function saveAsyncStack (instance, lines){
+  if (instance.client.config.asyncStackTraces) {
+    // a hack to get a callstack into the client code despite this
+    // node.js bug https://github.com/nodejs/node/issues/11865
+    const stackByLines = new Error().stack.split('\n')
+    stackByLines.splice(0, lines)
+    instance._asyncStack = stackByLines
+  }
+}

--- a/test/unit/interface.js
+++ b/test/unit/interface.js
@@ -1,0 +1,41 @@
+'use strict';
+/*global expect, describe, it*/
+var _interface = require("../../lib/interface");
+var chai = require("chai");
+
+describe('interface', function () {
+  it('catch and rethrow with an async stack trace', function (done) {
+    var error = new Error('Some SQL error')
+    function SomeClass() {
+      this.client = {
+        config: {
+          asyncStackTraces: true
+        },
+        runner: function (){
+          return {
+            run: function () {
+              return {
+                catch: function (rethrow) {
+                  rethrow.call(fakeInstance, error) // by calling here we're simulating that the promise was rejected
+                  chai.expect(error.stack).to.equal('Error: Some SQL error\nline1\nline2\nline3')
+                  done()
+                },
+                then: function () {}
+              }
+            }
+          }
+        }
+      }
+    }
+
+    _interface(SomeClass)
+    var fakeInstance = new SomeClass()
+    fakeInstance._asyncStack = [
+      'line1',
+      'line2',
+      'line3'
+    ]
+    fakeInstance.then()
+  })
+
+})

--- a/test/unit/util/save-async-stack.js
+++ b/test/unit/util/save-async-stack.js
@@ -1,0 +1,27 @@
+'use strict';
+/*global expect, describe, it*/
+var saveAsyncStack = require("../../../lib/util/save-async-stack");
+var chai = require("chai");
+
+describe('saveAsyncStack', function () {
+  it('should store an error stack on passed object', function () {
+    var fakeInstance = {
+      client: {
+        config: {
+          asyncStackTraces: true
+      }
+    }}
+    saveAsyncStack(fakeInstance, 1)
+
+    chai.expect(fakeInstance._asyncStack[0]).to.match(/at saveAsyncStack /)
+  })
+
+  it('should not store an error stack when config is disabled', function () {
+    var fakeInstance = {
+      client: {
+        config: {}
+    }}
+    saveAsyncStack(fakeInstance, 1)
+    chai.expect(fakeInstance._asyncStack).to.be.undefined
+  })
+})


### PR DESCRIPTION
slightly nasty way of getting better error stacks when using async/await.
Toggles on by setting a new config parameter called: `asyncStackTraces` to true