### PR TITLE
Add option of existingType to .enum method to support repeated use of enums

### DIFF
--- a/src/dialects/postgres/schema/columncompiler.js
+++ b/src/dialects/postgres/schema/columncompiler.js
@@ -30,7 +30,10 @@ assign(ColumnCompiler_PG.prototype, {
   enu(allowed, options) {
     options = options || {};
 
-    const values = allowed.join("', '");
+    const values =
+      options.useNative && options.existingType
+        ? undefined
+        : allowed.join("', '");
 
     if (options.useNative) {
       if (!options.existingType) {

--- a/src/dialects/postgres/schema/columncompiler.js
+++ b/src/dialects/postgres/schema/columncompiler.js
@@ -33,9 +33,11 @@ assign(ColumnCompiler_PG.prototype, {
     const values = allowed.join("', '");
 
     if (options.useNative) {
-      this.tableCompiler.unshiftQuery(
-        `create type "${options.enumName}" as enum ('${values}')`
-      );
+      if (!options.existingType) {
+        this.tableCompiler.unshiftQuery(
+          `create type "${options.enumName}" as enum ('${values}')`
+        );
+      }
 
       return `"${options.enumName}"`;
     }

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -266,6 +266,29 @@ module.exports = function(knex) {
               ]);
             });
         });
+
+        it('uses an existing native type when useNative and existingType are specified', function() {
+          return knex
+            .raw("create type \"foo_type\" as enum ('a', 'b', 'c')")
+            .then(() => {
+              return knex.schema
+                .createTable('native_enum_test', function(table) {
+                  table
+                    .enum('foo_column', ['a', 'b', 'c'], {
+                      useNative: true,
+                      enumName: 'foo_type',
+                      existingType: true,
+                    })
+                    .notNull();
+                  table.uuid('id').notNull();
+                })
+                .testSql(function(tester) {
+                  tester('pg', [
+                    'create table "native_enum_test" ("foo_column" "foo_type" not null, "id" uuid not null)',
+                  ]);
+                });
+            });
+        });
       });
 
       it('Callback function must be supplied', function() {

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -274,7 +274,7 @@ module.exports = function(knex) {
               return knex.schema
                 .createTable('native_enum_test', function(table) {
                   table
-                    .enum('foo_column', ['a', 'b', 'c'], {
+                    .enum('foo_column', null, {
                       useNative: true,
                       enumName: 'foo_type',
                       existingType: true,

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -917,6 +917,29 @@ describe('PostgreSQL SchemaBuilder', function() {
     );
   });
 
+  it('adding enum with useNative and existingType works without enum values', function() {
+    tableSql = client
+      .schemaBuilder()
+      .raw("create type \"foo_type\" as enum ('bar', 'baz')")
+      .table('users', function(table) {
+        table
+          .enu('foo', undefined, {
+            useNative: true,
+            existingType: true,
+            enumName: 'foo_type',
+          })
+          .notNullable();
+      })
+      .toSQL();
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      "create type \"foo_type\" as enum ('bar', 'baz')"
+    );
+    expect(tableSql[1].sql).to.equal(
+      'alter table "users" add column "foo" "foo_type" not null'
+    );
+  });
+
   it('adding date', function() {
     tableSql = client
       .schemaBuilder()

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -894,6 +894,29 @@ describe('PostgreSQL SchemaBuilder', function() {
     );
   });
 
+  it('adding enum with useNative and existingType', function() {
+    tableSql = client
+      .schemaBuilder()
+      .raw("create type \"foo_type\" as enum ('bar', 'baz')")
+      .table('users', function(table) {
+        table
+          .enu('foo', ['bar', 'baz'], {
+            useNative: true,
+            existingType: true,
+            enumName: 'foo_type',
+          })
+          .notNullable();
+      })
+      .toSQL();
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      "create type \"foo_type\" as enum ('bar', 'baz')"
+    );
+    expect(tableSql[1].sql).to.equal(
+      'alter table "users" add column "foo" "foo_type" not null'
+    );
+  });
+
   it('adding date', function() {
     tableSql = client
       .schemaBuilder()


### PR DESCRIPTION
I was super happy to see knex supporting native enums in postgres, but when I had an enum that I used repeatedly across different columns in different tables, I was running into errors as the `enum` method created the type enum for you each time. The type would already exist so it would error. I only wanted to create the type once, afterwards I just wanted to use that enum.

Could we add a flag in the options param to not run the sql that creates the type enum?

The first time you run it you could do

```
table.enu('current_mood', ['sad', 'ok', 'happy'], { useNative: true, enumName: 'mood' })
```

And then the other times you can run

```
table.enu('mood', ['sad', 'ok', 'happy'], { useNative: true, enumName: 'mood', existingType: true })
```