### PR TITLE
Fix mssql driver crashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,9 +84,9 @@
     "oracledb:test": "docker rmi -f --no-prune knex-test-oracledb && docker build -f scripts/oracle-tests-Dockerfile --tag knex-test-oracledb . && docker run -i -t knex-test-oracledb",
     "mssql:init": "docker-compose -f scripts/mssql-docker-compose.yml up --no-start && docker-compose -f scripts/mssql-docker-compose.yml start",
     "mssql:test": "DB=mssql npm test",
-    "mssql:destroy": "docker-compose -f scripts/mssql-docker-compose.yml stop",    
+    "mssql:destroy": "docker-compose -f scripts/mssql-docker-compose.yml stop",
     "stress:init": "docker-compose -f scripts/stress-test/docker-compose.yml up --no-start && docker-compose -f scripts/stress-test/docker-compose.yml start",
-    "stress:test": "node scripts/stress-test/knex-stress-test.js |  grep -A 3 -- '- STATS '",
+    "stress:test": "node scripts/stress-test/knex-stress-test.js |  grep -A 5 -B 60 -- '- STATS '",
     "stress:destroy": "docker-compose -f scripts/stress-test/docker-compose.yml stop"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "oracledb:test": "docker rmi -f --no-prune knex-test-oracledb && docker build -f scripts/oracle-tests-Dockerfile --tag knex-test-oracledb . && docker run -i -t knex-test-oracledb",
     "mssql:init": "docker-compose -f scripts/mssql-docker-compose.yml up --no-start && docker-compose -f scripts/mssql-docker-compose.yml start",
     "mssql:test": "DB=mssql npm test",
-    "mssql:destroy": "docker-compose -f scripts/mssql-docker-compose.yml stop",
+    "mssql:destroy": "docker-compose -f scripts/mssql-docker-compose.yml stop",    
     "stress:init": "docker-compose -f scripts/stress-test/docker-compose.yml up --no-start && docker-compose -f scripts/stress-test/docker-compose.yml start",
     "stress:test": "node scripts/stress-test/knex-stress-test.js |  grep -A 3 -- '- STATS '",
     "stress:destroy": "docker-compose -f scripts/stress-test/docker-compose.yml stop"

--- a/scripts/stress-test/docker-compose.yml
+++ b/scripts/stress-test/docker-compose.yml
@@ -8,9 +8,12 @@ services:
       - "23306:23306"
       - "25432:25432"
       - "21521:21521"
+      - "21433:21433"
     links:
       - "mysql"
       - "postgresql"
+      - "oracledbxe"
+      - "mssql"
 
   mysql:
     image: mysql:5.7
@@ -35,10 +38,10 @@ services:
     environment:
       - ORACLE_ALLOW_REMOTE=true
 
-#  mssql:
-#    image: microsoft/mssql-server-linux
-#    ports:
-#      - "31433:1433"
-#    environment:
-#      - ACCEPT_EULA=Y
-#      - SA_PASSWORD=mssqlpassword
+  mssql:
+    image: microsoft/mssql-server-linux:2017-latest
+    ports:
+      - "31433:1433"
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=S0meVeryHardPassword

