### PR TITLE
Allow PG timestamps without timezone

### DIFF
--- a/src/schema/tablebuilder.js
+++ b/src/schema/tablebuilder.js
@@ -168,9 +168,10 @@ each(columnTypes, function(type) {
 
 // The "timestamps" call is really just sets the `created_at` and `updated_at` columns.
 TableBuilder.prototype.timestamps = function timestamps() {
-  const method = (arguments[0] === true) ? 'timestamp' : 'datetime';
-  const createdAt = this[method]('created_at');
-  const updatedAt = this[method]('updated_at');
+  const isTimestamp = arguments[0] === true;
+  const method = isTimestamp ? 'timestamp' : 'datetime';
+  const createdAt = this[method]('created_at', isTimestamp);
+  const updatedAt = this[method]('updated_at', isTimestamp);
   if (arguments[1] === true) {
     const now = this.client.raw('CURRENT_TIMESTAMP');
     createdAt.notNullable().defaultTo(now);

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -585,6 +585,22 @@ describe("PostgreSQL SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" timestamptz');
   });
 
+  it("adding timestamps without tz", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.timestamps(true);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "created_at" timestamp, add column "updated_at" timestamp');
+  });
+
+  it("adding timestamps with defaults without tz", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.timestamps(true, true);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "created_at" timestamp not null default CURRENT_TIMESTAMP, add column "updated_at" timestamp not null default CURRENT_TIMESTAMP');
+  });
+
   it("adding timestamps", function() {
     tableSql = client.schemaBuilder().table('users', function(table) {
       table.timestamps();

--- a/test/unit/schema/redshift.js
+++ b/test/unit/schema/redshift.js
@@ -384,6 +384,24 @@ describe("Redshift SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table "users" add column "foo" timestamptz');
   });
 
+  it("adding timestamps without tz", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.timestamps(true);
+    }).toSQL();
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "created_at" timestamp');
+    expect(tableSql[1].sql).to.equal('alter table "users" add column "updated_at" timestamp');
+  });
+
+  it("adding timestamps with defaults without tz", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.timestamps(true, true);
+    }).toSQL();
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "created_at" timestamp not null default CURRENT_TIMESTAMP');
+    expect(tableSql[1].sql).to.equal('alter table "users" add column "updated_at" timestamp not null default CURRENT_TIMESTAMP');
+  });
+
   it("adding timestamps", function() {
     tableSql = client.schemaBuilder().table('users', function(table) {
       table.timestamps();


### PR DESCRIPTION
The `timestamps` method always translates to timestamp with timezone for PG and derivatives (redshift). If the first argument is set to true, then use timestamps without timezone.