### PR TITLE
Primary Key for Migration Lock Table

### DIFF
--- a/src/migrate/index.js
+++ b/src/migrate/index.js
@@ -166,7 +166,7 @@ export default class Migrator {
 
   _createMigrationLockTable(tableName, trx = this.knex) {
     return getSchemaBuilder(trx, this.config.schemaName).createTable(tableName, function(t) {
-      t.integer('is_locked');
+      t.integer('is_locked').primary();
     });
   }
 

--- a/src/migrate/index.js
+++ b/src/migrate/index.js
@@ -166,7 +166,8 @@ export default class Migrator {
 
   _createMigrationLockTable(tableName, trx = this.knex) {
     return getSchemaBuilder(trx, this.config.schemaName).createTable(tableName, function(t) {
-      t.integer('is_locked').primary();
+      t.increments('index').primary();
+      t.integer('is_locked');
     });
   }
 


### PR DESCRIPTION
In reference to #2534, the single line change has been run with tests against `DB='mysql' npm test`.

### Summary

```
  total:     84
  passing:   84
  duration:  1.6s
```

### Full result
[testIssue2534.txt](https://github.com/tgriesser/knex/files/1907638/testIssue2534.txt)
