### PR TITLE
Add support for spatial indexes in mysql dialect

### DIFF
--- a/src/dialects/mysql/schema/tablecompiler.js
+++ b/src/dialects/mysql/schema/tablecompiler.js
@@ -160,6 +160,11 @@ assign(TableCompiler_MySQL.prototype, {
     indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
     this.pushQuery(`alter table ${this.tableName()} add index ${indexName}(${this.formatter.columnize(columns)})`);
   },
+  
+  spatial(columns, indexName) {
+    indexName = indexName ? this.formatter.wrap(indexName) : this._indexCommand('index', this.tableNameRaw, columns);
+    this.pushQuery(`alter table ${this.tableName()} add spatial index ${indexName}(${this.formatter.columnize(columns)})`);
+  },
 
   primary(columns, constraintName) {
     constraintName = constraintName ? this.formatter.wrap(constraintName) : this.formatter.wrap(`${this.tableNameRaw}_pkey`);

--- a/src/schema/tablebuilder.js
+++ b/src/schema/tablebuilder.js
@@ -46,7 +46,7 @@ each([
 
   // Each of the index methods can be called individually, with the
   // column name to be used, e.g. table.unique('column').
-  'index', 'primary', 'unique',
+  'index', 'primary', 'unique', 'spatial',
 
   // Key specific
   'dropPrimary', 'dropUnique', 'dropIndex', 'dropForeign'


### PR DESCRIPTION
I'm not sure why indexType was never implemented.  I'm assuming due to injection fears as you would have to sanitize the indexType.  So, maybe just easier to offer a spatial index function.