### PR TITLE
Add test for retrieving null dates

### DIFF
--- a/test/integration/builder/selects.js
+++ b/test/integration/builder/selects.js
@@ -735,6 +735,31 @@ module.exports = function(knex) {
       });
     });
 
+    it('#1276 - Dates NULL should be returned as NULL, not as new Date(null)', function() {
+      return knex.schema
+        .dropTableIfExists('DatesTest')
+        .createTable('DatesTest', function(table) {
+          table.increments('id').primary();
+          table.dateTime('dateTimeCol');
+          table.timestamp('timeStampCol');
+        })
+        .then(function() {
+          return knex('DatesTest').insert([
+            {
+              dateTimeCol: null,
+              timeStampCol: null,
+            },
+          ]);
+        })
+        .then(function() {
+          return knex('DatesTest').select();
+        })
+        .then(function(rows) {
+          expect(rows[0].dateTimeCol).to.equal(null);
+          expect(rows[0].timeStampCol).to.equal(null);
+        });
+    });
+
     it('has a "distinct" clause', function() {
       return Promise.all([
         knex('accounts')

--- a/test/integration/builder/selects.js
+++ b/test/integration/builder/selects.js
@@ -741,7 +741,7 @@ module.exports = function(knex) {
         .createTable('DatesTest', function(table) {
           table.increments('id').primary();
           table.dateTime('dateTimeCol');
-          table.timestamp('timeStampCol');
+          table.timestamp('timeStampCol').defaultTo(null); // MySQL defaults TIMESTAMP columns to current timestamp
           table.date('dateCol');
           table.time('timeCol');
         })

--- a/test/integration/builder/selects.js
+++ b/test/integration/builder/selects.js
@@ -742,12 +742,16 @@ module.exports = function(knex) {
           table.increments('id').primary();
           table.dateTime('dateTimeCol');
           table.timestamp('timeStampCol');
+          table.date('dateCol');
+          table.time('timeCol');
         })
         .then(function() {
           return knex('DatesTest').insert([
             {
               dateTimeCol: null,
               timeStampCol: null,
+              dateCol: null,
+              timeCol: null,
             },
           ]);
         })
@@ -757,6 +761,8 @@ module.exports = function(knex) {
         .then(function(rows) {
           expect(rows[0].dateTimeCol).to.equal(null);
           expect(rows[0].timeStampCol).to.equal(null);
+          expect(rows[0].dateCol).to.equal(null);
+          expect(rows[0].timeCol).to.equal(null);
         });
     });
 

--- a/test/integration/builder/selects.js
+++ b/test/integration/builder/selects.js
@@ -741,7 +741,10 @@ module.exports = function(knex) {
         .createTable('DatesTest', function(table) {
           table.increments('id').primary();
           table.dateTime('dateTimeCol');
-          table.timestamp('timeStampCol').defaultTo(null); // MySQL defaults TIMESTAMP columns to current timestamp
+          table
+            .timestamp('timeStampCol')
+            .nullable()
+            .defaultTo(null); // MySQL defaults TIMESTAMP columns to current timestamp
           table.date('dateCol');
           table.time('timeCol');
         })


### PR DESCRIPTION
Looks like original issue was only with Maria dialect which we no longer support. This adds test from https://github.com/tgriesser/knex/pull/1308/ to make sure that other dialects don't have same problem.

fixes #1276 