### PR TITLE
 Create timestamp columns with millisecond precision on MySQL 5.6 and newer

### DIFF
--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -73,11 +73,11 @@ assign(ColumnCompiler_MySQL.prototype, {
   },
 
   datetime() {
-    return supportsPreciseTimestamps(this.client) ? 'datetime(3)' : 'datetime'
+    return supportsPreciseTimestamps(this.client) ? 'datetime(6)' : 'datetime'
   },
 
   timestamp() {
-    return supportsPreciseTimestamps(this.client) ? 'timestamp(3)' : 'timestamp'
+    return supportsPreciseTimestamps(this.client) ? 'timestamp(6)' : 'timestamp'
   },
 
   bit(length) {

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -9,9 +9,10 @@ import { assign } from 'lodash'
 
 function supportsPreciseTimestamps(client) {
   if (!client.version) {
-    const message = 'If you are using a MySQL version older than 5.6.4 you should specify the ' +
-                    'version in your client options when initializing Knex. See ' +
-                    'http://knexjs.org/#Schema-timestamps for more information.'
+    const message = 'To get rid of this warning you should specify the mysql dialect version in ' +
+                    'your knex configuration. Currently this defaults to 5.5, but in a future ' +
+                    'release it will default to 5.6 which supports high precision timestamps. ' +
+                    'See http://knexjs.org/#Schema-timestamps for more information.'
     helpers.warn(message)
   }
 

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -8,6 +8,13 @@ import * as helpers from '../../../helpers';
 import { assign } from 'lodash'
 
 function supportsPreciseTimestamps(client) {
+  if (!client.version) {
+    const message = 'If you are using a MySQL version older than 5.6.4 you should specify the ' +
+                    'version in your client options when initializing Knex. See ' +
+                    'http://knexjs.org/#Schema-timestamps for more information.'
+    helpers.warn(message)
+  }
+
   return client.version && parseFloat(client.version) > 5.5
 }
 

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -7,6 +7,10 @@ import * as helpers from '../../../helpers';
 
 import { assign } from 'lodash'
 
+function supportsPreciseTimestamps(client) {
+  return client.version && parseFloat(client.version) > 5.5
+}
+
 function ColumnCompiler_MySQL() {
   ColumnCompiler.apply(this, arguments);
   this.modifiers = ['unsigned', 'nullable', 'defaultTo', 'comment', 'collate', 'first', 'after']
@@ -68,9 +72,13 @@ assign(ColumnCompiler_MySQL.prototype, {
     return `enum('${allowed.join("', '")}')`
   },
 
-  datetime: 'datetime',
+  datetime() {
+    return supportsPreciseTimestamps(this.client) ? 'datetime(3)' : 'datetime'
+  },
 
-  timestamp: 'timestamp',
+  timestamp() {
+    return supportsPreciseTimestamps(this.client) ? 'timestamp(3)' : 'timestamp'
+  },
 
   bit(length) {
     return length ? `bit(${this._num(length)})` : 'bit'

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -503,7 +503,7 @@ describe(dialect + " SchemaBuilder", function() {
     delete client.version
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table `users` add `foo` timestamp(3)');
+    expect(tableSql[0].sql).to.equal('alter table `users` add `foo` timestamp(6)');
   });
 
   it('test adding precise time stamps', function() {
@@ -514,7 +514,7 @@ describe(dialect + " SchemaBuilder", function() {
     delete client.version
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('alter table `users` add `created_at` datetime(3), add `updated_at` datetime(3)');
+    expect(tableSql[0].sql).to.equal('alter table `users` add `created_at` datetime(6), add `updated_at` datetime(6)');
   });
 
   it('test adding binary', function() {

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -495,6 +495,28 @@ describe(dialect + " SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table `users` add `created_at` datetime, add `updated_at` datetime');
   });
 
+  it('test adding precise time stamp', function() {
+    client.version = '5.6'
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.timestamp('foo');
+    }).toSQL();
+    delete client.version
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table `users` add `foo` timestamp(3)');
+  });
+
+  it('test adding precise time stamps', function() {
+    client.version = '5.6'
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.timestamps();
+    }).toSQL();
+    delete client.version
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table `users` add `created_at` datetime(3), add `updated_at` datetime(3)');
+  });
+
   it('test adding binary', function() {
     tableSql = client.schemaBuilder().table('users', function() {
       this.binary('foo');


### PR DESCRIPTION
This changes the `timestamp()` and `timestamps()` schema building methods to output columns that have millisecond precision on MySQL versions 5.6 and newer.

This feature is not enabled by default for now and requires passing a `version: '5.6'` option when initializing the client to enable. The version number should be your actual MySQL server version, although as long as it is 5.6 or greater the feature will be enabled. The version number can be in the form `5.6` or `5.6.10`.

Fixes #2524.

Associated documentation update: https://github.com/knex/documentation/pull/99