### PR TITLE
Allow timestamp with timezone on mssql databases

### DIFF
--- a/src/dialects/mssql/schema/columncompiler.js
+++ b/src/dialects/mssql/schema/columncompiler.js
@@ -62,7 +62,9 @@ assign(ColumnCompiler_MSSQL.prototype, {
 
   datetime: 'datetime',
 
-  timestamp: 'datetime',
+  timestamp(useTz) {
+    return useTz ? 'datetimeoffset' : 'datetime';
+  },
 
   bit(length) {
     if (length > 1) {

--- a/src/dialects/mssql/schema/columncompiler.js
+++ b/src/dialects/mssql/schema/columncompiler.js
@@ -62,7 +62,7 @@ assign(ColumnCompiler_MSSQL.prototype, {
 
   datetime: 'datetime',
 
-  timestamp(useTz) {
+  timestamp({ useTz = false } = {}) {
     return useTz ? 'datetimeoffset' : 'datetime';
   },
 

--- a/test/unit/schema/mssql.js
+++ b/test/unit/schema/mssql.js
@@ -787,7 +787,9 @@ describe('MSSQL SchemaBuilder', function() {
     tableSql = client
       .schemaBuilder()
       .table('users', function() {
-        this.timestamp('foo', true);
+        this.timestamp('foo', {
+          useTz: true,
+        });
       })
       .toSQL();
 

--- a/test/unit/schema/mssql.js
+++ b/test/unit/schema/mssql.js
@@ -783,6 +783,20 @@ describe('MSSQL SchemaBuilder', function() {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] datetime');
   });
 
+  it('test adding time stamp with timezone', function() {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function() {
+        this.timestamp('foo', true);
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'ALTER TABLE [users] ADD [foo] datetimeoffset'
+    );
+  });
+
   it('test adding time stamps', function() {
     tableSql = client
       .schemaBuilder()


### PR DESCRIPTION
The SQL Server supports the following date / time data types:

date (Transact-SQL)
datetime (Transact-SQL)
datetime2 (Transact-SQL)
datetimeoffset (Transact-SQL)
smalldatetime (Transact-SQL)
time (Transact-SQL)

In my opinion, timestamp can be represented by (datetime, datetime2, datetimeoffset and smalldatetime).

Regarding the docs and integration tests, I want to wait for the reply about the incompatibility between dialects on the parameter for timestamp function on schema builder.