### PR TITLE
Restore 'query' event to its original form (no native sql string)

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -126,7 +126,6 @@ assign(Client.prototype, {
 
   query(connection, obj) {
     if (typeof obj === 'string') obj = {sql: obj}
-    obj.sql = this.positionBindings(obj.sql);
     obj.bindings = this.prepBindings(obj.bindings)
 
     const {__knexUid, __knexTxId} = connection;
@@ -134,6 +133,8 @@ assign(Client.prototype, {
     this.emit('query', assign({__knexUid, __knexTxId}, obj))
     debugQuery(obj.sql, __knexTxId)
     debugBindings(obj.bindings, __knexTxId)
+
+    obj.sql = this.positionBindings(obj.sql);
 
     return this._query(connection, obj).catch((err) => {
       err.message = this._formatQuery(obj.sql, obj.bindings) + ' - ' + err.message
@@ -144,7 +145,6 @@ assign(Client.prototype, {
 
   stream(connection, obj, stream, options) {
     if (typeof obj === 'string') obj = {sql: obj}
-    obj.sql = this.positionBindings(obj.sql);
     obj.bindings = this.prepBindings(obj.bindings)
 
     const {__knexUid, __knexTxId} = connection;
@@ -152,6 +152,8 @@ assign(Client.prototype, {
     this.emit('query', assign({__knexUid, __knexTxId}, obj))
     debugQuery(obj.sql, __knexTxId)
     debugBindings(obj.bindings, __knexTxId)
+
+    obj.sql = this.positionBindings(obj.sql);
 
     return this._stream(connection, obj, stream, options)
   },

--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -689,6 +689,20 @@ module.exports = function(knex) {
         });
     });
 
+    it('Event \'query\' should not emit native sql string', function() {
+      var builder = knex('accounts')
+        .where('id', 1)
+        .select();
+
+      builder
+        .on('query', function(obj) {
+          expect(obj.sql).to.not.equal(builder.toSQL().toNative().sql);
+          expect(obj.sql).to.equal(builder.toSQL().sql);
+        });
+
+      return builder;
+    });
+
   });
 
 };


### PR DESCRIPTION
Fixes #2549