### PR TITLE
Added error if chaining update/insert/etc with first()

### DIFF
--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -10,7 +10,7 @@ import * as helpers from '../helpers';
 import JoinClause from './joinclause';
 import {
   assign, clone, each, isBoolean, isEmpty, isFunction, isNumber, isObject,
-  isString, isUndefined, tail, toArray, reject
+  isString, isUndefined, tail, toArray, reject, includes
 } from 'lodash';
 
 // Typically called from `knex.builder`,
@@ -766,6 +766,12 @@ assign(Builder.prototype, {
   // Sets the values for a `select` query, informing that only the first
   // row should be returned (limit 1).
   first() {
+    const {_method} = this;
+
+    if(!includes(['pluck', 'first', 'select'], _method)) {
+      throw new Error(`Cannot chain .first() on "${_method}" query!`);
+    }
+
     const args = new Array(arguments.length);
     for (let i = 0; i < args.length; i++) {
       args[i] = arguments[i];

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -5418,4 +5418,34 @@ describe("QueryBuilder", function() {
       expect(error.message).to.equal('Empty .update() call detected! Update data does not contain any values to update. This will result in a faulty query.');
     }
   });
+
+  it('Throws error if .first() is called on update', function() {
+    try {
+      qb().table('sometable').update({column: 'value'}).first().toSQL();
+
+      throw new Error('Should not reach this point');
+    } catch(error) {
+      expect(error.message).to.equal('Cannot chain .first() on "update" query!');
+    }
+  });
+
+  it('Throws error if .first() is called on insert', function() {
+    try {
+      qb().table('sometable').insert({column: 'value'}).first().toSQL();
+
+      throw new Error('Should not reach this point');
+    } catch(error) {
+      expect(error.message).to.equal('Cannot chain .first() on "insert" query!');
+    }
+  });
+
+  it('Throws error if .first() is called on delete', function() {
+    try {
+      qb().table('sometable').del().first().toSQL();
+
+      throw new Error('Should not reach this point');
+    } catch(error) {
+      expect(error.message).to.equal('Cannot chain .first() on "del" query!');
+    }
+  });
 });


### PR DESCRIPTION
Fixes #2061

This throws error in for example

```javascript
knex(table)
.update({column: value})
.first();
```

But does not throw for
```javascript
knex(table)
.first()
.update({column: value});
```

Since the latter correctly generates an update query.