### PR TITLE
Extracts length from value wrapping to allow for prefix indexing.

### DIFF
--- a/src/dialects/mysql/index.js
+++ b/src/dialects/mysql/index.js
@@ -11,7 +11,7 @@ import SchemaCompiler from './schema/compiler';
 import TableCompiler from './schema/tablecompiler';
 import ColumnCompiler from './schema/columncompiler';
 
-import { assign, map } from 'lodash';
+import { assign, map, parseInt } from 'lodash';
 import { makeEscape } from '../../query/string';
 
 // Always initialize with the "QueryBuilder" and "QueryCompiler"
@@ -54,7 +54,16 @@ assign(Client_MySQL.prototype, {
   _escapeBinding: makeEscape(),
 
   wrapIdentifierImpl(value) {
-    return value !== '*' ? `\`${value.replace(/`/g, '``')}\`` : '*';
+    const subPartIndex = value.indexOf('(');
+    let subPart = '';
+    if (subPartIndex !== -1) {
+      const length = parseInt(value.slice(subPartIndex + 1, -1));
+      if (!isNaN(length)) {
+        value = value.slice(0, subPartIndex);
+        subPart = '(' + length + ')';
+      }
+    }
+    return value !== '*' ? `\`${value.replace(/`/g, '``')}\`` + subPart : '*';
   },
 
   // Get a raw connection, called by the `pool` whenever a new

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -300,6 +300,20 @@ module.exports = function(dialect) {
       );
     });
 
+    it('test adding prefix index', function() {
+      tableSql = client
+        .schemaBuilder()
+        .table('users', function() {
+          this.index(['foo', 'bar(128)'], 'baz');
+        })
+        .toSQL();
+
+      equal(1, tableSql.length);
+      expect(tableSql[0].sql).to.equal(
+        'alter table `users` add index `baz`(`foo`, `bar`(128))'
+      );
+    });
+
     it('test adding foreign key', function() {
       tableSql = client
         .schemaBuilder()


### PR DESCRIPTION
For an existing implementation, I've needed to add a prefix index.  index() does not support adding a column with a length, so I had to fall back on using raw() instead to add this index.  

I've extracted (_length_) from the value and parsed it to avoid SQL injection.  This length is re-introduced after the value is wrapped.