### PR TITLE
Throw instead of process.exit when client module missing

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -215,10 +215,9 @@ assign(Client.prototype, {
     try {
       this.driver = this._driver();
     } catch (e) {
-      this.logger.error(
-        `Knex: run\n$ npm install ${this.driverName} --save\n${e.stack}`
-      );
-      process.exit(1);
+      const message = `Knex: run\n$ npm install ${this.driverName} --save`;
+      this.logger.error(`${message}\n${e.stack}`);
+      throw new Error(message);
     }
   },
 

--- a/src/client.js
+++ b/src/client.js
@@ -216,8 +216,8 @@ assign(Client.prototype, {
       this.driver = this._driver();
     } catch (e) {
       const message = `Knex: run\n$ npm install ${this.driverName} --save`;
-      this.logger.error(`${message}\n${e.stack}`);
-      throw new Error(message);
+      this.logger.error(`${message}\n${e.message}\n${e.stack}`);
+      throw new Error(`${message}\n${e.message}`);
     }
   },
 

--- a/test/unit/knex.js
+++ b/test/unit/knex.js
@@ -119,4 +119,10 @@ describe('knex', () => {
       return Promise.resolve();
     });
   });
+
+  it('throws if client module has not been installed', () => {
+    expect(knex({ client: 'oracle' })).to.throw(
+      /Knex: run\n$ npm install oracle/
+    );
+  });
 });


### PR DESCRIPTION
A couple of things - 

- The test relies on the `oracle` module not being in devDependencies. It will fail if it is ever added.
- I added the test to `test/unit/knex.js`, but I don't think the tests in this file are being run. I can't see the output for any of the tests in this file.