### PR TITLE
Ensure knex.destroy() returns a bluebird promise

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -315,15 +315,10 @@ assign(Client.prototype, {
 
   // Destroy the current connection pool for the client.
   destroy(callback) {
-    let promise = null
 
-    if (this.pool) {
-      promise = this.pool.destroy()
-    } else {
-      promise = Promise.resolve()
-    }
+    const maybeDestroy = this.pool && this.pool.destroy()
 
-    return promise.then(() => {
+    return Promise.resolve(maybeDestroy).then(() => {
       this.pool = void 0
 
       if (typeof callback === 'function') {


### PR DESCRIPTION
Tarn's `destroy()` method doesn't return a bluebird promise, which means knex's `destroy()` method currently does not return a bluebird promise.  With this change, it should again :)