### PR TITLE
Fixes onIn with empty values array

### DIFF
--- a/src/query/joinclause.js
+++ b/src/query/joinclause.js
@@ -95,7 +95,7 @@ assign(JoinClause.prototype, {
   },
 
   onIn(column, values) {
-    if (Array.isArray(values) && values.length === 0) return this.where(this._not());
+    if (Array.isArray(values) && values.length === 0) return this.on(1, '=', 0);
     this.clauses.push({
       type: 'onIn',
       column,

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -2614,6 +2614,29 @@ describe("QueryBuilder", function() {
     });
   });
 
+  it("complex join with empty in", function() {
+    testsql(qb().select('*').from('users').join('contacts', function(qb) {
+      qb.on('users.id', '=', 'contacts.id').onIn('users.name', []);
+    }), {
+      mysql: {
+        sql: 'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and 1 = 0',
+        bindings: []
+      },
+      mssql: {
+        sql: 'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and 1 = 0',
+        bindings: []
+      },
+      postgres: {
+        sql: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and 1 = 0',
+        bindings: []
+      },
+      redshift: {
+        sql: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and 1 = 0',
+        bindings: []
+      },
+    });
+  });
+
   it("joins with raw", function() {
     testsql(qb().select('*').from('users').join('contacts', 'users.id', raw(1)).leftJoin('photos', 'photos.title', '=', raw('?', ['My Photo'])), {
       mysql: {


### PR DESCRIPTION
Currently the `.onIn()` will try to call a non-existent `.where()` function, if you pass it an empty values array. This PR changes that to be a `1 = 0` clause instead.