### PR TITLE
Allow table names with forUpdate/forShare (tgriesser/knex#2834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Feature/2690: Multiple migration directories #2735
 - Allow cloning query builder with .userParams({}) assigned to it #2802
 - Kill queries after timeout for PostgreSQL #2636
+- Allow table names with `forUpdate`/`forShare` #2834
 
 ### Bug fixes:
 

--- a/src/dialects/postgres/query/compiler.js
+++ b/src/dialects/postgres/query/compiler.js
@@ -75,8 +75,12 @@ assign(QueryCompiler_PG.prototype, {
     for (let i = 0; i < tables.length; i++) {
       let tableName = tables[i];
 
-      if (tableName && schemaName) tableName = `${schemaName}.${tableName}`;
-      if (tableName) sql.push(this.formatter.wrap(tableName));
+      if (tableName) {
+        if (schemaName) {
+          tableName = `${schemaName}.${tableName}`;
+        }
+        sql.push(this.formatter.wrap(tableName));
+      }
     }
 
     return sql.join(', ');

--- a/src/dialects/postgres/query/compiler.js
+++ b/src/dialects/postgres/query/compiler.js
@@ -67,12 +67,35 @@ assign(QueryCompiler_PG.prototype, {
     return value ? ` returning ${this.formatter.columnize(value)}` : '';
   },
 
+  // Join array of table names and apply default schema.
+  _tableNames(tables) {
+    const schemaName = this.single.schema;
+    const sql = [];
+
+    for (let i = 0; i < tables.length; i++) {
+      let tableName = tables[i];
+
+      if (tableName && schemaName) tableName = `${schemaName}.${tableName}`;
+      if (tableName) sql.push(this.formatter.wrap(tableName));
+    }
+
+    return sql.join(', ');
+  },
+
   forUpdate() {
-    return 'for update';
+    const tables = this.single.lockTables || [];
+
+    return (
+      'for update' + (tables.length ? ' of ' + this._tableNames(tables) : '')
+    );
   },
 
   forShare() {
-    return 'for share';
+    const tables = this.single.lockTables || [];
+
+    return (
+      'for share' + (tables.length ? ' of ' + this._tableNames(tables) : '')
+    );
   },
 
   // Compiles a columnInfo query

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -951,12 +951,14 @@ assign(Builder.prototype, {
   // Set a lock for update constraint.
   forUpdate() {
     this._single.lock = 'forUpdate';
+    this._single.lockTables = helpers.normalizeArr.apply(null, arguments);
     return this;
   },
 
   // Set a lock for share constraint.
   forShare() {
     this._single.lock = 'forShare';
+    this._single.lockTables = helpers.normalizeArr.apply(null, arguments);
     return this;
   },
 

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -6023,6 +6023,34 @@ describe('QueryBuilder', function() {
     );
   });
 
+  it('lock only some tables for update', function() {
+    testsql(
+      qb()
+        .select('*')
+        .from('foo')
+        .where('bar', '=', 'baz')
+        .forUpdate('lo', 'rem'),
+      {
+        mysql: {
+          sql: 'select * from `foo` where `bar` = ? for update',
+          bindings: ['baz'],
+        },
+        pg: {
+          sql: 'select * from "foo" where "bar" = ? for update of "lo", "rem"',
+          bindings: ['baz'],
+        },
+        mssql: {
+          sql: 'select * from [foo] with (UPDLOCK) where [bar] = ?',
+          bindings: ['baz'],
+        },
+        oracledb: {
+          sql: 'select * from "foo" where "bar" = ? for update',
+          bindings: ['baz'],
+        },
+      }
+    );
+  });
+
   it('allows insert values of sub-select, #121', function() {
     testsql(
       qb()


### PR DESCRIPTION
This implements optional table names to select locks that get applied in `SELECT … FOR UPDATE` and `SELECT … FOR SHARE` queries for PostgreSQL dialect. See #2834 for details and rationale.