### PR TITLE
Simple squelch for warning messages

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -43,9 +43,14 @@ export function deprecate(method, alternate) {
   warn(`${method} is deprecated, please use ${alternate}`);
 }
 
+const priorMessage = "";
+
   // Used to warn about incorrect use, without error'ing
 export function warn(msg) {
-  console.log(chalk.yellow(`Knex:warning - ${msg}`))
+  if (priorMessage !== msg) {
+    console.log(chalk.yellow(`Knex:warning - ${msg}`));
+    priorMessage = msg;
+  }
 }
 
 export function exit(msg) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -43,7 +43,7 @@ export function deprecate(method, alternate) {
   warn(`${method} is deprecated, please use ${alternate}`);
 }
 
-const priorMessage = "";
+let priorMessage = "";
 
   // Used to warn about incorrect use, without error'ing
 export function warn(msg) {


### PR DESCRIPTION
https://github.com/tgriesser/knex/pull/2471 caused logfiles to fill up with 

```
Knex:warning - .returning() is not supported by sqlite3 and will not have any effect.
```

when using Objection (which, afaict, is using knex correctly). This PR is a simple squelch to the `warn` function to omit repeated messages. 

The correct solution for this issue, of course, is to make Objection and Knex play nicely together, but I'd like to prevent my servers from dying first.