### PR TITLE
Implement missing schema support for mssql dialect

### DIFF
--- a/src/dialects/mssql/schema/compiler.js
+++ b/src/dialects/mssql/schema/compiler.js
@@ -23,7 +23,7 @@ assign(SchemaCompiler_MSSQL.prototype, {
   renameTable(tableName, to) {
     this.pushQuery(
       `exec sp_rename ${this.formatter.parameter(
-        tableName
+        prefixedTableName(this.schema, tableName)
       )}, ${this.formatter.parameter(to)}`
     );
   },
@@ -31,8 +31,9 @@ assign(SchemaCompiler_MSSQL.prototype, {
   // Check whether a table exists on the query.
   hasTable(tableName) {
     const formattedTable = this.formatter.parameter(
-      this.formatter.wrap(tableName)
+      this.formatter.wrap(prefixedTableName(this.schema, tableName))
     );
+
     const sql =
       `select object_id from sys.tables ` +
       `where object_id = object_id(${formattedTable})`;
@@ -43,7 +44,7 @@ assign(SchemaCompiler_MSSQL.prototype, {
   hasColumn(tableName, column) {
     const formattedColumn = this.formatter.parameter(column);
     const formattedTable = this.formatter.parameter(
-      this.formatter.wrap(tableName)
+      this.formatter.wrap(prefixedTableName(this.schema, tableName))
     );
     const sql =
       `select object_id from sys.columns ` +

--- a/test/unit/schema/mssql.js
+++ b/test/unit/schema/mssql.js
@@ -240,6 +240,75 @@ describe('MSSQL SchemaBuilder', function() {
     expect(tableSql[0].bindings[1]).to.equal('foo');
   });
 
+  it('test has table', function() {
+    tableSql = client
+      .schemaBuilder()
+      .hasTable('users')
+      .toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'select object_id from sys.tables where object_id = object_id(?)'
+    );
+    expect(tableSql[0].bindings[0]).to.equal('[users]');
+  });
+
+  it('test has table with schema', function() {
+    tableSql = client
+      .schemaBuilder()
+      .withSchema('schema')
+      .hasTable('users')
+      .toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'select object_id from sys.tables where object_id = object_id(?)'
+    );
+    expect(tableSql[0].bindings[0]).to.equal('[schema].[users]');
+  });
+
+  it('test rename table with schema', function() {
+    tableSql = client
+      .schemaBuilder()
+      .withSchema('schema')
+      .renameTable('users', 'foo')
+      .toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('exec sp_rename ?, ?');
+    expect(tableSql[0].bindings[0]).to.equal('schema.users');
+    expect(tableSql[0].bindings[1]).to.equal('foo');
+  });
+
+  it('test has column', function() {
+    tableSql = client
+      .schemaBuilder()
+      .hasColumn('users', 'foo')
+      .toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'select object_id from sys.columns where name = ? and object_id = object_id(?)'
+    );
+    expect(tableSql[0].bindings[0]).to.equal('foo');
+    expect(tableSql[0].bindings[1]).to.equal('[users]');
+  });
+
+  it('test has column with schema', function() {
+    tableSql = client
+      .schemaBuilder()
+      .withSchema('schema')
+      .hasColumn('users', 'foo')
+      .toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'select object_id from sys.columns where name = ? and object_id = object_id(?)'
+    );
+    expect(tableSql[0].bindings[0]).to.equal('foo');
+    expect(tableSql[0].bindings[1]).to.equal('[schema].[users]');
+  });
+
   it('test adding primary key', function() {
     tableSql = client
       .schemaBuilder()


### PR DESCRIPTION
- implement schema support in tablecompiler
- add unit tests for hasTable, hasColumn and renameTable

Fixes the mssql part of #2591
