### PR TITLE
Adjust typing for forUpdate()/forShare() variant with table names

### DIFF
--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -457,8 +457,11 @@ declare namespace Knex {
     //TODO: Promise?
     columnInfo(column?: string): Bluebird<ColumnInfo>;
 
-    forUpdate(): QueryBuilder;
-    forShare(): QueryBuilder;
+    forUpdate(...tableNames: string[]): QueryBuilder;
+    forUpdate(tableNames: string[]): QueryBuilder;
+
+    forShare(...tableNames: string[]): QueryBuilder;
+    forShare(tableNames: string[]): QueryBuilder;
 
     toSQL(): Sql;
 


### PR DESCRIPTION
This is a followup to #2835 that became necessary with the merge of #2845. It adjust the typing of `forUpdate()` and `forShare()` to support the new call variants with table names.

It makes it possible to call `forUpdate()` and `forShare()` in either of the following three ways:

- `forUpdate()`
- `forUpdate('lorem', 'ipsum')`
- `forUpdate(['lorem', 'ipsum'])`