### PR TITLE
Support postgresql connection uri protocol

### DIFF
--- a/src/util/parse-connection.js
+++ b/src/util/parse-connection.js
@@ -19,10 +19,13 @@ export default function parseConnectionString(str) {
   if (protocol.slice(-1) === ':') {
     protocol = protocol.slice(0, -1);
   }
+
+  const isPG = ['postgresql', 'postgres'].includes(protocol);
+
   return {
     client: protocol,
-    connection: protocol === 'postgres' ? parsePG(str) : connectionObject(parsed)
-  }
+    connection: isPG ? parsePG(str) : connectionObject(parsed)
+  };
 }
 
 function connectionObject(parsed) {

--- a/test/tape/parse-connection.js
+++ b/test/tape/parse-connection.js
@@ -83,3 +83,15 @@ test('#852, ssl param with PG query string', function(t) {
     ssl: true
   })
 })
+
+test('support postgresql connection protocol', function(t) {
+  t.plan(1)
+  t.deepEqual(parseConnection('postgresql://user:password@host:0000/database?ssl=true').connection, {
+    host: 'host',
+    port: '0000',
+    user: 'user',
+    password: 'password',
+    database: 'database',
+    ssl: true
+  })
+})


### PR DESCRIPTION
Postgres supports 2 uri connection protocols:

> The URI scheme designator can be either postgresql:// or postgres://.

https://www.postgresql.org/docs/current/static/libpq-connect.html#id-1.7.3.8.3.6
