### PR TITLE
Use Datetime2 for MSSQL datetime + timestamp types

### DIFF
--- a/src/dialects/mssql/schema/columncompiler.js
+++ b/src/dialects/mssql/schema/columncompiler.js
@@ -60,9 +60,9 @@ assign(ColumnCompiler_MSSQL.prototype, {
 
   uuid: 'uniqueidentifier',
 
-  datetime: 'datetime',
+  datetime: 'datetime2',
 
-  timestamp: 'datetime',
+  timestamp: 'datetime2',
 
   bit(length) {
     if (length > 1) {

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -355,7 +355,7 @@ module.exports = function(knex) {
               'create index "test_table_one_logins_index" on "test_table_one" ("logins")',
             ]);
             tester('mssql', [
-              "CREATE TABLE [test_table_one] ([id] bigint identity(1,1) not null primary key, [first_name] nvarchar(255), [last_name] nvarchar(255), [email] nvarchar(255) null, [logins] int default '1', [balance] float default '0', [about] nvarchar(max), [created_at] datetime, [updated_at] datetime)",
+              "CREATE TABLE [test_table_one] ([id] bigint identity(1,1) not null primary key, [first_name] nvarchar(255), [last_name] nvarchar(255), [email] nvarchar(255) null, [logins] int default '1', [balance] float default '0', [about] nvarchar(max), [created_at] datetime2, [updated_at] datetime2)",
               'CREATE INDEX [test_table_one_first_name_index] ON [test_table_one] ([first_name])',
               'CREATE UNIQUE INDEX [test_table_one_email_unique] ON [test_table_one] ([email]) WHERE [email] IS NOT NULL',
               'CREATE INDEX [test_table_one_logins_index] ON [test_table_one] ([logins])',

--- a/test/unit/schema/mssql.js
+++ b/test/unit/schema/mssql.js
@@ -756,7 +756,7 @@ describe('MSSQL SchemaBuilder', function() {
       .toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] datetime');
+    expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] datetime2');
   });
 
   it('test adding time', function() {
@@ -780,7 +780,7 @@ describe('MSSQL SchemaBuilder', function() {
       .toSQL();
 
     equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] datetime');
+    expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] datetime2');
   });
 
   it('test adding time stamps', function() {
@@ -793,7 +793,7 @@ describe('MSSQL SchemaBuilder', function() {
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
-      'ALTER TABLE [users] ADD [created_at] datetime, [updated_at] datetime'
+      'ALTER TABLE [users] ADD [created_at] datetime2, [updated_at] datetime2'
     );
   });
 
@@ -850,7 +850,7 @@ describe('MSSQL SchemaBuilder', function() {
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
-      'CREATE TABLE [default_raw_test] ([created_at] datetime default GETDATE())'
+      'CREATE TABLE [default_raw_test] ([created_at] datetime2 default GETDATE())'
     );
   });
 
@@ -878,7 +878,7 @@ describe('MSSQL SchemaBuilder', function() {
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
-      'CREATE TABLE [default_raw_test] ([created_at] datetime default GETDATE())'
+      'CREATE TABLE [default_raw_test] ([created_at] datetime2 default GETDATE())'
     );
   });
 


### PR DESCRIPTION
Datetime2 is now the recommended column type for new date work: https://docs.microsoft.com/en-us/sql/t-sql/data-types/datetime-transact-sql?view=sql-server-2017