### PR TITLE
append error detail if available

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -143,6 +143,10 @@ assign(Client.prototype, {
 
     return this._query(connection, obj).catch((err) => {
       err.message = this._formatQuery(obj.sql, obj.bindings) + ' - ' + err.message
+      const {detail} = err
+      if (detail) {
+        err.message += '\nDetail: ' + detail
+      }
       this.emit('query-error', err, assign({__knexUid, __knexTxId}, obj))
       throw err
     })

--- a/test/unit/client.js
+++ b/test/unit/client.js
@@ -1,0 +1,34 @@
+'use strict';
+/*global expect, describe, it*/
+const Client = require("../../lib/client");
+const chai = require("chai");
+
+describe('client', function () {
+  it('should append error details when available', async () => {
+    const client = new Client({ client: {} })
+    client._query = () => {
+      const err = new Error('error message')
+      err.detail = 'hmm very tasty details'
+      return Promise.reject(err)
+    }
+    try {
+      await client.query('select * from a', {sql: 'select * from a', bindings: []})
+    } catch (err) {
+      chai.expect(err.message).to.equal('select * from a - error message\nDetail: hmm very tasty details')
+    }
+  })
+
+  it('should not append error details when not available', async () => {
+    const client = new Client({ client: {} })
+    client._query = () => {
+      const err = new Error('error message')
+      return Promise.reject(err)
+    }
+    try {
+      await client.query('select * from a', {sql: 'select * from a', bindings: []})
+    } catch (err) {
+      chai.expect(err.message).to.equal('select * from a - error message')
+    }
+  })
+
+})


### PR DESCRIPTION
this makes it easier to see what is wrong with a migration when for example adding a foreign key, but some of the rows have values which aren't in the other table, so instead of:
```
Knex:warning - migration file "20180506221158_missing_refs.js" failed
Knex:warning - migration failed with error: alter table "user_topics" add constraint "user_topics_user_id_foreign" foreign key ("user_id") references "users" ("id") on delete CASCADE - insert or update on table "user_topics" violates foreign key constraint "user_topics_user_id_foreign"
error: insert or update on table "user_topics" violates foreign key constraint "user_topics_user_id_foreign"
    at Connection.parseE (/home/capaj/git_projects/knex-repos/knex/node_modules/pg/lib/connection.js:545:11)
    at Connection.parseMessage (/home/capaj/git_projects/knex-repos/knex/node_modules/pg/lib/connection.js:370:19)
    at Socket.<anonymous> (/home/capaj/git_projects/knex-repos/knex/node_modules/pg/lib/connection.js:113:22)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at addChunk (_stream_readable.js:263:12)
    at readableAddChunk (_stream_readable.js:250:11)
    at Socket.Readable.push (_stream_readable.js:208:10)
    at TCP.onread (net.js:594:20)
```

we get this in a failed migration:
```
Knex:warning - migration file "20180506221158_missing_refs.js" failed
Knex:warning - migration failed with error: alter table "user_topics" add constraint "user_topics_user_id_foreign" foreign key ("user_id") references "users" ("id") on delete CASCADE - insert or update on table "user_topics" violates foreign key constraint "user_topics_user_id_foreign"
Detail: Key (user_id)=(18) is not present in table "users".
error: insert or update on table "user_topics" violates foreign key constraint "user_topics_user_id_foreign"
    at Connection.parseE (/home/capaj/git_projects/knex-repos/knex/node_modules/pg/lib/connection.js:545:11)
    at Connection.parseMessage (/home/capaj/git_projects/knex-repos/knex/node_modules/pg/lib/connection.js:370:19)
    at Socket.<anonymous> (/home/capaj/git_projects/knex-repos/knex/node_modules/pg/lib/connection.js:113:22)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at addChunk (_stream_readable.js:263:12)
    at readableAddChunk (_stream_readable.js:250:11)
    at Socket.Readable.push (_stream_readable.js:208:10)
    at TCP.onread (net.js:594:20)
```
