### PR TITLE
add homepage field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "type": "git",
     "url": "git://github.com/tgriesser/knex.git"
   },
+  "homepage": "https://knexjs.org",
   "keywords": [
     "sql",
     "query",


### PR DESCRIPTION
This is a minor quibble, but I noticed that `npm docs knex` was opening the github repo instead of the knex documentation.

This adds the homepage field to package.json so that `npm docs` will automatically open the knex docs in a browser. This will also add the site URL to https://www.npmjs.com/package/knex.