### PR TITLE
Add support for native enums on Postgres

### DIFF
--- a/src/dialects/postgres/schema/columncompiler.js
+++ b/src/dialects/postgres/schema/columncompiler.js
@@ -30,8 +30,17 @@ assign(ColumnCompiler_PG.prototype, {
 
   // Create the column definition for an enum type.
   // Using method "2" here: http://stackoverflow.com/a/10984951/525714
-  enu(allowed) {
-    return `text check (${this.formatter.wrap(this.args[0])} in ('${allowed.join("', '")}'))`;
+  enu(allowed, options) {
+    options = options || {};
+
+    const values = allowed.join("', '");
+
+    if (options.useNative) {
+      this.tableCompiler.unshiftQuery(`create type "${options.enumName}" as enum ('${values}')`);
+
+      return `"${options.enumName}"`;
+    }
+    return `text check (${this.formatter.wrap(this.args[0])} in ('${values}'))`;
   },
 
   double: 'double precision',

--- a/src/schema/columncompiler.js
+++ b/src/schema/columncompiler.js
@@ -25,6 +25,8 @@ ColumnCompiler.prototype.pushQuery = helpers.pushQuery
 
 ColumnCompiler.prototype.pushAdditional = helpers.pushAdditional
 
+ColumnCompiler.prototype.unshiftQuery = helpers.unshiftQuery
+
 ColumnCompiler.prototype._defaultMap = {
   'columnName': function() {
     if (!this.isIncrements) {

--- a/src/schema/compiler.js
+++ b/src/schema/compiler.js
@@ -1,5 +1,5 @@
 
-import { pushQuery, pushAdditional } from './helpers';
+import { pushQuery, pushAdditional, unshiftQuery } from './helpers';
 
 import { assign, isUndefined } from 'lodash'
 
@@ -19,6 +19,8 @@ assign(SchemaCompiler.prototype, {
   pushQuery: pushQuery,
 
   pushAdditional: pushAdditional,
+
+  unshiftQuery: unshiftQuery,
 
   createTable: buildTable('create'),
 

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -34,3 +34,27 @@ export function pushAdditional(fn) {
   fn.call(child, tail(arguments));
   this.sequence.additional = (this.sequence.additional || []).concat(child.sequence);
 }
+
+// Unshift a new query onto the compiled "sequence" stack,
+// creating a new formatter, returning the compiler.
+export function unshiftQuery(query) {
+  if (!query) return;
+  if (isString(query)) {
+    query = {sql: query};
+  }
+  if (!query.bindings) {
+    query.bindings = this.formatter.bindings;
+  }
+  this.sequence.unshift(query);
+
+  let builder;
+  if (this instanceof ColumnCompiler) {
+    builder = this.columnBuilder;
+  } else if (this instanceof TableCompiler) {
+    builder = this.tableBuilder;
+  } else if (this instanceof SchemaCompiler) {
+    builder = this.builder;
+  }
+
+  this.formatter = this.client.formatter(builder);
+}

--- a/src/schema/tablecompiler.js
+++ b/src/schema/tablecompiler.js
@@ -2,7 +2,7 @@
 
 // Table Compiler
 // -------
-import { pushAdditional, pushQuery } from './helpers';
+import { pushAdditional, pushQuery, unshiftQuery } from './helpers';
 import * as helpers from '../helpers';
 import { groupBy, reduce, map, first, tail, isEmpty, indexOf, isArray, isUndefined } from 'lodash'
 
@@ -22,6 +22,8 @@ function TableCompiler(client, tableBuilder) {
 TableCompiler.prototype.pushQuery = pushQuery
 
 TableCompiler.prototype.pushAdditional = pushAdditional
+
+TableCompiler.prototype.unshiftQuery = unshiftQuery
 
 // Convert the tableCompiler toSQL
 TableCompiler.prototype.toSQL = function () {

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -84,7 +84,7 @@ module.exports = function(knex) {
             const table_name = 'increments_columns_1_test';
             const expected_column = 'id'
             const expected_comment = 'comment_1';
-            
+
             return knex.raw('SELECT c.oid FROM pg_catalog.pg_class c WHERE c.relname = ?',[table_name]).then(function(res) {
               const column_oid = res.rows[0].oid;
 
@@ -106,13 +106,13 @@ module.exports = function(knex) {
             const table_name = 'increments_columns_2_test';
             const expected_column = 'named_2';
             const expected_comment = 'comment_2';
-            
+
             return knex.raw('SELECT c.oid FROM pg_catalog.pg_class c WHERE c.relname = ?',[table_name]).then(function(res) {
               const column_oid = res.rows[0].oid;
-              
+
               return knex.raw('SELECT pg_catalog.col_description(?,?);', [column_oid, '1']).then(function(_res) {
                 const comment = _res.rows[0].col_description;
-                
+
                 return knex.raw('select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = ?;', table_name).then((res) => {
                   const column_name = res.rows[0].column_name;
 
@@ -161,7 +161,7 @@ module.exports = function(knex) {
               TABLE_NAME = ? AND
               COLUMN_NAME = ?
             `
-            
+
             return knex.raw(query,[table_name, expected_column]).then(function(res) {
               const comment = res[0][0].COLUMN_COMMENT
               expect(comment).to.equal(expected_comment)
@@ -183,14 +183,40 @@ module.exports = function(knex) {
               TABLE_NAME = ? AND
               COLUMN_NAME = ?
             `
-            
+
             return knex.raw(query,[table_name, expected_column]).then(function(res) {
               const comment = res[0][0].COLUMN_COMMENT
               expect(comment).to.equal(expected_comment)
             })
-            
+
           });
       });
+
+      describe('enum - postgres', function() {
+        if (!knex || !knex.client || !(/postgres/i.test(knex.client.dialect))) {
+          return Promise.resolve();
+        }
+
+        afterEach(function() {
+          return knex.schema.dropTableIfExists('native_enum_test').raw('DROP TYPE "foo_type"');
+        });
+
+        it('uses native type when useNative is specified', function() {
+          return knex.schema
+            .createTable('native_enum_test', function(table) {
+              table.enum('foo_column', ['a', 'b', 'c'], {
+                useNative: true,
+                enumName: 'foo_type'
+              }).notNull();
+              table.uuid('id').notNull();
+            }).testSql(function(tester) {
+              tester('pg', [
+                'create type "foo_type" as enum (\'a\', \'b\', \'c\')',
+                'create table "native_enum_test" ("foo_column" "foo_type" not null, "id" uuid not null)'
+              ]);
+            });
+        });
+      })
 
       it('Callback function must be supplied', function() {
         expect(function() {

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -541,6 +541,18 @@ describe("PostgreSQL SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" text check ("foo" in (\'bar\', \'baz\'))');
   });
 
+  it("adding enum with useNative", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.enu('foo', ['bar', 'baz'], {
+        useNative: true,
+        enumName: 'foo_type'
+      }).notNullable();
+    }).toSQL();
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal('create type "foo_type" as enum (\'bar\', \'baz\')')
+    expect(tableSql[1].sql).to.equal('alter table "users" add column "foo" "foo_type" not null');
+  });
+
   it("adding date", function() {
     tableSql = client.schemaBuilder().table('users', function(table) {
       table.date('foo');


### PR DESCRIPTION
This is my initial pass at implementing native enum support for **Postgres only.** 

I am looking for feedback on the implementation and whether or not this is the _best_ way to solve this.

I followed the advice of [this comment](https://github.com/tgriesser/knex/issues/394#issuecomment-315528899) and added the following argument to the `enu` method:

```js
{
  nativeEnum: boolean,
  enumName: string
}
```

If `nativeEnum` is truthy, I use the `enumName` to generate the appropriate `type`. I am not sure if having two fields is entirely necessary (I could check `enumName` alone and use that) but I am not sure of the behavior for other RDBMS's.

Reference https://www.postgresql.org/docs/current/static/sql-createtype.html

Documentation: https://github.com/knex/documentation/pull/117

Closes #394