### PR TITLE
Fix when dropping a unique index in MSSQL

### DIFF
--- a/src/dialects/mssql/schema/tablecompiler.js
+++ b/src/dialects/mssql/schema/tablecompiler.js
@@ -146,7 +146,11 @@ assign(TableCompiler_MSSQL.prototype, {
   // Compile a drop unique key command.
   dropUnique (column, indexName) {
     indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('unique', this.tableNameRaw, column);
-    this.pushQuery(`ALTER TABLE ${this.tableName()} DROP CONSTRAINT ${indexName}`);
+    if (!this.forCreate) {
+      this.pushQuery(`DROP INDEX ${indexName} ON ${this.tableName()}`);
+    } else {
+      this.pushQuery(`ALTER TABLE ${this.tableName()} DROP CONSTRAINT ${indexName}`);
+    }
   }
 
 })

--- a/test/unit/schema/mssql.js
+++ b/test/unit/schema/mssql.js
@@ -90,7 +90,7 @@ describe("MSSQL SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('ALTER TABLE [users] DROP CONSTRAINT [users_foo_unique]');
+    expect(tableSql[0].sql).to.equal('DROP INDEX [users_foo_unique] ON [users]');
   });
 
   it('should alter columns with the alter flag', function() {
@@ -110,7 +110,7 @@ describe("MSSQL SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('ALTER TABLE [users] DROP CONSTRAINT [foo]');
+    expect(tableSql[0].sql).to.equal('DROP INDEX [foo] ON [users]');
   });
 
   it('test drop index', function() {
@@ -530,7 +530,7 @@ describe("MSSQL SchemaBuilder", function() {
     }).toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('ALTER TABLE [composite_key_test] DROP CONSTRAINT [composite_key_test_column_a_column_b_unique]');
+    expect(tableSql[0].sql).to.equal('DROP INDEX [composite_key_test_column_a_column_b_unique] ON [composite_key_test]');
   });
 
   it('allows default as alias for defaultTo', function() {


### PR DESCRIPTION
If an MSSQL unique index is created as an index https://github.com/wilsonge/knex/blob/156d1128de1f692dd6de2841198884deaa8276d8/src/dialects/mssql/schema/tablecompiler.js#L121-L125 it needs to be dropped as an index not as a constraint. You can also see in the tests that we are creating index's and dropping constraints. 

https://docs.microsoft.com/en-us/sql/t-sql/statements/drop-index-transact-sql?view=sql-server-2017 isn't very clear - it says `The DROP INDEX statement does not apply to indexes created by defining PRIMARY KEY or UNIQUE constraints` isn't as clear as it should be - it basically says that you must drop a unique constraint as a constraint. But that means you should still drop unique index's as an index.

This is tested on a local mssql docker container