### PR TITLE
Fix join using builder withSchema.

### DIFF
--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -176,7 +176,11 @@ assign(Builder.prototype, {
     } else if (joinType === 'raw') {
       join = new JoinClause(this.client.raw(table, first), 'raw');
     } else {
-      join = new JoinClause(table, joinType, schema);
+      join = new JoinClause(
+        table,
+        joinType,
+        table instanceof Builder ? undefined : schema
+      );
       if (arguments.length > 1) {
         join.on.apply(join, toArray(arguments).slice(1));
       }

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -8149,4 +8149,35 @@ describe('QueryBuilder', function() {
       oracledb: 'select 0',
     });
   });
+
+  it('join with subquery using .withSchema', function() {
+    testsql(
+      qb()
+        .from('departments')
+        .withSchema('foo')
+        .join(
+          qb()
+            .from('trainees')
+            .withSchema('foo')
+            .groupBy('department_id')
+            .select('department_id', raw('count(*)'))
+            .as('trainee_cnts'),
+          'trainee_cnts.department_id',
+          'departments.id'
+        )
+        .select('departments.*', 'trainee_cnts.count as trainee_cnt'),
+      {
+        pg:
+          'select "departments".*, "trainee_cnts"."count" as "trainee_cnt" from "foo"."departments" inner join (select "department_id", count(*) from "foo"."trainees" group by "department_id") as "trainee_cnts" on "trainee_cnts"."department_id" = "departments"."id"',
+        mysql:
+          'select `departments`.*, `trainee_cnts`.`count` as `trainee_cnt` from `foo`.`departments` inner join (select `department_id`, count(*) from `foo`.`trainees` group by `department_id`) as `trainee_cnts` on `trainee_cnts`.`department_id` = `departments`.`id`',
+        mssql:
+          'select [departments].*, [trainee_cnts].[count] as [trainee_cnt] from [foo].[departments] inner join (select [department_id], count(*) from [foo].[trainees] group by [department_id]) as [trainee_cnts] on [trainee_cnts].[department_id] = [departments].[id]',
+        'pg-redshift':
+          'select "departments".*, "trainee_cnts"."count" as "trainee_cnt" from "foo"."departments" inner join (select "department_id", count(*) from "foo"."trainees" group by "department_id") as "trainee_cnts" on "trainee_cnts"."department_id" = "departments"."id"',
+        oracledb:
+          'select "departments".*, "trainee_cnts"."count" "trainee_cnt" from "foo"."departments" inner join (select "department_id", count(*) from "foo"."trainees" group by "department_id") "trainee_cnts" on "trainee_cnts"."department_id" = "departments"."id"',
+      }
+    );
+  });
 });


### PR DESCRIPTION
Relates to #2607.

Previously the joinbuilder would preemptively append the main builder's schema name from `.withSchema` to a subquery, which is invalid sql syntax. This change simply does not pass the schemaname to the `JoinClause` when subject is a `Builder`.