### PR TITLE
switch to uuid-random instead of uuid package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Node.js, featuring:
 Node.js versions 6+ are supported.
 
 [Read the full documentation to get started!](http://knexjs.org)
+[Or check out our Recipes wiki to search for solutions to some specific problems](https://github.com/tgriesser/knex/wiki/Recipes)
 
 For support and questions, join the `#bookshelf` channel on freenode IRC
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "dev": "rimraf ./lib && babel -w src --out-dir lib --copy-files",
     "lint": "eslint '{src,test}/**/*.js'",
     "plaintest": "mocha --exit -t 10000 -b -R spec test/index.js && npm run tape",
-    "prepublish": "npm run babel",
+    "prepare": "npm run babel",
     "pre_test": "npm run lint",
     "tape": "node test/tape/index.js | tap-spec",
     "debug_tape": "node --inspect-brk test/tape/index.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "pg-connection-string": "2.0.0",
     "tarn": "^1.1.4",
     "tildify": "1.2.0",
-    "uuid": "^3.3.2",
+    "uuid-random": "^1.0.6",
     "v8flags": "^3.1.1"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "lint": "eslint '{src,test}/**/*.js'",
     "plaintest": "mocha --exit -t 10000 -b -R spec test/index.js && npm run tape",
     "prepare": "npm run babel",
+    "postinstall": "npm run babel",
     "pre_test": "npm run lint",
     "tape": "node test/tape/index.js | tap-spec",
     "debug_tape": "node --inspect-brk test/tape/index.js",

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -19,7 +19,7 @@ import {
   has,
   keys,
 } from 'lodash';
-import uuid from 'uuid';
+import uuid from 'uuid-random';
 
 const debugBindings = debug('knex:bindings');
 
@@ -67,7 +67,7 @@ assign(QueryCompiler.prototype, {
       timeout: this.timeout,
       cancelOnTimeout: this.cancelOnTimeout,
       bindings: this.formatter.bindings || [],
-      __knexQueryUid: uuid.v4(),
+      __knexQueryUid: uuid(),
     };
 
     Object.defineProperties(query, {

--- a/src/raw.js
+++ b/src/raw.js
@@ -14,7 +14,7 @@ import {
   isNumber,
 } from 'lodash';
 import saveAsyncStack from './util/save-async-stack';
-import uuid from 'uuid';
+import uuid from 'uuid-random';
 
 const debugBindings = debug('knex:bindings');
 
@@ -109,7 +109,7 @@ assign(Raw.prototype, {
       );
     }
 
-    obj.__knexQueryUid = uuid.v4();
+    obj.__knexQueryUid = uuid();
 
     return obj;
   },


### PR DESCRIPTION
Because usage of synchronous functions inside "uuid" package performance suffers, if knex is used in context of node based web-server. I tested "uuid-random" package which increase performance by 30%. (despite of my commit comment, new package does use synchr. functions, but in optimized way)
