### PR TITLE
Introduced abstraction for getting migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "json-loader": "^0.5.7",
     "lint-staged": "^7.2.2",
     "mocha": "^5.2.0",
-    "mock-fs": "^4.6.0",
+    "mock-fs": "^4.7.0",
     "mssql": "^4.1.0",
     "mysql": "^2.16.0",
     "mysql2": "^1.6.1",

--- a/src/migrate/Migrator.js
+++ b/src/migrate/Migrator.js
@@ -25,7 +25,7 @@ import {
 } from './table-resolver';
 import { getSchemaBuilder } from './table-creator';
 import * as migrationListResolver from './migration-list-resolver';
-import FsMigrations from './sources/fs-migrations';
+import FsMigrations, { DEFAULT_LOAD_EXTENSIONS } from './sources/fs-migrations';
 
 function LockError(msg) {
   this.name = 'MigrationLocked';
@@ -36,7 +36,7 @@ inherits(LockError, Error);
 
 const CONFIG_DEFAULT = Object.freeze({
   extension: 'js',
-  loadExtensions: migrationListResolver.DEFAULT_LOAD_EXTENSIONS,
+  loadExtensions: DEFAULT_LOAD_EXTENSIONS,
   tableName: 'knex_migrations',
   schemaName: null,
   directory: './migrations',
@@ -114,10 +114,7 @@ export default class Migrator {
       getTable(this.knex, this.config.tableName, this.config.schemaName).select(
         '*'
       ),
-      migrationListResolver.listAll(
-        this.config.migrationSource,
-        this.config.loadExtensions
-      ),
+      migrationListResolver.listAll(this.config.migrationSource),
     ]).spread((db, code) => db.length - code.length);
   }
 
@@ -451,11 +448,14 @@ export default class Migrator {
     if (
       config &&
       !config.migrationSource &&
-      (config.directory || config.sortDirsSeparately !== undefined)
+      (config.directory ||
+        config.sortDirsSeparately !== undefined ||
+        config.loadExtensions)
     ) {
       newConfig.migrationSource = new FsMigrations(
         newConfig.directory,
-        newConfig.sortDirsSeparately
+        newConfig.sortDirsSeparately,
+        newConfig.loadExtensions
       );
     }
 

--- a/src/migrate/Migrator.js
+++ b/src/migrate/Migrator.js
@@ -459,7 +459,7 @@ export default class Migrator {
       );
     }
 
-    //
+    // Ensure a migrationSource is set
     if (!newConfig.migrationSource) {
       newConfig.migrationSource = new FsMigrations(
         newConfig.directory,

--- a/src/migrate/Migrator.js
+++ b/src/migrate/Migrator.js
@@ -284,18 +284,23 @@ export default class Migrator {
 
   // Validates some migrations by requiring and checking for an `up` and `down`
   // function.
-  _validateMigrationStructure(name) {
-    const migrationContent = this.config.migrationSource.getMigration(name);
+  _validateMigrationStructure(migration) {
+    const migrationName = this.config.migrationSource.getMigrationName(
+      migration
+    );
+    const migrationContent = this.config.migrationSource.getMigration(
+      migration
+    );
     if (
       typeof migrationContent.up !== 'function' ||
       typeof migrationContent.down !== 'function'
     ) {
       throw new Error(
-        `Invalid migration: ${name} must have both an up and down function`
+        `Invalid migration: ${migrationName} must have both an up and down function`
       );
     }
 
-    return name;
+    return migration;
   }
 
   // Generates the stub template for the current migration, returning a compiled

--- a/src/migrate/Migrator.js
+++ b/src/migrate/Migrator.js
@@ -25,7 +25,7 @@ import {
 } from './table-resolver';
 import { getSchemaBuilder } from './table-creator';
 import * as migrationListResolver from './migration-list-resolver';
-import { FsMigrations } from './sources/fs-migrations';
+import FsMigrations from './sources/fs-migrations';
 
 function LockError(msg) {
   this.name = 'MigrationLocked';
@@ -444,12 +444,29 @@ export default class Migrator {
 
   setConfig(config) {
     const newConfig = assign({}, CONFIG_DEFAULT, this.config || {}, config);
-    if ((config && !config.migrationSource) || !newConfig.migrationSource) {
+
+    // If migrationSource is not specified, but fs related config has been specified
+    // recreate the FsMigration source so the new filesystem related settings
+    // are used
+    if (
+      config &&
+      !config.migrationSource &&
+      (config.directory || config.sortDirsSeparately !== undefined)
+    ) {
       newConfig.migrationSource = new FsMigrations(
         newConfig.directory,
         newConfig.sortDirsSeparately
       );
     }
+
+    //
+    if (!newConfig.migrationSource) {
+      newConfig.migrationSource = new FsMigrations(
+        newConfig.directory,
+        newConfig.sortDirsSeparately
+      );
+    }
+
     return newConfig;
   }
 }

--- a/src/migrate/Migrator.js
+++ b/src/migrate/Migrator.js
@@ -64,6 +64,7 @@ export default class Migrator {
       .listAllAndCompleted(this.config, this.knex)
       .tap(validateMigrationList)
       .spread((all, completed) => {
+        console.log('@@@', all, completed)
         const migrations = getNewMigrations(all, completed);
 
         const transactionForAll =
@@ -269,19 +270,20 @@ export default class Migrator {
 
   // Validates some migrations by requiring and checking for an `up` and `down`
   // function.
-  _validateMigrationStructure(migration) {
-    const migrationContent = require(resolveMigrationPath(migration));
+  _validateMigrationStructure(name) {
+    const migrationContent = this.config.migrationSource.getMigration(name);
     if (
       typeof migrationContent.up !== 'function' ||
       typeof migrationContent.down !== 'function'
     ) {
       throw new Error(
         `Invalid migration: ${
-          migration
+          name
         } must have both an up and down function`
       );
     }
-    return migration;
+
+    return name;
   }
 
   // Generates the stub template for the current migration, returning a compiled

--- a/src/migrate/migration-list-resolver.js
+++ b/src/migrate/migration-list-resolver.js
@@ -21,13 +21,14 @@ export function listAll(
   loadExtensions = DEFAULT_LOAD_EXTENSIONS
 ) {
   return migrationSource.getMigrations().then((migrations) => {
-    return filterMigrations(migrations, loadExtensions);
+    return filterMigrations(migrationSource, migrations, loadExtensions);
   });
 }
 
-function filterMigrations(migrations, loadExtensions) {
-  return filter(migrations, (value) => {
-    const extension = path.extname(value);
+function filterMigrations(migrationSource, migrations, loadExtensions) {
+  return filter(migrations, (migration) => {
+    const migrationName = migrationSource.getMigrationName(migration);
+    const extension = path.extname(migrationName);
     return loadExtensions.includes(extension);
   });
 }

--- a/src/migrate/migration-list-resolver.js
+++ b/src/migrate/migration-list-resolver.js
@@ -1,10 +1,8 @@
 import Promise from 'bluebird';
-import { filter, map } from 'lodash';
+import { filter } from 'lodash';
 import path from 'path';
 import { getTableName } from './table-resolver';
 import { ensureTable } from './table-creator';
-
-const readDirAsync = Promise.promisify(fs.readdir, { context: fs });
 
 export const DEFAULT_LOAD_EXTENSIONS = Object.freeze([
   '.co',

--- a/src/migrate/migration-list-resolver.js
+++ b/src/migrate/migration-list-resolver.js
@@ -1,36 +1,10 @@
 import Promise from 'bluebird';
-import { filter } from 'lodash';
-import path from 'path';
 import { getTableName } from './table-resolver';
 import { ensureTable } from './table-creator';
 
-export const DEFAULT_LOAD_EXTENSIONS = Object.freeze([
-  '.co',
-  '.coffee',
-  '.eg',
-  '.iced',
-  '.js',
-  '.litcoffee',
-  '.ls',
-  '.ts',
-]);
-
 // Lists all available migration versions, as a sorted array.
-export function listAll(
-  migrationSource,
-  loadExtensions = DEFAULT_LOAD_EXTENSIONS
-) {
-  return migrationSource.getMigrations().then((migrations) => {
-    return filterMigrations(migrationSource, migrations, loadExtensions);
-  });
-}
-
-function filterMigrations(migrationSource, migrations, loadExtensions) {
-  return filter(migrations, (migration) => {
-    const migrationName = migrationSource.getMigrationName(migration);
-    const extension = path.extname(migrationName);
-    return loadExtensions.includes(extension);
-  });
+export function listAll(migrationSource, loadExtensions) {
+  return migrationSource.getMigrations(loadExtensions);
 }
 
 // Lists all migrations that have been completed for the current db, as an
@@ -54,7 +28,7 @@ export function listCompleted(tableName, schemaName, trxOrKnex) {
 // the list of completed migrations to check what should be run.
 export function listAllAndCompleted(config, trxOrKnex) {
   return Promise.all([
-    listAll(config.migrationSource, config.loadExtensions),
+    listAll(config.migrationSource),
     listCompleted(config.tableName, config.schemaName, trxOrKnex),
   ]);
 }

--- a/src/migrate/sources/fs-migrations.js
+++ b/src/migrate/sources/fs-migrations.js
@@ -5,7 +5,7 @@ import { sortBy } from 'lodash';
 
 const readDirAsync = Promise.promisify(fs.readdir, { context: fs });
 
-export class FsMigrations {
+export default class FsMigrations {
   constructor(migrationDirectories, sortDirsSeparately) {
     this.sortDirsSeparately = sortDirsSeparately;
 

--- a/src/migrate/sources/fs-migrations.js
+++ b/src/migrate/sources/fs-migrations.js
@@ -30,7 +30,7 @@ export class FsMigrations {
     });
 
     return Promise.all(readMigrationsPromises).then((allMigrations) => {
-      const relativeMigrations = allMigrations.reduce(
+      const migrations = allMigrations.reduce(
         (acc, migrationDirectory) => {
           // When true, files inside the folder should be sorted
           if (this.sortDirsSeparately) {
@@ -38,8 +38,7 @@ export class FsMigrations {
           }
 
           migrationDirectory.files
-            .map((file) => path.join(migrationDirectory.configDir, file))
-            .forEach((relativeMigation) => acc.push(relativeMigation));
+            .forEach((file) => acc.push({ file, directory: migrationDirectory.configDir }));
 
           return acc;
         },
@@ -47,19 +46,21 @@ export class FsMigrations {
       );
 
       // If true we have already sorted the migrations inside the folders
+      // return the migrations fully qualified
       if (this.sortDirsSeparately) {
-        return relativeMigrations;
+        return migrations
+          .map((migration) => path.join(migration.configDir, migration.file));
       }
 
-      return relativeMigrations.sort();
+      return migrations.map(migration => migration.file).sort();
     });
   }
 
-  getMigration(name) {
-    return require(resolveMigrationPath(name));
+  getMigrationName(migration) {
+    return require(migration.file);
   }
-}
 
-function resolveMigrationPath(migration) {
-  return path.join(migration.directory, migration.file);
+  getMigration(migration) {
+    return require(path.join(migration.directory, migration.file));
+  }
 }

--- a/src/migrate/sources/fs-migrations.js
+++ b/src/migrate/sources/fs-migrations.js
@@ -1,0 +1,65 @@
+import fs from 'fs';
+import path from 'path';
+import Promise from 'bluebird';
+
+const readDirAsync = Promise.promisify(fs.readdir, { context: fs });
+
+export class FsMigrations {
+  constructor(migrationDirectories, sortDirsSeparately) {
+    this.sortDirsSeparately = sortDirsSeparately;
+
+    if (!Array.isArray(migrationDirectories)) {
+      migrationDirectories = [migrationDirectories];
+    }
+    this.migrationsPaths = migrationDirectories;
+  }
+
+  /**
+   * Gets the migration names
+   * @returns Promise<string[]>
+   */
+  getMigrations() {
+    // Get a list of files in all specified migration directories
+    const readMigrationsPromises = this.migrationsPaths.map((configDir) => {
+      const absoluteDir = path.resolve(process.cwd(), configDir);
+      return readDirAsync(absoluteDir).then((files) => ({
+        files,
+        configDir,
+        absoluteDir,
+      }));
+    });
+
+    return Promise.all(readMigrationsPromises).then((allMigrations) => {
+      const relativeMigrations = allMigrations.reduce(
+        (acc, migrationDirectory) => {
+          // When true, files inside the folder should be sorted
+          if (this.sortDirsSeparately) {
+            migrationDirectory.files = migrationDirectory.files.sort();
+          }
+
+          migrationDirectory.files
+            .map((file) => path.join(migrationDirectory.configDir, file))
+            .forEach((relativeMigation) => acc.push(relativeMigation));
+
+          return acc;
+        },
+        []
+      );
+
+      // If true we have already sorted the migrations inside the folders
+      if (this.sortDirsSeparately) {
+        return relativeMigrations;
+      }
+
+      return relativeMigrations.sort();
+    });
+  }
+
+  getMigration(name) {
+    return require(resolveMigrationPath(name));
+  }
+}
+
+function resolveMigrationPath(migration) {
+  return path.join(migration.directory, migration.file);
+}

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -5,6 +5,7 @@ const equal = require('assert').equal;
 const path = require('path');
 const rimraf = require('rimraf');
 const Promise = require('bluebird');
+const testMemoryMigrations = require('./memory-migrations');
 
 module.exports = function(knex) {
   require('rimraf').sync(path.join(__dirname, './migration'));
@@ -538,5 +539,40 @@ module.exports = function(knex) {
         });
       });
     }
+  });
+
+  describe('migrationSource config', function() {
+    const migrationSource = {
+      getMigrations() {
+        console.log('???', Object.keys(testMemoryMigrations).sort());
+        return Promise.resolve(Object.keys(testMemoryMigrations).sort());
+      },
+      getMigrationName(migration) {
+        return migration;
+      },
+      getMigration(migration) {
+        return testMemoryMigrations[migration];
+      },
+    };
+
+    before(() => {
+      return knex.migrate.latest({
+        migrationSource,
+      });
+    });
+
+    after(() => {
+      return knex.migrate.rollback({
+        migrationSource,
+      });
+    });
+
+    it('can accept a custom migration source', function() {
+      return knex.schema
+        .hasColumn('migration_source_test_1', 'name')
+        .then(function(exists) {
+          expect(exists).to.equal(true);
+        });
+    });
   });
 };

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -293,13 +293,10 @@ module.exports = function(knex) {
           .spread(function(batchNo, log) {
             expect(batchNo).to.equal(1);
             expect(log).to.have.length(2);
-            const migrationPath = [
-              'test',
-              'integration',
-              'migrate',
-              'test',
-            ].join(path.sep); //Test fails on windows if explicitly defining /test/integration/.. ~wubzz
-            expect(log[0]).to.contain(migrationPath);
+            var migrationPath = ['test', 'integration', 'migrate', 'test'].join(
+              path.sep
+            ); //Test fails on windows if explicitly defining /test/integration/.. ~wubzz
+            expect(log[0]).to.contain(batchNo);
             return knex('knex_migrations')
               .select('*')
               .then(function(data) {

--- a/test/integration/migrate/memory-migrations.js
+++ b/test/integration/migrate/memory-migrations.js
@@ -1,0 +1,13 @@
+module.exports = {
+  migration_source_test_1: {
+    up(knex) {
+      return knex.schema.createTable('migration_source_test_1', function(t) {
+        t.increments();
+        t.string('name');
+      });
+    },
+    down(knex) {
+      return knex.schema.dropTable('migration_source_test_1');
+    },
+  },
+};

--- a/test/tape/migrate.js
+++ b/test/tape/migrate.js
@@ -2,7 +2,7 @@
 
 const tape = require('tape');
 const Migrator = require('../../lib/migrate/Migrator').default;
-const mergeConfig = require('../../lib/migrate/Migrator').mergeConfig;
+const mergeConfig = require('../../lib/migrate/Migrator').getMergedConfig;
 
 tape('migrate: constructor uses config.migrations', function(t) {
   t.plan(1);

--- a/test/tape/migrate.js
+++ b/test/tape/migrate.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const tape = require('tape');
-const Migrator = require('../../lib/migrate/Migrator');
+const Migrator = require('../../lib/migrate/Migrator').default;
+const mergeConfig = require('../../lib/migrate/Migrator').mergeConfig;
 
 tape('migrate: constructor uses config.migrations', function(t) {
   t.plan(1);
@@ -15,11 +16,8 @@ tape('migrate: setConfig() overrides configs given in constructor', function(
   t
 ) {
   t.plan(1);
-  const migrator = new Migrator({
-    client: { config: { migrations: { directory: '/some/dir' } } },
-  });
 
-  const config = migrator.setConfig({ directory: './custom/path' });
+  const config = mergeConfig({ directory: './custom/path' });
 
   t.equal(config.directory, './custom/path');
 });

--- a/test/unit/migrate/migration-list-resolver.js
+++ b/test/unit/migrate/migration-list-resolver.js
@@ -40,14 +40,38 @@ describe('migration-list-resolver', () => {
     it('should include all supported extensions by default', () => {
       return migrationListResolver.listAll(migrationSource).then((list) => {
         expect(list).to.eql([
-          'co-migration.co',
-          'coffee-migration.coffee',
-          'eg-migration.eg',
-          'iced-migration.iced',
-          'js-migration.js',
-          'litcoffee-migration.litcoffee',
-          'ls-migration.ls',
-          'ts-migration.ts',
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'co-migration.co',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'coffee-migration.coffee',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'eg-migration.eg',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'iced-migration.iced',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'js-migration.js',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'litcoffee-migration.litcoffee',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'ls-migration.ls',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'ts-migration.ts',
+          },
         ]);
       });
     });
@@ -57,8 +81,14 @@ describe('migration-list-resolver', () => {
         .listAll(migrationSource, ['.ts', '.js'])
         .then((list) => {
           expect(list).to.eql([
-            'test/integration/migrate/migration/js-migration.js',
-            'test/integration/migrate/migration/ts-migration.ts',
+            {
+              directory: 'test/integration/migrate/migration',
+              file: 'js-migration.js',
+            },
+            {
+              directory: 'test/integration/migrate/migration',
+              file: 'ts-migration.ts',
+            },
           ]);
         });
     });
@@ -87,39 +117,76 @@ describe('migration-list-resolver', () => {
     it('should include files from both folders, sorted globally', () => {
       const migrationSource = new FsMigrations([
         'test/integration/migrate/migration',
-        'test/integration/migrate/seeds'
+        'test/integration/migrate/seeds',
       ]);
 
-      return migrationListResolver
-        .listAll(migrationSource)
-        .then((list) => {
-          expect(list).to.eql([
-            '001_migration.js',
-            '002_migration.js',
-            '003_migration.js',
-            '004_migration.js',
-            '005_migration.js',
-            '006_migration.js',
-          ]);
-        });
+      return migrationListResolver.listAll(migrationSource).then((list) => {
+        expect(list).to.eql([
+          {
+            directory: 'test/integration/migrate/migration',
+            file: '001_migration.js',
+          },
+          {
+            directory: 'test/integration/migrate/seeds',
+            file: '002_migration.js',
+          },
+          {
+            directory: 'test/integration/migrate/seeds',
+            file: '003_migration.js',
+          },
+          {
+            directory: 'test/integration/migrate/seeds',
+            file: '004_migration.js',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: '005_migration.js',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: '006_migration.js',
+          },
+        ]);
+      });
     });
 
     it('should include files from both folders, sorted within their folders', () => {
-      const migrationSource = new FsMigrations([
-        'test/integration/migrate/migration',
-        'test/integration/migrate/seeds'
-      ], true);
+      const migrationSource = new FsMigrations(
+        [
+          'test/integration/migrate/migration',
+          'test/integration/migrate/seeds',
+        ],
+        true
+      );
 
       return migrationListResolver
         .listAll(migrationSource, ['.js'])
         .then((list) => {
           expect(list).to.eql([
-            'test/integration/migrate/migration/001_migration.js',
-            'test/integration/migrate/migration/005_migration.js',
-            'test/integration/migrate/migration/006_migration.js',
-            'test/integration/migrate/seeds/002_migration.js',
-            'test/integration/migrate/seeds/003_migration.js',
-            'test/integration/migrate/seeds/004_migration.js',
+            {
+              directory: 'test/integration/migrate/migration',
+              file: '001_migration.js',
+            },
+            {
+              directory: 'test/integration/migrate/migration',
+              file: '005_migration.js',
+            },
+            {
+              directory: 'test/integration/migrate/migration',
+              file: '006_migration.js',
+            },
+            {
+              directory: 'test/integration/migrate/seeds',
+              file: '002_migration.js',
+            },
+            {
+              directory: 'test/integration/migrate/seeds',
+              file: '003_migration.js',
+            },
+            {
+              directory: 'test/integration/migrate/seeds',
+              file: '004_migration.js',
+            },
           ]);
         });
     });

--- a/test/unit/migrate/migration-list-resolver.js
+++ b/test/unit/migrate/migration-list-resolver.js
@@ -6,7 +6,8 @@ const chai = require('chai');
 const { expect } = require('chai');
 const mockFs = require('mock-fs');
 const migrationListResolver = require('../../../lib/migrate/migration-list-resolver');
-const FsMigrations = require('../../../lib/migrate/sources/fs-migrations');
+const FsMigrations = require('../../../lib/migrate/sources/fs-migrations')
+  .default;
 
 describe('migration-list-resolver', () => {
   describe('listAll', () => {

--- a/test/unit/migrate/migration-list-resolver.js
+++ b/test/unit/migrate/migration-list-resolver.js
@@ -7,18 +7,17 @@ const chaiSubset = require('chai-subset-in-order');
 const { expect } = require('chai');
 const mockFs = require('mock-fs');
 const migrationListResolver = require('../../../lib/migrate/migration-list-resolver');
+const FsMigrations = require('../../../lib/migrate/sources/fs-migrations')
+  .FsMigrations;
 const path = require('path');
 
 chai.use(chaiSubset);
 
 describe('migration-list-resolver', () => {
-  describe('listAll - single directory', () => {
-    let absoluteConfigDirectory;
+  describe('listAll', () => {
+    let migrationSource;
     before(() => {
-      absoluteConfigDirectory = path.resolve(
-        process.cwd(),
-        'test/integration/migrate/migration'
-      );
+      migrationSource = new FsMigrations('test/integration/migrate/migration');
       mockFs({
         'test/integration/migrate/migration': {
           'co-migration.co': 'co migation content',
@@ -39,33 +38,27 @@ describe('migration-list-resolver', () => {
     });
 
     it('should include all supported extensions by default', () => {
-      return migrationListResolver
-        .listAll(absoluteConfigDirectory)
-        .then((list) => {
-          expect(list).to.containSubsetInOrder([
-            { file: 'co-migration.co' },
-            { file: 'coffee-migration.coffee' },
-            { file: 'eg-migration.eg' },
-            { file: 'iced-migration.iced' },
-            { file: 'js-migration.js' },
-            { file: 'litcoffee-migration.litcoffee' },
-            { file: 'ls-migration.ls' },
-            { file: 'ts-migration.ts' },
-          ]);
-
-          expect(list[0].directory.replace(/\\/g, '/')).to.include(
-            'knex/test/integration/migrate/migration'
-          );
-        });
+      return migrationListResolver.listAll(migrationSource).then((list) => {
+        expect(list).to.eql([
+          'co-migration.co',
+          'coffee-migration.coffee',
+          'eg-migration.eg',
+          'iced-migration.iced',
+          'js-migration.js',
+          'litcoffee-migration.litcoffee',
+          'ls-migration.ls',
+          'ts-migration.ts',
+        ]);
+      });
     });
 
     it('should include only files with specified extensions', function() {
       return migrationListResolver
-        .listAll(absoluteConfigDirectory, ['.ts', '.js'])
+        .listAll(migrationSource, ['.ts', '.js'])
         .then((list) => {
-          expect(list).to.containSubsetInOrder([
-            { file: 'js-migration.js' },
-            { file: 'ts-migration.ts' },
+          expect(list).to.eql([
+            'js-migration.js',
+            'ts-migration.ts',
           ]);
 
           expect(list[0].directory.replace(/\\/g, '/')).to.include(
@@ -104,13 +97,13 @@ describe('migration-list-resolver', () => {
       return migrationListResolver
         .listAll(absoluteConfigDirectory)
         .then((list) => {
-          expect(list).to.containSubsetInOrder([
-            { file: '001_migration.js' },
-            { file: '002_migration.js' },
-            { file: '003_migration.js' },
-            { file: '004_migration.js' },
-            { file: '005_migration.js' },
-            { file: '006_migration.js' },
+          expect(list).to.eql([
+            '001_migration.js',
+            '002_migration.js',
+            '003_migration.js',
+            '004_migration.js',
+            '005_migration.js',
+            '006_migration.js',
           ]);
 
           expect(list[0].directory.replace(/\\/g, '/')).to.include(
@@ -132,13 +125,13 @@ describe('migration-list-resolver', () => {
       return migrationListResolver
         .listAll(absoluteConfigDirectory, ['.js'], true)
         .then((list) => {
-          expect(list).to.containSubsetInOrder([
-            { file: '001_migration.js' },
-            { file: '005_migration.js' },
-            { file: '006_migration.js' },
-            { file: '002_migration.js' },
-            { file: '003_migration.js' },
-            { file: '004_migration.js' },
+          expect(list).to.eql([
+            '001_migration.js',
+            '005_migration.js',
+            '006_migration.js',
+            '002_migration.js',
+            '003_migration.js',
+            '004_migration.js',
           ]);
 
           expect(list[0].directory.replace(/\\/g, '/')).to.include(

--- a/test/unit/migrate/migration-list-resolver.js
+++ b/test/unit/migrate/migration-list-resolver.js
@@ -3,15 +3,10 @@
 'use strict';
 
 const chai = require('chai');
-const chaiSubset = require('chai-subset-in-order');
 const { expect } = require('chai');
 const mockFs = require('mock-fs');
 const migrationListResolver = require('../../../lib/migrate/migration-list-resolver');
-const FsMigrations = require('../../../lib/migrate/sources/fs-migrations')
-  .FsMigrations;
-const path = require('path');
-
-chai.use(chaiSubset);
+const FsMigrations = require('../../../lib/migrate/sources/fs-migrations');
 
 describe('migration-list-resolver', () => {
   describe('listAll', () => {

--- a/test/unit/migrate/migration-list-resolver.js
+++ b/test/unit/migrate/migration-list-resolver.js
@@ -57,24 +57,15 @@ describe('migration-list-resolver', () => {
         .listAll(migrationSource, ['.ts', '.js'])
         .then((list) => {
           expect(list).to.eql([
-            'js-migration.js',
-            'ts-migration.ts',
+            'test/integration/migrate/migration/js-migration.js',
+            'test/integration/migrate/migration/ts-migration.ts',
           ]);
-
-          expect(list[0].directory.replace(/\\/g, '/')).to.include(
-            'knex/test/integration/migrate/migration'
-          );
         });
     });
   });
 
   describe('listAll - multiple directories', () => {
-    let absoluteConfigDirectory;
     before(() => {
-      absoluteConfigDirectory = [
-        path.resolve(process.cwd(), 'test/integration/migrate/migration'),
-        path.resolve(process.cwd(), 'test/integration/migrate/seeds'),
-      ];
       mockFs({
         'test/integration/migrate/migration': {
           '006_migration.js': 'dummy',
@@ -94,8 +85,13 @@ describe('migration-list-resolver', () => {
     });
 
     it('should include files from both folders, sorted globally', () => {
+      const migrationSource = new FsMigrations([
+        'test/integration/migrate/migration',
+        'test/integration/migrate/seeds'
+      ]);
+
       return migrationListResolver
-        .listAll(absoluteConfigDirectory)
+        .listAll(migrationSource)
         .then((list) => {
           expect(list).to.eql([
             '001_migration.js',
@@ -105,47 +101,26 @@ describe('migration-list-resolver', () => {
             '005_migration.js',
             '006_migration.js',
           ]);
-
-          expect(list[0].directory.replace(/\\/g, '/')).to.include(
-            'knex/test/integration/migrate/migration'
-          );
-          expect(list[1].directory.replace(/\\/g, '/')).to.include(
-            'knex/test/integration/migrate/seeds'
-          );
-          expect(list[2].directory.replace(/\\/g, '/')).to.include(
-            'knex/test/integration/migrate/seeds'
-          );
-          expect(list[3].directory.replace(/\\/g, '/')).to.include(
-            'knex/test/integration/migrate/seeds'
-          );
         });
     });
 
     it('should include files from both folders, sorted within their folders', () => {
+      const migrationSource = new FsMigrations([
+        'test/integration/migrate/migration',
+        'test/integration/migrate/seeds'
+      ], true);
+
       return migrationListResolver
-        .listAll(absoluteConfigDirectory, ['.js'], true)
+        .listAll(migrationSource, ['.js'])
         .then((list) => {
           expect(list).to.eql([
-            '001_migration.js',
-            '005_migration.js',
-            '006_migration.js',
-            '002_migration.js',
-            '003_migration.js',
-            '004_migration.js',
+            'test/integration/migrate/migration/001_migration.js',
+            'test/integration/migrate/migration/005_migration.js',
+            'test/integration/migrate/migration/006_migration.js',
+            'test/integration/migrate/seeds/002_migration.js',
+            'test/integration/migrate/seeds/003_migration.js',
+            'test/integration/migrate/seeds/004_migration.js',
           ]);
-
-          expect(list[0].directory.replace(/\\/g, '/')).to.include(
-            'knex/test/integration/migrate/migration'
-          );
-          expect(list[1].directory.replace(/\\/g, '/')).to.include(
-            'knex/test/integration/migrate/migration'
-          );
-          expect(list[2].directory.replace(/\\/g, '/')).to.include(
-            'knex/test/integration/migrate/migration'
-          );
-          expect(list[3].directory.replace(/\\/g, '/')).to.include(
-            'knex/test/integration/migrate/seeds'
-          );
         });
     });
   });


### PR DESCRIPTION
This would allow a webpack migration source which is compatible with bundling. As an example:

``` typescript
const migrationConfig = config || {
    directory: path.resolve(__dirname, 'migrations'),
    migrationSource: new WebpackMigrationSource(require.context('./migrations', false)),
}

class WebpackMigrationSource {
    constructor(private migrationContext: __WebpackModuleApi.RequireContext) {}
    /**
   * Gets the migration names
   * @returns Promise<string[]>
   */
    getMigrations() {
        return Promise.resolve(this.migrationContext.keys())
    }

    getMigration(name: string) {
        return this.migrationContext(name)
    }
}
```

I can now use webpack and bundle my database migration project.