### PR TITLE
Added onVal, andOnVal, orOnVal to JoinClause

### DIFF
--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -589,6 +589,16 @@ assign(QueryCompiler.prototype, {
     );
   },
 
+  onVal(clause) {
+    return (
+      this.formatter.wrap(clause.column) +
+      ' ' +
+      this.formatter.operator(clause.operator) +
+      ' ' +
+      this.formatter.parameter(clause.value)
+    );
+  },
+
   onRaw(clause) {
     return this.formatter.unwrapRaw(clause.value);
   },

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -8149,4 +8149,59 @@ describe('QueryBuilder', function() {
       oracledb: 'select 0',
     });
   });
+
+  it('join with onVal andOnVal orOnVal', () => {
+    testsql(
+      qb()
+        .select({
+          id: 'p.ID',
+          status: 'p.post_status',
+          name: 'p.post_title',
+          // type: 'terms.name',
+          price: 'price.meta_value',
+          createdAt: 'p.post_date_gmt',
+          updatedAt: 'p.post_modified_gmt',
+        })
+        .from({ p: 'wp_posts' })
+        .leftJoin({ price: 'wp_postmeta' }, function() {
+          this.on('p.id', '=', 'price.post_id')
+            .onVal(function() {
+              this.onVal('price.meta_key', '_regular_price').andOnVal(
+                'price_meta_key',
+                '_regular_price'
+              );
+            })
+            .orOnVal(function() {
+              this.onVal('price_meta.key', '_regular_price');
+            });
+        }),
+      {
+        pg: {
+          sql:
+            'select "p"."ID" as "id", "p"."post_status" as "status", "p"."post_title" as "name", "price"."meta_value" as "price", "p"."post_date_gmt" as "createdAt", "p"."post_modified_gmt" as "updatedAt" from "wp_posts" as "p" left join "wp_postmeta" as "price" on "p"."id" = "price"."post_id" and ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
+          bindings: ['_regular_price', '_regular_price', '_regular_price'],
+        },
+        mysql: {
+          sql:
+            'select `p`.`ID` as `id`, `p`.`post_status` as `status`, `p`.`post_title` as `name`, `price`.`meta_value` as `price`, `p`.`post_date_gmt` as `createdAt`, `p`.`post_modified_gmt` as `updatedAt` from `wp_posts` as `p` left join `wp_postmeta` as `price` on `p`.`id` = `price`.`post_id` and (`price`.`meta_key` = ? and `price_meta_key` = ?) or (`price_meta`.`key` = ?)',
+          bindings: ['_regular_price', '_regular_price', '_regular_price'],
+        },
+        mssql: {
+          sql:
+            'select [p].[ID] as [id], [p].[post_status] as [status], [p].[post_title] as [name], [price].[meta_value] as [price], [p].[post_date_gmt] as [createdAt], [p].[post_modified_gmt] as [updatedAt] from [wp_posts] as [p] left join [wp_postmeta] as [price] on [p].[id] = [price].[post_id] and ([price].[meta_key] = ? and [price_meta_key] = ?) or ([price_meta].[key] = ?)',
+          bindings: ['_regular_price', '_regular_price', '_regular_price'],
+        },
+        'pg-redshift': {
+          sql:
+            'select "p"."ID" as "id", "p"."post_status" as "status", "p"."post_title" as "name", "price"."meta_value" as "price", "p"."post_date_gmt" as "createdAt", "p"."post_modified_gmt" as "updatedAt" from "wp_posts" as "p" left join "wp_postmeta" as "price" on "p"."id" = "price"."post_id" and ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
+          bindings: ['_regular_price', '_regular_price', '_regular_price'],
+        },
+        oracledb: {
+          sql:
+            'select "p"."ID" "id", "p"."post_status" "status", "p"."post_title" "name", "price"."meta_value" "price", "p"."post_date_gmt" "createdAt", "p"."post_modified_gmt" "updatedAt" from "wp_posts" "p" left join "wp_postmeta" "price" on "p"."id" = "price"."post_id" and ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
+          bindings: ['_regular_price', '_regular_price', '_regular_price'],
+        },
+      }
+    );
+  });
 });


### PR DESCRIPTION
Relates to #2707 - See discussion

Allows join using parameters instead of having to rely on `Raw`.

Before
```javascript
this.on('p.id', '=', 'price.post_id').andOn('price.meta_key', knex.raw('_regular_price'))
```

After
```javascript
this.on('p.id', '=', 'price.post_id').andOnVal('price.meta_key', '_regular_price')
```