### PR TITLE
Add json support to the query builder for mysql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,18 @@ after_script:
 notifications:
   email: false
 
+services:
+  - mysql
 addons:
   postgresql: '9.6'
   apt:
+    sources:
+      - mysql-5.7-trusty
     packages:
-    - g++-4.8
-    - gcc-4.8
+      - g++-4.8
+      - gcc-4.8
+      - libmysqlclient-dev
+      - libmysqlclient20
+      - mysql-community-client
+      - mysql-common
+      - mysql-community-server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 # Master (Unreleased)
 
 - Drop support for Node.js 4 and 5
-- `json` data type is no longer converted to `text` within a schema builder migration for MySQL databases (note that json data type is only supported for MySQL versions greater than 5.7.8)
+- `json` data type is no longer converted to `text` within a schema builder migration for MySQL databases (note that JSON data type is only supported for MySQL 5.7.8+)
 
 # 0.14.6 - 12 Apr, 2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 # Master (Unreleased)
 
 - Drop support for Node.js 4 and 5
+- `json` data type is no longer converted to `text` within a schema builder migration for MySQL databases (note that json data type is only supported for MySQL versions greater than 5.7.8)
 
 # 0.14.6 - 12 Apr, 2018
 

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -95,6 +95,10 @@ assign(ColumnCompiler_MySQL.prototype, {
     return length ? `varbinary(${this._num(length)})` : 'blob'
   },
 
+  json() {
+    return 'json';
+  },
+
   // Modifiers
   // ------
 

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -54,6 +54,15 @@ describe(dialect + " SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table `users` add `id` int unsigned not null auto_increment primary key, add `email` varchar(255)');
   });
 
+  if(dialect !== 'maria') {
+    it('adding json', function() {
+	  tableSql = client.schemaBuilder().table('user', function(t) {
+	  t.json('preferences');
+	  }).toSQL();
+	  expect(tableSql[0].sql).to.equal('alter table `user` add `preferences` json');
+    });
+  }
+
   it('test drop table', function() {
     tableSql = client.schemaBuilder().dropTable('users').toSQL();
 


### PR DESCRIPTION
Minimalistic version of #1902, only adding support for JSON column type for MySQL.