### PR TITLE
TypeScript: object spread

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -20,7 +20,7 @@ import { Pool, TimeoutError } from 'tarn';
 import { EventEmitter } from 'events';
 
 import { makeEscape } from './query/string';
-import { assign, uniqueId, cloneDeep, defaults } from 'lodash';
+import { uniqueId, cloneDeep, defaults } from 'lodash';
 
 import Logger from './logger';
 
@@ -142,7 +142,7 @@ export class Client extends EventEmitter {
 
     const { __knexUid, __knexTxId } = connection;
 
-    this.emit('query', assign({ __knexUid, __knexTxId }, obj));
+    this.emit('query', { __knexUid, __knexTxId, ...obj });
     debugQuery(obj.sql, __knexTxId);
     debugBindings(obj.bindings, __knexTxId);
 
@@ -151,7 +151,7 @@ export class Client extends EventEmitter {
     return this._query(connection, obj).catch((err) => {
       err.message =
         this._formatQuery(obj.sql, obj.bindings) + ' - ' + err.message;
-      this.emit('query-error', err, assign({ __knexUid, __knexTxId }, obj));
+      this.emit('query-error', err, { __knexUid, __knexTxId, ...obj });
       throw err;
     });
   }
@@ -162,7 +162,7 @@ export class Client extends EventEmitter {
 
     const { __knexUid, __knexTxId } = connection;
 
-    this.emit('query', assign({ __knexUid, __knexTxId }, obj));
+    this.emit('query', { __knexUid, __knexTxId, ...obj });
     debugQuery(obj.sql, __knexTxId);
     debugBindings(obj.bindings, __knexTxId);
 
@@ -253,7 +253,8 @@ export class Client extends EventEmitter {
     // choose the smallest, positive timeout setting and set on poolConfig
     poolConfig.acquireTimeoutMillis = Math.min(...timeouts);
 
-    return Object.assign(poolConfig, {
+    return {
+      ...poolConfig,
       create: () => {
         return this.acquireRawConnection().tap((connection) => {
           connection.__knexUid = uniqueId('__knexUid');
@@ -287,7 +288,7 @@ export class Client extends EventEmitter {
 
         return this.validateConnection(connection);
       },
-    });
+    };
   }
 
   initializePool(config = this.config) {

--- a/src/dialects/mssql/index.js
+++ b/src/dialects/mssql/index.js
@@ -1,6 +1,6 @@
 // MSSQL Client
 // -------
-import { assign, map, flatten, values } from 'lodash';
+import { map, flatten, values } from 'lodash';
 
 import Client from '../../client';
 import Promise from 'bluebird';
@@ -84,7 +84,7 @@ class Client_MSSQL extends Client {
           userName: this.config.user,
           password: this.config.password,
           server: this.config.server,
-          options: Object.assign({}, this.config.options),
+          options: { ...this.config.options },
           domain: this.config.domain,
         };
 
@@ -204,7 +204,7 @@ class Client_MSSQL extends Client {
   // connection needs to be added to the pool.
   acquireRawConnection() {
     return new Promise((resolver, rejecter) => {
-      const settings = Object.assign({}, this.connectionSettings);
+      const settings = { ...this.connectionSettings };
       settings.pool = this.mssqlPoolSettings;
 
       const connection = new this.driver.ConnectionPool(settings);

--- a/src/dialects/mssql/query/compiler.js
+++ b/src/dialects/mssql/query/compiler.js
@@ -2,9 +2,7 @@
 // ------
 import QueryCompiler from '../../../query/compiler';
 
-import { assign, isEmpty, compact, identity } from 'lodash';
-
-class QueryCompiler_MSSQL extends QueryCompiler {}
+import { isEmpty, compact, identity } from 'lodash';
 
 const components = [
   'columns',
@@ -19,14 +17,14 @@ const components = [
   'offset',
 ];
 
-assign(QueryCompiler_MSSQL.prototype, {
-  _emptyInsertValue: 'default values',
+class QueryCompiler_MSSQL extends QueryCompiler {
+  _emptyInsertValue = 'default values';
 
   select() {
     const sql = this.with();
     const statements = components.map((component) => this[component](this));
     return sql + compact(statements).join(' ');
-  },
+  }
 
   // Compiles an "insert" query, allowing for multiple
   // inserts using a single query statement.
@@ -75,7 +73,7 @@ assign(QueryCompiler_MSSQL.prototype, {
       sql,
       returning,
     };
-  },
+  }
 
   // Compiles an `update` query, allowing for a return value.
   update() {
@@ -98,7 +96,7 @@ assign(QueryCompiler_MSSQL.prototype, {
         (!returning ? this._returning('rowcount', '@@rowcount') : ''),
       returning: returning || '@@rowcount',
     };
-  },
+  }
 
   // Compiles a `delete` query.
   del() {
@@ -115,7 +113,7 @@ assign(QueryCompiler_MSSQL.prototype, {
         (!returning ? this._returning('rowcount', '@@rowcount') : ''),
       returning: returning || '@@rowcount',
     };
-  },
+  }
 
   // Compiles the columns in the query, specifying if an item was distinct.
   columns() {
@@ -146,7 +144,7 @@ assign(QueryCompiler_MSSQL.prototype, {
       sql.join(', ') +
       (this.tableName ? ` from ${this.tableName}` : '')
     );
-  },
+  }
 
   _returning(method, value) {
     switch (method) {
@@ -162,23 +160,23 @@ assign(QueryCompiler_MSSQL.prototype, {
       case 'rowcount':
         return value ? ';select @@rowcount' : '';
     }
-  },
+  }
 
   // Compiles a `truncate` query.
   truncate() {
     return `truncate table ${this.tableName}`;
-  },
+  }
 
   forUpdate() {
     // this doesn't work exacltly as it should, one should also mention index while locking
     // https://stackoverflow.com/a/9818448/360060
     return 'with (UPDLOCK)';
-  },
+  }
 
   forShare() {
     // http://www.sqlteam.com/article/introduction-to-locking-in-sql-server
     return 'with (HOLDLOCK)';
-  },
+  }
 
   // Compiles a `columnInfo` query.
   columnInfo() {
@@ -220,18 +218,18 @@ assign(QueryCompiler_MSSQL.prototype, {
         return (column && out[column]) || out;
       },
     };
-  },
+  }
 
   top() {
     const noLimit = !this.single.limit && this.single.limit !== 0;
     const noOffset = !this.single.offset;
     if (noLimit || !noOffset) return '';
     return `top (${this.formatter.parameter(this.single.limit)})`;
-  },
+  }
 
   limit() {
     return '';
-  },
+  }
 
   offset() {
     const noLimit = !this.single.limit && this.single.limit !== 0;
@@ -246,8 +244,8 @@ assign(QueryCompiler_MSSQL.prototype, {
       )} rows only`;
     }
     return offset;
-  },
-});
+  }
+}
 
 // Set the QueryBuilder & QueryCompiler on the client object,
 // in case anyone wants to modify things to suit their own purposes.

--- a/src/dialects/mssql/schema/columncompiler.js
+++ b/src/dialects/mssql/schema/columncompiler.js
@@ -2,8 +2,6 @@
 // -------
 import ColumnCompiler from '../../../schema/columncompiler';
 
-import { assign } from 'lodash';
-
 class ColumnCompiler_MSSQL extends ColumnCompiler {
   modifiers = ['nullable', 'defaultTo', 'first', 'after', 'comment'];
 

--- a/src/dialects/mssql/schema/compiler.js
+++ b/src/dialects/mssql/schema/compiler.js
@@ -2,8 +2,6 @@
 // -------
 import SchemaCompiler from '../../../schema/compiler';
 
-import { assign } from 'lodash';
-
 class SchemaCompiler_MSSQL extends SchemaCompiler {
   dropTablePrefix = 'DROP TABLE ';
 

--- a/src/dialects/mssql/schema/tablecompiler.js
+++ b/src/dialects/mssql/schema/tablecompiler.js
@@ -6,8 +6,6 @@ import TableCompiler from '../../../schema/tablecompiler';
 import * as helpers from '../../../helpers';
 import Promise from 'bluebird';
 
-import { assign } from 'lodash';
-
 // Table Compiler
 // ------
 

--- a/src/dialects/mysql/index.js
+++ b/src/dialects/mysql/index.js
@@ -10,7 +10,7 @@ import SchemaCompiler from './schema/compiler';
 import TableCompiler from './schema/tablecompiler';
 import ColumnCompiler from './schema/columncompiler';
 
-import { assign, map } from 'lodash';
+import { map } from 'lodash';
 import { makeEscape } from '../../query/string';
 
 // Always initialize with the "QueryBuilder" and "QueryCompiler"
@@ -94,7 +94,7 @@ class Client_MySQL extends Client {
   // and pass that through to the stream we've sent back to the client.
   _stream(connection, obj, stream, options) {
     options = options || {};
-    const queryOptions = assign({ sql: obj.sql }, obj.options);
+    const queryOptions = { sql: obj.sql, ...obj.options };
     return new Promise((resolver, rejecter) => {
       stream.on('error', rejecter);
       stream.on('end', resolver);
@@ -120,7 +120,7 @@ class Client_MySQL extends Client {
         resolver();
         return;
       }
-      const queryOptions = assign({ sql: obj.sql }, obj.options);
+      const queryOptions = { sql: obj.sql, ...obj.options };
       connection.query(queryOptions, obj.bindings, function(err, rows, fields) {
         if (err) return rejecter(err);
         obj.response = [rows, fields];

--- a/src/dialects/mysql/query/compiler.js
+++ b/src/dialects/mysql/query/compiler.js
@@ -2,7 +2,7 @@
 // ------
 import QueryCompiler from '../../../query/compiler';
 
-import { assign, identity } from 'lodash';
+import { identity } from 'lodash';
 
 class QueryCompiler_MySQL extends QueryCompiler {
   _emptyInsertValue = '() values ()';

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -2,8 +2,6 @@
 // -------
 import ColumnCompiler from '../../../schema/columncompiler';
 
-import { assign } from 'lodash';
-
 function supportsPreciseTimestamps(client) {
   if (!client.version) {
     const message =

--- a/src/dialects/mysql/schema/compiler.js
+++ b/src/dialects/mysql/schema/compiler.js
@@ -2,8 +2,6 @@
 // -------
 import SchemaCompiler from '../../../schema/compiler';
 
-import { assign } from 'lodash';
-
 class SchemaCompiler_MySQL extends SchemaCompiler {
   // Rename a table on the schema.
   renameTable(tableName, to) {

--- a/src/dialects/mysql/schema/tablecompiler.js
+++ b/src/dialects/mysql/schema/tablecompiler.js
@@ -5,8 +5,6 @@
 import TableCompiler from '../../../schema/tablecompiler';
 import Promise from 'bluebird';
 
-import { assign } from 'lodash';
-
 // Table Compiler
 // ------
 

--- a/src/dialects/mysql/transaction.js
+++ b/src/dialects/mysql/transaction.js
@@ -1,12 +1,10 @@
 import Transaction from '../../transaction';
 import Debug from 'debug';
-import { assign, isUndefined } from 'lodash';
+import { isUndefined } from 'lodash';
 
 const debug = Debug('knex:tx');
 
-class Transaction_MySQL extends Transaction {}
-
-assign(Transaction_MySQL.prototype, {
+class Transaction_MySQL extends Transaction {
   query(conn, sql, status, value) {
     const t = this;
     const q = this.trxClient
@@ -39,7 +37,7 @@ assign(Transaction_MySQL.prototype, {
       t._completed = true;
     }
     return q;
-  },
-});
+  }
+}
 
 export default Transaction_MySQL;

--- a/src/dialects/mysql2/index.js
+++ b/src/dialects/mysql2/index.js
@@ -1,7 +1,6 @@
 // MySQL2 Client
 // -------
 import Client_MySQL from '../mysql';
-import { assign } from 'lodash';
 import Transaction from './transaction';
 
 // Always initialize with the "QueryBuilder" and "QueryCompiler"

--- a/src/dialects/mysql2/transaction.js
+++ b/src/dialects/mysql2/transaction.js
@@ -1,11 +1,9 @@
 import Transaction from '../../transaction';
 const debug = require('debug')('knex:tx');
 
-import { assign, isUndefined } from 'lodash';
+import { isUndefined } from 'lodash';
 
-class Transaction_MySQL2 extends Transaction {}
-
-assign(Transaction_MySQL2.prototype, {
+class Transaction_MySQL2 extends Transaction {
   query(conn, sql, status, value) {
     const t = this;
     const q = this.trxClient
@@ -38,7 +36,7 @@ assign(Transaction_MySQL2.prototype, {
       t._completed = true;
     }
     return q;
-  },
-});
+  }
+}
 
 export default Transaction_MySQL2;

--- a/src/dialects/oracle/index.js
+++ b/src/dialects/oracle/index.js
@@ -1,6 +1,6 @@
 // Oracle Client
 // -------
-import { assign, map, flatten, values } from 'lodash';
+import { map, flatten, values } from 'lodash';
 
 import Client from '../../client';
 import Promise from 'bluebird';

--- a/src/dialects/oracle/query/compiler.js
+++ b/src/dialects/oracle/query/compiler.js
@@ -3,7 +3,6 @@
 // Oracle Query Builder & Compiler
 // ------
 import {
-  assign,
   isPlainObject,
   isEmpty,
   isString,

--- a/src/dialects/oracle/schema/columncompiler.js
+++ b/src/dialects/oracle/schema/columncompiler.js
@@ -1,4 +1,4 @@
-import { assign, uniq, map } from 'lodash';
+import { uniq, map } from 'lodash';
 import Raw from '../../../raw';
 import ColumnCompiler from '../../../schema/columncompiler';
 import Trigger from './trigger';

--- a/src/dialects/oracle/schema/tablecompiler.js
+++ b/src/dialects/oracle/schema/tablecompiler.js
@@ -4,7 +4,7 @@ import TableCompiler from '../../../schema/tablecompiler';
 import * as helpers from '../../../helpers';
 import Trigger from './trigger';
 
-import { assign, map } from 'lodash';
+import { map } from 'lodash';
 
 // Table Compiler
 // ------

--- a/src/dialects/oracledb/schema/columncompiler.js
+++ b/src/dialects/oracledb/schema/columncompiler.js
@@ -1,4 +1,3 @@
-import { assign } from 'lodash';
 import ColumnCompiler_Oracle from '../../oracle/schema/columncompiler';
 
 export default class ColumnCompiler_Oracledb extends ColumnCompiler_Oracle {

--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -1,6 +1,6 @@
 // PostgreSQL
 // -------
-import { assign, map, extend, isArray, isString, includes } from 'lodash';
+import { map, isArray, isString, includes } from 'lodash';
 import Client from '../../client';
 import Promise from 'bluebird';
 
@@ -225,7 +225,7 @@ class Client_PG extends Client {
   // and any other necessary prep work.
   _query(connection, obj) {
     let sql = obj.sql;
-    if (obj.options) sql = extend({ text: sql }, obj.options);
+    if (obj.options) sql = { text: sql, ...obj.options };
     return new Promise(function(resolver, rejecter) {
       connection.query(sql, obj.bindings, function(err, response) {
         if (err) return rejecter(err);

--- a/src/dialects/postgres/query/compiler.js
+++ b/src/dialects/postgres/query/compiler.js
@@ -2,7 +2,7 @@
 // ------
 import QueryCompiler from '../../../query/compiler';
 
-import { assign, reduce, identity } from 'lodash';
+import { reduce, identity } from 'lodash';
 
 class QueryCompiler_PG extends QueryCompiler {
   // Compiles a truncate query.

--- a/src/dialects/postgres/schema/columncompiler.js
+++ b/src/dialects/postgres/schema/columncompiler.js
@@ -2,8 +2,6 @@
 // -------
 import ColumnCompiler from '../../../schema/columncompiler';
 
-import { assign } from 'lodash';
-
 class ColumnCompiler_PG extends ColumnCompiler {
   modifiers = ['nullable', 'defaultTo', 'comment'];
 

--- a/src/dialects/redshift/index.js
+++ b/src/dialects/redshift/index.js
@@ -1,7 +1,7 @@
 // Redshift
 // -------
 import Client_PG from '../postgres';
-import { assign, map } from 'lodash';
+import { map } from 'lodash';
 
 import Transaction from './transaction';
 import QueryCompiler from './query/compiler';

--- a/src/dialects/redshift/query/compiler.js
+++ b/src/dialects/redshift/query/compiler.js
@@ -3,7 +3,7 @@
 import QueryCompiler from '../../../query/compiler';
 import QueryCompiler_PG from '../../postgres/query/compiler';
 
-import { assign, reduce, identity } from 'lodash';
+import { reduce, identity } from 'lodash';
 
 class QueryCompiler_Redshift extends QueryCompiler_PG {
   truncate() {

--- a/src/dialects/redshift/schema/columncompiler.js
+++ b/src/dialects/redshift/schema/columncompiler.js
@@ -3,8 +3,6 @@
 
 import ColumnCompiler_PG from '../../postgres/schema/columncompiler';
 
-import { assign } from 'lodash';
-
 class ColumnCompiler_Redshift extends ColumnCompiler_PG {
   bigincrements = 'bigint identity(1,1) primary key not null';
   binary = 'varchar(max)';

--- a/src/dialects/sqlite3/index.js
+++ b/src/dialects/sqlite3/index.js
@@ -2,7 +2,7 @@
 // -------
 import Promise from 'bluebird';
 
-import { isUndefined, map, assign, defaults } from 'lodash';
+import { isUndefined, map, defaults } from 'lodash';
 
 import Client from '../../client';
 

--- a/src/dialects/sqlite3/query/compiler.js
+++ b/src/dialects/sqlite3/query/compiler.js
@@ -1,15 +1,7 @@
 // SQLite3 Query Builder & Compiler
 
 import QueryCompiler from '../../../query/compiler';
-import {
-  assign,
-  each,
-  isEmpty,
-  isString,
-  noop,
-  reduce,
-  identity,
-} from 'lodash';
+import { each, isEmpty, isString, noop, reduce, identity } from 'lodash';
 
 class QueryCompiler_SQLite3 extends QueryCompiler {
   constructor(client, builder) {

--- a/src/dialects/sqlite3/schema/ddl.js
+++ b/src/dialects/sqlite3/schema/ddl.js
@@ -5,7 +5,7 @@
 // -------
 
 import Promise from 'bluebird';
-import { assign, uniqueId, find, identity, map, omit } from 'lodash';
+import { uniqueId, find, identity, map, omit } from 'lodash';
 
 // So altering the schema in SQLite3 is a major pain.
 // We have our own object to deal with the renaming and altering the types

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,6 @@ import Client from './client';
 import makeKnex from './util/make-knex';
 import parseConnection from './util/parse-connection';
 
-import { assign } from 'lodash';
-
 // The client names we'll allow in the `{name: lib}` pairing.
 const aliases = {
   pg: 'postgres',
@@ -15,7 +13,7 @@ const aliases = {
 
 export default function Knex(config) {
   if (typeof config === 'string') {
-    return new Knex(assign(parseConnection(config), arguments[2]));
+    return new Knex({ ...parseConnection(config), ...arguments[1] });
   }
   let Dialect;
   if (arguments.length === 0 || (!config.client && !config.dialect)) {
@@ -31,9 +29,10 @@ export default function Knex(config) {
       clientName}/index.js`).default;
   }
   if (typeof config.connection === 'string') {
-    config = assign({}, config, {
+    config = {
+      ...config,
       connection: parseConnection(config.connection).connection,
-    });
+    };
   }
   return makeKnex(new Dialect(config).init());
 }

--- a/src/migrate/index.js
+++ b/src/migrate/index.js
@@ -5,7 +5,6 @@ import path from 'path';
 import mkdirp from 'mkdirp';
 import Promise from 'bluebird';
 import {
-  assign,
   bind,
   difference,
   each,
@@ -466,7 +465,7 @@ export default class Migrator {
   }
 
   setConfig(config) {
-    return assign({}, CONFIG_DEFAULT, this.config || {}, config);
+    return { ...CONFIG_DEFAULT, ...(this.config || {}), ...config };
   }
 }
 

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -7,7 +7,6 @@ import Raw from '../raw';
 import * as helpers from '../helpers';
 import JoinClause from './joinclause';
 import {
-  assign,
   clone,
   each,
   isBoolean,

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -6,7 +6,6 @@ import JoinClause from './joinclause';
 import debug from 'debug';
 
 import {
-  assign,
   bind,
   compact,
   groupBy,
@@ -61,7 +60,11 @@ class QueryCompiler {
 
     const query = {
       method,
-      options: reduce(this.options, assign, {}),
+      options: reduce(
+        this.options,
+        (result, opts) => ({ ...result, ...opts }),
+        {}
+      ),
       timeout: this.timeout,
       cancelOnTimeout: this.cancelOnTimeout,
       bindings: this.formatter.bindings || [],
@@ -83,7 +86,7 @@ class QueryCompiler {
     if (isString(val)) {
       query.sql = val;
     } else {
-      assign(query, val);
+      Object.assign(query, val);
     }
 
     if (method === 'select' || method === 'first') {

--- a/src/query/joinclause.js
+++ b/src/query/joinclause.js
@@ -1,4 +1,3 @@
-import { assign } from 'lodash';
 import assert from 'assert';
 
 // JoinClause

--- a/src/raw.js
+++ b/src/raw.js
@@ -4,14 +4,7 @@ import * as helpers from './helpers';
 import { EventEmitter } from 'events';
 import debug from 'debug';
 
-import {
-  assign,
-  reduce,
-  isPlainObject,
-  isObject,
-  isUndefined,
-  isNumber,
-} from 'lodash';
+import { reduce, isPlainObject, isObject, isUndefined, isNumber } from 'lodash';
 import Formatter from './formatter';
 import saveAsyncStack from './util/save-async-stack';
 import uuid from 'uuid';
@@ -99,7 +92,11 @@ class Raw extends EventEmitter {
       obj.sql = obj.sql + this._wrappedAfter;
     }
 
-    obj.options = reduce(this._options, assign, {});
+    obj.options = reduce(
+      this._options,
+      (result, opts) => ({ ...result, ...opts }),
+      {}
+    );
 
     if (this._timeout) {
       obj.timeout = this._timeout;

--- a/src/schema/columnbuilder.js
+++ b/src/schema/columnbuilder.js
@@ -1,4 +1,4 @@
-import { extend, each, toArray } from 'lodash';
+import { each, toArray } from 'lodash';
 import { addQueryContext } from '../helpers';
 
 // The chainable interface off the original "column" method.
@@ -16,7 +16,7 @@ export default class ColumnBuilder {
     // If we're altering the table, extend the object
     // with the available "alter" methods.
     if (tableBuilder._method === 'alter') {
-      extend(this, AlterMethods);
+      Object.assign(this, AlterMethods);
     }
   }
 }

--- a/src/schema/compiler.js
+++ b/src/schema/compiler.js
@@ -1,6 +1,6 @@
 import { pushQuery, pushAdditional, unshiftQuery } from './helpers';
 
-import { assign, isUndefined } from 'lodash';
+import { isUndefined } from 'lodash';
 
 // The "SchemaCompiler" takes all of the query statements which have been
 // gathered in the "SchemaBuilder" and turns them into an array of

--- a/src/schema/tablebuilder.js
+++ b/src/schema/tablebuilder.js
@@ -6,7 +6,7 @@
 // method, pushing everything we want to do onto the "allStatements" array,
 // which is then compiled into sql.
 // ------
-import { extend, each, toArray, isString, isFunction } from 'lodash';
+import { each, toArray, isString, isFunction } from 'lodash';
 import * as helpers from '../helpers';
 
 class TableBuilder {
@@ -37,7 +37,7 @@ TableBuilder.prototype.setSchema = function(schemaName) {
 // rather than creating the table.
 TableBuilder.prototype.toSQL = function() {
   if (this._method === 'alter') {
-    extend(this, AlterMethods);
+    Object.assign(this, AlterMethods);
   }
   this._fn.call(this, this);
   return this.client.tableCompiler(this).toSQL();
@@ -246,7 +246,7 @@ TableBuilder.prototype.foreign = function(column, keyName) {
       return returnObj;
     },
     _columnBuilder(builder) {
-      extend(builder, returnObj);
+      Object.assign(builder, returnObj);
       returnObj = builder;
       return builder;
     },

--- a/src/seed/index.js
+++ b/src/seed/index.js
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import mkdirp from 'mkdirp';
 import Promise from 'bluebird';
-import { filter, includes, map, bind, template, each, extend } from 'lodash';
+import { filter, includes, map, bind, template, each } from 'lodash';
 
 // The new seeds we're performing, typically called from the `knex.seed`
 // interface on the main `knex` object. Passes the `knex` instance performing
@@ -138,24 +138,22 @@ class Seeder {
   }
 
   setConfig(config) {
-    return extend(
-      {
-        extension: 'js',
-        directory: './seeds',
-        loadExtensions: [
-          '.co',
-          '.coffee',
-          '.eg',
-          '.iced',
-          '.js',
-          '.litcoffee',
-          '.ls',
-          '.ts',
-        ],
-      },
-      this.config || {},
-      config
-    );
+    return {
+      extension: 'js',
+      directory: './seeds',
+      loadExtensions: [
+        '.co',
+        '.coffee',
+        '.eg',
+        '.iced',
+        '.js',
+        '.litcoffee',
+        '.ls',
+        '.ts',
+      ],
+      ...this.config,
+      ...config,
+    };
   }
 }
 

--- a/src/util/batchInsert.js
+++ b/src/util/batchInsert.js
@@ -1,4 +1,4 @@
-import { isNumber, isArray, chunk, flatten, assign } from 'lodash';
+import { isNumber, isArray, chunk, flatten } from 'lodash';
 import Promise from 'bluebird';
 
 export default function batchInsert(
@@ -22,63 +22,58 @@ export default function batchInsert(
       client.transaction(resolve).catch(reject);
     });
 
-  const wrapper = assign(
-    new Promise((resolve, reject) => {
-      const chunks = chunk(batch, chunkSize);
+  const wrapper = new Promise((resolve, reject) => {
+    const chunks = chunk(batch, chunkSize);
 
-      if (!isNumber(chunkSize) || chunkSize < 1) {
-        return reject(new TypeError(`Invalid chunkSize: ${chunkSize}`));
-      }
-
-      if (!isArray(batch)) {
-        return reject(
-          new TypeError(`Invalid batch: Expected array, got ${typeof batch}`)
-        );
-      }
-
-      //Next tick to ensure wrapper functions are called if needed
-      return Promise.delay(1)
-        .then(getTransaction)
-        .then((tr) => {
-          return Promise.mapSeries(chunks, (items) =>
-            tr(tableName).insert(items, returning)
-          )
-            .then((result) => {
-              result = flatten(result || []);
-
-              if (autoTransaction) {
-                //TODO: -- Oracle tr.commit() does not return a 'thenable' !? Ugly hack for now.
-                return (tr.commit(result) || Promise.resolve()).then(
-                  () => result
-                );
-              }
-
-              return result;
-            })
-            .catch((error) => {
-              if (autoTransaction) {
-                return tr.rollback(error).then(() => Promise.reject(error));
-              }
-
-              return Promise.reject(error);
-            });
-        })
-        .then(resolve)
-        .catch(reject);
-    }),
-    {
-      returning(columns) {
-        returning = columns;
-
-        return this;
-      },
-      transacting(tr) {
-        transaction = tr;
-
-        return this;
-      },
+    if (!isNumber(chunkSize) || chunkSize < 1) {
+      return reject(new TypeError(`Invalid chunkSize: ${chunkSize}`));
     }
-  );
+
+    if (!isArray(batch)) {
+      return reject(
+        new TypeError(`Invalid batch: Expected array, got ${typeof batch}`)
+      );
+    }
+
+    //Next tick to ensure wrapper functions are called if needed
+    return Promise.delay(1)
+      .then(getTransaction)
+      .then((tr) => {
+        return Promise.mapSeries(chunks, (items) =>
+          tr(tableName).insert(items, returning)
+        )
+          .then((result) => {
+            result = flatten(result || []);
+
+            if (autoTransaction) {
+              //TODO: -- Oracle tr.commit() does not return a 'thenable' !? Ugly hack for now.
+              return (tr.commit(result) || Promise.resolve()).then(
+                () => result
+              );
+            }
+
+            return result;
+          })
+          .catch((error) => {
+            if (autoTransaction) {
+              return tr.rollback(error).then(() => Promise.reject(error));
+            }
+
+            return Promise.reject(error);
+          });
+      })
+      .then(resolve)
+      .catch(reject);
+  });
+
+  wrapper.returning = (columns) => {
+    returning = columns;
+    return wrapper;
+  };
+  wrapper.transacting = (tr) => {
+    transaction = tr;
+    return wrapper;
+  };
 
   return wrapper;
 }

--- a/src/util/make-knex.js
+++ b/src/util/make-knex.js
@@ -4,7 +4,6 @@ import Migrator from '../migrate';
 import Seeder from '../seed';
 import FunctionHelper from '../functionhelper';
 import QueryInterface from '../query/methods';
-import { assign } from 'lodash';
 import batchInsert from './batchInsert';
 
 export default function makeKnex(client) {
@@ -18,7 +17,7 @@ export default function makeKnex(client) {
     return tableName ? qb.table(tableName, options) : qb;
   }
 
-  assign(knex, {
+  Object.assign(knex, {
     Promise: require('bluebird'),
 
     // A new query builder instance.

--- a/test/knexfile.js
+++ b/test/knexfile.js
@@ -19,7 +19,8 @@ var pool = {
   },
 };
 
-var mysqlPool = _.extend({}, pool, {
+var mysqlPool = {
+  ...pool,
   afterCreate: function(connection, callback) {
     Promise.promisify(connection.query, { context: connection })(
       "SET sql_mode='TRADITIONAL';",
@@ -28,7 +29,7 @@ var mysqlPool = _.extend({}, pool, {
       callback(null, connection);
     });
   },
-});
+};
 
 var migrations = {
   directory: 'test/integration/migrate/migration',

--- a/test/knexfile.js
+++ b/test/knexfile.js
@@ -19,8 +19,7 @@ var pool = {
   },
 };
 
-var mysqlPool = {
-  ...pool,
+var mysqlPool = Object.assign({}, pool, {
   afterCreate: function(connection, callback) {
     Promise.promisify(connection.query, { context: connection })(
       "SET sql_mode='TRADITIONAL';",
@@ -29,7 +28,7 @@ var mysqlPool = {
       callback(null, connection);
     });
   },
-};
+});
 
 var migrations = {
   directory: 'test/integration/migrate/migration',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "module": "commonjs",
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "downlevelIteration": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "strict": true,
     "module": "commonjs",
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "downlevelIteration": true
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
- Remove `_.assign`/`_.extend` usage
- favor object spread over Object.assign wherever possible