### PR TITLE
Allow chaining of increment, decrement, and update

### DIFF
--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -806,13 +806,36 @@ assign(Builder.prototype, {
   },
 
   // Increments a column's value by the specified amount.
-  increment(column, amount) {
+  increment(column, amount = 1) {
+    if (isObject(column)) {
+      for (const key in column) {
+        this._counter(key, column[key]);
+      }
+
+      return this;
+    }
+
     return this._counter(column, amount);
   },
 
   // Decrements a column's value by the specified amount.
-  decrement(column, amount) {
-    return this._counter(column, amount, '-');
+  decrement(column, amount = 1) {
+    if (isObject(column)) {
+      for (const key in column) {
+        this._counter(key, -column[key]);
+      }
+
+      return this;
+    }
+
+    return this._counter(column, -amount);
+  },
+
+  // Clears increments/decrements
+  clearCounters() {
+    this._single.counter = [];
+
+    return this;
   },
 
   // Sets the values for a `select` query, informing that only the first
@@ -971,15 +994,18 @@ assign(Builder.prototype, {
   // ----------------------------------------------------------------------
 
   // Helper for the incrementing/decrementing queries.
-  _counter(column, amount, symbol) {
-    let amt = parseFloat(amount);
-    if (isNaN(amt)) amt = 1;
-    this._method = 'counter';
-    this._single.counter = {
+  _counter(column, amount) {
+    amount = parseFloat(amount);
+
+    this._method = 'update';
+
+    this._single.counter = this._single.counter || [];
+
+    this._single.counter.push({
       column,
-      amount: amt,
-      symbol: symbol || '+',
-    };
+      amount,
+    });
+
     return this;
   },
 

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -833,7 +833,7 @@ assign(Builder.prototype, {
 
   // Clears increments/decrements
   clearCounters() {
-    this._single.counter = [];
+    this._single.counter = {};
 
     return this;
   },
@@ -999,12 +999,9 @@ assign(Builder.prototype, {
 
     this._method = 'update';
 
-    this._single.counter = this._single.counter || [];
+    this._single.counter = this._single.counter || {};
 
-    this._single.counter.push({
-      column,
-      amount,
-    });
+    this._single.counter[column] = amount;
 
     return this;
   },

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -742,10 +742,7 @@ assign(QueryCompiler.prototype, {
         0
       );
 
-      data[column] = this.client.raw('??' + ' ' + '+' + ' ' + '?', [
-        column,
-        value,
-      ]);
+      data[column] = this.client.raw('?? + ?', [column, value]);
     }
 
     data = omitBy(data, isUndefined);

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -736,13 +736,19 @@ assign(QueryCompiler.prototype, {
         continue;
       }
 
-      const value = reduce(
+      let value = reduce(
         grouped[column],
         (memo, item) => memo + item.amount,
         0
       );
 
-      data[column] = this.client.raw('?? + ?', [column, value]);
+      const symbol = value < 0 ? '-' : '+';
+
+      if (symbol === '-') {
+        value = -value;
+      }
+
+      data[column] = this.client.raw(`?? ${symbol} ?`, [column, value]);
     }
 
     data = omitBy(data, isUndefined);

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -17,6 +17,7 @@ import {
   omitBy,
   reduce,
   has,
+  keys,
 } from 'lodash';
 import uuid from 'uuid';
 
@@ -723,10 +724,9 @@ assign(QueryCompiler.prototype, {
 
   // "Preps" the update.
   _prepUpdate(data = {}) {
-    const { counter = [] } = this.single;
-    const grouped = groupBy(counter, 'column');
+    const { counter = {} } = this.single;
 
-    for (const column in grouped) {
+    for (const column of keys(counter)) {
       //Skip?
       if (has(data, column)) {
         //Needed?
@@ -736,11 +736,7 @@ assign(QueryCompiler.prototype, {
         continue;
       }
 
-      let value = reduce(
-        grouped[column],
-        (memo, item) => memo + item.amount,
-        0
-      );
+      let value = counter[column];
 
       const symbol = value < 0 ? '-' : '+';
 
@@ -752,9 +748,11 @@ assign(QueryCompiler.prototype, {
     }
 
     data = omitBy(data, isUndefined);
+
     const vals = [];
     const columns = Object.keys(data);
     let i = -1;
+
     while (++i < columns.length) {
       vals.push(
         this.formatter.wrap(columns[i]) +

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -5620,7 +5620,7 @@ describe('QueryBuilder', function() {
     );
   });
 
-  it('Can chain increments', () => {
+  it('Can chain increment', () => {
     testsql(
       qb()
         .into('users')
@@ -5649,7 +5649,7 @@ describe('QueryBuilder', function() {
     );
   });
 
-  it('Can chain increments and decrements in same build-chain', () => {
+  it('Can chain increment and decrement in same build-chain', () => {
     testsql(
       qb()
         .into('users')
@@ -5658,27 +5658,27 @@ describe('QueryBuilder', function() {
         .decrement('balance', 100),
       {
         pg: {
-          sql: 'update "users" set "balance" = "balance" + ? where "id" = ?',
-          bindings: [-90, 1],
+          sql: 'update "users" set "balance" = "balance" - ? where "id" = ?',
+          bindings: [90, 1],
         },
         mysql: {
-          sql: 'update `users` set `balance` = `balance` + ? where `id` = ?',
-          bindings: [-90, 1],
+          sql: 'update `users` set `balance` = `balance` - ? where `id` = ?',
+          bindings: [90, 1],
         },
         mssql: {
           sql:
-            'update [users] set [balance] = [balance] + ? where [id] = ?;select @@rowcount',
-          bindings: [-90, 1],
+            'update [users] set [balance] = [balance] - ? where [id] = ?;select @@rowcount',
+          bindings: [90, 1],
         },
         'pg-redshift': {
-          sql: 'update "users" set "balance" = "balance" + ? where "id" = ?',
-          bindings: [-90, 1],
+          sql: 'update "users" set "balance" = "balance" - ? where "id" = ?',
+          bindings: [90, 1],
         },
       }
     );
   });
 
-  it('Can chain increments / decrements with .update in same build-chain', () => {
+  it('Can chain increment / decrement with .update in same build-chain', () => {
     testsql(
       qb()
         .into('users')
@@ -5691,29 +5691,29 @@ describe('QueryBuilder', function() {
       {
         pg: {
           sql:
-            'update "users" set "email" = ?, "balance" = "balance" + ? where "id" = ?',
-          bindings: ['foo@bar.com', -90, 1],
+            'update "users" set "email" = ?, "balance" = "balance" - ? where "id" = ?',
+          bindings: ['foo@bar.com', 90, 1],
         },
         mysql: {
           sql:
-            'update `users` set `email` = ?, `balance` = `balance` + ? where `id` = ?',
-          bindings: ['foo@bar.com', -90, 1],
+            'update `users` set `email` = ?, `balance` = `balance` - ? where `id` = ?',
+          bindings: ['foo@bar.com', 90, 1],
         },
         mssql: {
           sql:
-            'update [users] set [email] = ?, [balance] = [balance] + ? where [id] = ?;select @@rowcount',
-          bindings: ['foo@bar.com', -90, 1],
+            'update [users] set [email] = ?, [balance] = [balance] - ? where [id] = ?;select @@rowcount',
+          bindings: ['foo@bar.com', 90, 1],
         },
         'pg-redshift': {
           sql:
-            'update "users" set "email" = ?, "balance" = "balance" + ? where "id" = ?',
-          bindings: ['foo@bar.com', -90, 1],
+            'update "users" set "email" = ?, "balance" = "balance" - ? where "id" = ?',
+          bindings: ['foo@bar.com', 90, 1],
         },
       }
     );
   });
 
-  it('Can chain increments / decrements with .update in same build-chain and ignores increment/decrement if column is also supplied in .update', () => {
+  it('Can chain increment / decrement with .update in same build-chain and ignores increment/decrement if column is also supplied in .update', () => {
     testsql(
       qb()
         .into('users')
@@ -5745,7 +5745,7 @@ describe('QueryBuilder', function() {
     );
   });
 
-  it('Can use object syntax for increments/decrements', () => {
+  it('Can use object syntax for increment/decrement', () => {
     testsql(
       qb()
         .into('users')
@@ -5761,23 +5761,23 @@ describe('QueryBuilder', function() {
       {
         pg: {
           sql:
-            'update "users" set "balance" = "balance" + ?, "times" = "times" + ?, "value" = "value" + ?, "subvalue" = "subvalue" + ? where "id" = ?',
-          bindings: [10, 1, -50, -30, 1],
+            'update "users" set "balance" = "balance" + ?, "times" = "times" + ?, "value" = "value" - ?, "subvalue" = "subvalue" - ? where "id" = ?',
+          bindings: [10, 1, 50, 30, 1],
         },
         mysql: {
           sql:
-            'update `users` set `balance` = `balance` + ?, `times` = `times` + ?, `value` = `value` + ?, `subvalue` = `subvalue` + ? where `id` = ?',
-          bindings: [10, 1, -50, -30, 1],
+            'update `users` set `balance` = `balance` + ?, `times` = `times` + ?, `value` = `value` - ?, `subvalue` = `subvalue` - ? where `id` = ?',
+          bindings: [10, 1, 50, 30, 1],
         },
         mssql: {
           sql:
-            'update [users] set [balance] = [balance] + ?, [times] = [times] + ?, [value] = [value] + ?, [subvalue] = [subvalue] + ? where [id] = ?;select @@rowcount',
-          bindings: [10, 1, -50, -30, 1],
+            'update [users] set [balance] = [balance] + ?, [times] = [times] + ?, [value] = [value] - ?, [subvalue] = [subvalue] - ? where [id] = ?;select @@rowcount',
+          bindings: [10, 1, 50, 30, 1],
         },
         'pg-redshift': {
           sql:
-            'update "users" set "balance" = "balance" + ?, "times" = "times" + ?, "value" = "value" + ?, "subvalue" = "subvalue" + ? where "id" = ?',
-          bindings: [10, 1, -50, -30, 1],
+            'update "users" set "balance" = "balance" + ?, "times" = "times" + ?, "value" = "value" - ?, "subvalue" = "subvalue" - ? where "id" = ?',
+          bindings: [10, 1, 50, 30, 1],
         },
       }
     );
@@ -5854,21 +5854,21 @@ describe('QueryBuilder', function() {
         .decrement('balance', 10),
       {
         mysql: {
-          sql: 'update `users` set `balance` = `balance` + ? where `id` = ?',
-          bindings: [-10, 1],
+          sql: 'update `users` set `balance` = `balance` - ? where `id` = ?',
+          bindings: [10, 1],
         },
         mssql: {
           sql:
-            'update [users] set [balance] = [balance] + ? where [id] = ?;select @@rowcount',
-          bindings: [-10, 1],
+            'update [users] set [balance] = [balance] - ? where [id] = ?;select @@rowcount',
+          bindings: [10, 1],
         },
         pg: {
-          sql: 'update "users" set "balance" = "balance" + ? where "id" = ?',
-          bindings: [-10, 1],
+          sql: 'update "users" set "balance" = "balance" - ? where "id" = ?',
+          bindings: [10, 1],
         },
         'pg-redshift': {
-          sql: 'update "users" set "balance" = "balance" + ? where "id" = ?',
-          bindings: [-10, 1],
+          sql: 'update "users" set "balance" = "balance" - ? where "id" = ?',
+          bindings: [10, 1],
         },
       }
     );
@@ -5882,21 +5882,21 @@ describe('QueryBuilder', function() {
         .decrement('balance', 1.23),
       {
         mysql: {
-          sql: 'update `users` set `balance` = `balance` + ? where `id` = ?',
-          bindings: [-1.23, 1],
+          sql: 'update `users` set `balance` = `balance` - ? where `id` = ?',
+          bindings: [1.23, 1],
         },
         mssql: {
           sql:
-            'update [users] set [balance] = [balance] + ? where [id] = ?;select @@rowcount',
-          bindings: [-1.23, 1],
+            'update [users] set [balance] = [balance] - ? where [id] = ?;select @@rowcount',
+          bindings: [1.23, 1],
         },
         pg: {
-          sql: 'update "users" set "balance" = "balance" + ? where "id" = ?',
-          bindings: [-1.23, 1],
+          sql: 'update "users" set "balance" = "balance" - ? where "id" = ?',
+          bindings: [1.23, 1],
         },
         'pg-redshift': {
-          sql: 'update "users" set "balance" = "balance" + ? where "id" = ?',
-          bindings: [-1.23, 1],
+          sql: 'update "users" set "balance" = "balance" - ? where "id" = ?',
+          bindings: [1.23, 1],
         },
       }
     );


### PR DESCRIPTION
Relates to #269 

Changes include:
- Chainable `.increment`, `.decrement`, `.update` in the same build-chain
- Can call `.increment` / `.decrement` on same column multiple times
- Uses reduce for final query value
- Object syntax for `.increment` / `.decrement`
- ~Generates queries with `"column" + ?` only~ Reverted!
- Added `.clearCounters()` to clear previous `.increment` / `.decrement` calls in a build chain
- If `.increment` / `.decrement` is called for a column that has already been specified in `.update` then value specified in `.update` will take presedence.

See tests for examples.

May have missed something or completely misinterpreted the issue, in which case please let me know.