### PR TITLE
Fix #2715

### DIFF
--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -5,19 +5,6 @@ import ColumnCompiler from '../../../schema/columncompiler';
 
 import { assign } from 'lodash';
 
-function supportsPreciseTimestamps(client) {
-  if (!client.version) {
-    const message =
-      'To get rid of this warning you should specify the mysql dialect version in ' +
-      'your knex configuration. Currently this defaults to 5.5, but in a future ' +
-      'release it will default to 5.6 which supports high precision timestamps. ' +
-      'See http://knexjs.org/#Schema-timestamps for more information.';
-    client.logger.warn(message);
-  }
-
-  return client.version && parseFloat(client.version) > 5.5;
-}
-
 function ColumnCompiler_MySQL() {
   ColumnCompiler.apply(this, arguments);
   this.modifiers = [
@@ -86,13 +73,15 @@ assign(ColumnCompiler_MySQL.prototype, {
     return `enum('${allowed.join("', '")}')`;
   },
 
-  datetime() {
-    return supportsPreciseTimestamps(this.client) ? 'datetime(6)' : 'datetime';
+  datetime(precision) {
+    return typeof precision === 'number'
+      ? `datetime(${precision})`
+      : 'datetime';
   },
 
-  timestamp() {
-    return supportsPreciseTimestamps(this.client)
-      ? 'timestamp(6)'
+  timestamp(precision) {
+    return typeof precision === 'number'
+      ? `timestamp(${precision})`
       : 'timestamp';
   },
 

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -85,6 +85,10 @@ assign(ColumnCompiler_MySQL.prototype, {
       : 'timestamp';
   },
 
+  time(precision) {
+    return typeof precision === 'number' ? `time(${precision})` : 'time';
+  },
+
   bit(length) {
     return length ? `bit(${this._num(length)})` : 'bit';
   },

--- a/src/functionhelper.js
+++ b/src/functionhelper.js
@@ -4,7 +4,10 @@ function FunctionHelper(client) {
   this.client = client;
 }
 
-FunctionHelper.prototype.now = function() {
+FunctionHelper.prototype.now = function(precision) {
+  if (typeof precision === 'number') {
+    return this.client.raw(`CURRENT_TIMESTAMP(${precision})`);
+  }
   return this.client.raw('CURRENT_TIMESTAMP');
 };
 

--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -318,6 +318,7 @@ module.exports = function(knex) {
     it('should allow using .fn-methods to create raw statements', function() {
       expect(knex.fn.now().prototype === knex.raw().prototype);
       expect(knex.fn.now().toQuery()).to.equal('CURRENT_TIMESTAMP');
+      expect(knex.fn.now(6).toQuery()).to.equal('CURRENT_TIMESTAMP(6)');
     });
 
     it('gets the columnInfo', function() {

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -771,7 +771,7 @@ module.exports = function(dialect) {
       );
     });
 
-    it('test adding precise time stamp', function() {
+    it('test adding precise timestamp', function() {
       tableSql = client
         .schemaBuilder()
         .table('users', function() {
@@ -781,6 +781,19 @@ module.exports = function(dialect) {
       equal(1, tableSql.length);
       expect(tableSql[0].sql).to.equal(
         'alter table `users` add `foo` timestamp(6)'
+      );
+    });
+
+    it('test adding precise datetime', function() {
+      tableSql = client
+        .schemaBuilder()
+        .table('users', function() {
+          this.datetime('foo', 6);
+        })
+        .toSQL();
+      equal(1, tableSql.length);
+      expect(tableSql[0].sql).to.equal(
+        'alter table `users` add `foo` datetime(6)'
       );
     });
 

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -772,34 +772,15 @@ module.exports = function(dialect) {
     });
 
     it('test adding precise time stamp', function() {
-      client.version = '5.6';
       tableSql = client
         .schemaBuilder()
         .table('users', function() {
-          this.timestamp('foo');
+          this.timestamp('foo', 6);
         })
         .toSQL();
-      delete client.version;
-
       equal(1, tableSql.length);
       expect(tableSql[0].sql).to.equal(
         'alter table `users` add `foo` timestamp(6)'
-      );
-    });
-
-    it('test adding precise time stamps', function() {
-      client.version = '5.6';
-      tableSql = client
-        .schemaBuilder()
-        .table('users', function() {
-          this.timestamps();
-        })
-        .toSQL();
-      delete client.version;
-
-      equal(1, tableSql.length);
-      expect(tableSql[0].sql).to.equal(
-        'alter table `users` add `created_at` datetime(6), add `updated_at` datetime(6)'
       );
     });
 


### PR DESCRIPTION
Turns out that #2542 was a bit of bigger change than anticipated because it also required that `NOW` / `CURRENT_TIMESTAMP` also have the precision specified to work correctly. So for now we're going to make it:

1. Opt-in, you must specify the timestamp precision for mysql in order to enable this
2. Doesn't work with `.timestamps()` - I personally find it better to specify timestamps manually, the extra line saved is not worth the added complexity given the current confusing options in that method.
3. Only for mysql - although PostgreSQL supports a precision option, it's probably a bad idea since it defaults to the current, which is why I didn't add this option for that driver.

In the future I'd like to revisit to get a better API here / warn / correct for invalid behavior, because I do agree it'd be good to have millisecond precision built-in... but for now I'm not sure it's worth the backward incompatibility, given that a lot of projects probably have something like:

```
t.timestamp('created_at').defaultTo(knex.raw('CURRENT_TIMESTAMP'))
```

So to use it in mysql:

```js
knex.schema.alterTable(t => {
  t.datetime('column', 6).defaultTo(knex.fn.now(6))
  t.timestamp('column', 6).defaultTo(knex.fn.now(6))
})
```

@ricardograca I'm going to put this out as a patch release since it didn't actually ship properly in 0.15 given the client flag option, and then the inconsistencies were discovered in 0.15.1.