### PR TITLE
Fix collation when renaming column in MySQL dialect

### DIFF
--- a/src/dialects/mysql/schema/tablecompiler.js
+++ b/src/dialects/mysql/schema/tablecompiler.js
@@ -69,7 +69,7 @@ assign(TableCompiler_MySQL.prototype, {
     const wrapped = this.formatter.wrap(from) + ' ' + this.formatter.wrap(to);
 
     this.pushQuery({
-      sql: `show fields from ${table} where field = ` +
+      sql: `show full fields from ${table} where field = ` +
         this.formatter.parameter(from),
       output(resp) {
         const column = resp[0];
@@ -87,6 +87,9 @@ assign(TableCompiler_MySQL.prototype, {
               }
               if(column.Default !== void 0 && column.Default !== null) {
                 sql += ` DEFAULT '${column.Default}'`
+              }
+              if (column.Collation !== void 0 && column.Collation !== null) {
+                sql += ` COLLATE '${column.Collation}'`;
               }
 
               return runner.query({


### PR DESCRIPTION
Ran into an issue today where `.renameColumn()` was failing because the columns had a different collation after the rename and recreating the foreign keys caused an error. The collation was being lost during the `alter change`. This change preserves the collation through the alter.

I'm not familiar enough with the knex test suite to know how to go about adding an integration test for this. If someone can provide some pointers, I'd appreciate it. Didn't want to let that stop me raising the issue and providing this patch.

Thanks!