### PR TITLE
MSSQL Implement `IDENTITY_INSERT ON/OFF` insert query

### DIFF
--- a/src/dialects/mssql/query/compiler.js
+++ b/src/dialects/mssql/query/compiler.js
@@ -35,6 +35,7 @@ assign(QueryCompiler_MSSQL.prototype, {
   // Compiles an "insert" query, allowing for multiple
   // inserts using a single query statement.
   insert() {
+    const queryContext = this.formatter.builder._queryContext || {};
     const insertValues = this.single.insert || [];
     let sql = this.with() + `insert into ${this.tableName} `;
     const { returning } = this.single;
@@ -75,6 +76,12 @@ assign(QueryCompiler_MSSQL.prototype, {
         sql = '';
       }
     }
+
+    if(queryContext && queryContext.identityInsert) {
+      sql = `SET IDENTITY_INSERT ${this.tableName} ON; ${sql}; `;
+      sql += `SET IDENTITY_INSERT ${this.tableName} OFF;`;
+    }
+
     return {
       sql,
       returning,

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -5314,6 +5314,34 @@ describe('QueryBuilder', function() {
     );
   });
 
+  it('insert with primarykey/identitykey is set using queryContext identityInsert=true', function() {
+    testsql(
+      qb()
+        .queryContext({ identityInsert: true })
+        .into("users")
+        .insert({ id: 1, email: "foo" }),
+      {
+        mysql: {
+          sql: "insert into `users` (`email`, `id`) values (?, ?)",
+          bindings: ["foo", 1]
+        },
+        mssql: {
+          sql:
+            "SET IDENTITY_INSERT [users] ON; insert into [users] ([email], [id]) values (?, ?); SET IDENTITY_INSERT [users] OFF;",
+          bindings: ["foo", 1]
+        },
+        pg: {
+          sql: 'insert into "users" ("email", "id") values (?, ?)',
+          bindings: ["foo", 1]
+        },
+        'pg-redshift': {
+          sql: 'insert into "users" ("email", "id") values (?, ?)',
+          bindings: ["foo", 1]
+        }
+      }
+    );
+  });
+
   it('update method', function() {
     testsql(
       qb()


### PR DESCRIPTION
- utilize `_queryContext` to determine if `identityInsert` set to true wrap insert query into `IDENTITY_INSERT ON/OFF`

#Case
- During `integration test` there are some scenario that we need to set values on  primary keys.

## Related issue
https://github.com/tgriesser/knex/issues/2262

## Usage
It's to the user to determine if a table has a identity column
### knex
```
knex('users')
  .queryContext({ identityInsert: true })
  .insert({
    id: 1,
    user: 'foo',
  }, 'id')
```

###  objection.js custom query builder usage
```
insert(args) {
    const knex = this._modelClass.constructor.knex;
    const client = this._modelClass.client;

    if (!this.has(/returning/)) {
      this.returning(this._modelClass.getIdColumn());
    }

    if (client === 'mssql') {
      // eslint-disable-next-line no-unused-vars
      this.onBuildKnex((knexBuilder, objectionBuilder) => {
        knexBuilder.queryContext({
          identityInsert: isIdentityWrapperRequired(
            this.jsonProperties,
            Array.isArray(args) ? args[0] : args
          ),
        });
      });
    }

    return super.insert.apply(this, [args]);
  }
```


