### PR TITLE
add clearOrder method fix #2360

### DIFF
--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -814,6 +814,12 @@ assign(Builder.prototype, {
     return this;
   },
 
+  // Remove everything from select clause
+  clearOrder(){
+    this._clearGrouping('order');
+    return this;
+  },
+
   // Insert & Update
   // ------
 

--- a/src/query/methods.js
+++ b/src/query/methods.js
@@ -77,6 +77,7 @@ export default [
   'pluck',
   'clearSelect',
   'clearWhere',
+  'clearOrder',
   'insert',
   'update',
   'returning',

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -413,6 +413,39 @@ describe("QueryBuilder", function() {
     });
   });
 
+
+  it("clear an order", function() {
+    testsql(qb().table('users').orderBy('name', 'desc').clearOrder(), {
+      mysql: {
+        sql: 'select * from `users`'
+      },
+      mssql: {
+        sql: 'select * from [users]'
+      },
+      postgres: {
+        sql: 'select * from "users"'
+      },
+      redshift: {
+        sql: 'select * from "users"'
+      },
+    });
+
+    testsql(qb().table('users').orderBy('name', 'desc').clearOrder().orderBy('id', 'asc'), {
+      mysql: {
+        sql: 'select * from `users` order by `id` asc'
+      },
+      mssql: {
+        sql: 'select * from [users] order by [id] asc'
+      },
+      postgres: {
+        sql: 'select * from "users" order by "id" asc'
+      },
+      redshift: {
+        sql: 'select * from "users" order by "id" asc'
+      },
+    });
+  });
+
   it("basic wheres", function() {
     testsql(qb().select('*').from('users').where('id', '=', 1), {
       mysql: {


### PR DESCRIPTION
this adds the `clearOrder` method

is it normal that atm the order clause is reused like in this example ? 

i ran into this for some obscure reason in a sqlite environnement. the order clause was getting a field from another database... 

```js
 const textData = await knex
    .select()
    .from("myTable")
    .where({
      etat: "TOP"
    })
    .orderBy("date", "desc")
    .first()
    .catch(console.log);
```
