### PR TITLE
Timeout errors shouldn't silently ignore the passed errors

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -100,7 +100,7 @@ export default class Transaction extends EventEmitter {
     return this.query(conn, 'ROLLBACK;', 2, error)
       .timeout(5000)
       .catch(Promise.TimeoutError, () => {
-        this._resolver();
+        this._rejecter(error);
       });
   }
 
@@ -108,7 +108,7 @@ export default class Transaction extends EventEmitter {
     return this.query(conn, `ROLLBACK TO SAVEPOINT ${this.txid}`, 2, error)
       .timeout(5000)
       .catch(Promise.TimeoutError, () => {
-        this._resolver();
+        this._rejecter(error);
       });
   }
 


### PR DESCRIPTION
but rather reject with original error. Fixes #2582