--- a/scripts/stress-test/knex-stress-test.js
+++ b/scripts/stress-test/knex-stress-test.js
@@ -153,18 +153,18 @@ async function main() {
 
   await recreateProxies();
 
-  /*
   loopQueries('PSQL:', pg.raw('select 1'));
   loopQueries('PSQL TO:', pg.raw('select 1').timeout(20));
 
   loopQueries('MYSQL:', mysql.raw('select 1'));
   loopQueries('MYSQL TO:', mysql.raw('select 1').timeout(20));
 
-  loopQueries('MYSQL2:', mysql2.raw('select 1'));
-  loopQueries('MYSQL2 TO:', mysql2.raw('select 1').timeout(20));
+// mysql2 still crashes app (without connection killer nor timeouts)
+// https://github.com/sidorares/node-mysql2/issues/731
+//  loopQueries('MYSQL2:', mysql2.raw('select 1'));
+//  loopQueries('MYSQL2 TO:', mysql2.raw('select 1').timeout(20));
 
   loopQueries('MSSQL:', mssql.raw('select 1'));
-*/
   loopQueries('MSSQL TO:', mssql.raw('select 1').timeout(20));
 
   setInterval(recreateProxies, 2000);
@@ -173,8 +173,8 @@ async function main() {
     await Bluebird.delay(20); // kill everything every quite often from server side
     try {
       await Promise.all([
-//        killConnectionsPg(),
-//        killConnectionsMyslq(mysql),
+        killConnectionsPg(),
+        killConnectionsMyslq(mysql),
 //        killConnectionsMyslq(mysql2),
         killConnectionsMssql()  
       ]);

--- a/scripts/stress-test/knex-stress-test.js
+++ b/scripts/stress-test/knex-stress-test.js
@@ -24,6 +24,18 @@ const mysql = Knex({
   pool: { max: 50 }
 });
 
+const mssql = Knex({
+  client: 'mssql',
+  connection: {
+    port: 21433,
+    user: "sa",
+    password: "S0meVeryHardPassword",
+    server: "localhost",
+    requestTimeout: 500
+  },
+  pool: { max: 50 }
+});
+
 /* TODO: figure out how to nicely install oracledb node driver on osx
 const mysql = Knex({
   client: 'oracledb',
@@ -50,6 +62,7 @@ function setQueryCounters(instance, name) {
 setQueryCounters(pg, 'pg');
 setQueryCounters(mysql, 'mysql');
 setQueryCounters(mysql2, 'mysql2');
+setQueryCounters(mssql, 'mssql');
 
 const _ = require('lodash');
 
@@ -82,6 +95,11 @@ async function killConnectionsPg() {
 async function killConnectionsMyslq(client) {
   const [rows, colDefs] = await client.raw(`SHOW FULL PROCESSLIST`);
   await Promise.all(rows.map(row => client.raw(`KILL ${row.Id}`)));
+} 
+
+async function killConnectionsMssql() {
+  const rows = await mssql('sys.dm_exec_sessions').select('session_id');
+  await Promise.all(rows.map(row => mssql.raw(`KILL ${row.session_id}`)));
 } 
 
 async function main() {
@@ -130,10 +148,12 @@ async function main() {
     await recreateProxy('postgresql', 25432, 5432);
     await recreateProxy('mysql', 23306, 3306);
     await recreateProxy('oracledbxe', 21521, 1521);
+    await recreateProxy('mssql', 21433, 1433);
   }
 
   await recreateProxies();
-  
+
+  /*
   loopQueries('PSQL:', pg.raw('select 1'));
   loopQueries('PSQL TO:', pg.raw('select 1').timeout(20));
 
@@ -143,14 +163,20 @@ async function main() {
   loopQueries('MYSQL2:', mysql2.raw('select 1'));
   loopQueries('MYSQL2 TO:', mysql2.raw('select 1').timeout(20));
 
+  loopQueries('MSSQL:', mssql.raw('select 1'));
+*/
+  loopQueries('MSSQL TO:', mssql.raw('select 1').timeout(20));
+
+  setInterval(recreateProxies, 2000);
 
   while(true) {
     await Bluebird.delay(20); // kill everything every quite often from server side
     try {
       await Promise.all([
-        killConnectionsPg(),
-        killConnectionsMyslq(mysql),
-        killConnectionsMyslq(mysql2),
+//        killConnectionsPg(),
+//        killConnectionsMyslq(mysql),
+//        killConnectionsMyslq(mysql2),
+        killConnectionsMssql()  
       ]);
     } catch (err) {
       console.log('KILLER ERROR:', err);


### PR DESCRIPTION
Since mssql driver has not been maintained, locked driver version and monkey patched it to fix couple of problems of leaking connections / hanging and crashing when connections are closed unexpectedly.

We should eventually change mssql dialect to use directly tedious driver.

I did run this stress test script overnight and it didn't crash and memory consumption didn't grow either (it was stable between 150MB - 400MB)