### PR TITLE
Add verbose option to CLI commands

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -186,6 +186,7 @@ function invoke(env) {
   commander
     .command('migrate:latest')
     .description('        Run all migrations that have not yet been run.')
+    .option('--verbose', 'verbose')
     .action(() => {
       pending = initKnex(env, commander.opts())
         .migrate.latest()
@@ -194,8 +195,8 @@ function invoke(env) {
             success(chalk.cyan('Already up to date'));
           }
           success(
-            chalk.green(`Batch ${batchNo} run: ${log.length} migrations \n`) +
-              chalk.cyan(log.join('\n'))
+            chalk.green(`Batch ${batchNo} run: ${log.length} migrations`) +
+              (argv.verbose ? `\n${chalk.cyan(log.join('\n'))}` : '')
           );
         })
         .catch(exit);
@@ -204,6 +205,7 @@ function invoke(env) {
   commander
     .command('migrate:rollback')
     .description('        Rollback the last set of migrations performed.')
+    .option('--verbose', 'verbose')
     .action(() => {
       pending = initKnex(env, commander.opts())
         .migrate.rollback()
@@ -213,8 +215,8 @@ function invoke(env) {
           }
           success(
             chalk.green(
-              `Batch ${batchNo} rolled back: ${log.length} migrations \n`
-            ) + chalk.cyan(log.join('\n'))
+              `Batch ${batchNo} rolled back: ${log.length} migrations`
+            ) + (argv.verbose ? `\n${chalk.cyan(log.join('\n'))}` : '')
           );
         })
         .catch(exit);
@@ -259,6 +261,7 @@ function invoke(env) {
   commander
     .command('seed:run')
     .description('        Run seed files.')
+    .option('--verbose', 'verbose')
     .action(() => {
       pending = initKnex(env, commander.opts())
         .seed.run()
@@ -267,9 +270,8 @@ function invoke(env) {
             success(chalk.cyan('No seed files exist'));
           }
           success(
-            chalk.green(
-              `Ran ${log.length} seed files \n${chalk.cyan(log.join('\n'))}`
-            )
+            chalk.green(`Ran ${log.length} seed files`) +
+              (argv.verbose ? `\n${chalk.cyan(log.join('\n'))}` : '')
           );
         })
         .catch(exit);

--- a/test/jake-util/helpers/migration-test-helper.js
+++ b/test/jake-util/helpers/migration-test-helper.js
@@ -9,12 +9,14 @@ function assertExec(cmd, desc) {
   desc = desc || 'Run ' + cmd;
   return new Promise((resolve, reject) => {
     let stderr = '';
-    console.log(`Executing: ${cmd}`);
+    let stdout = '';
+    // console.log(`Executing: ${cmd}`);
     const bin = jake.createExec([cmd]);
     bin.addListener('error', (msg, code) =>
       reject(Error(desc + ' FAIL. ' + stderr))
     );
-    bin.addListener('cmdEnd', resolve);
+    bin.addListener('cmdEnd', (cmd) => resolve({ cmd, stdout, stderr }));
+    bin.addListener('stdout', (data) => (stdout += data.toString()));
     bin.addListener('stderr', (data) => (stderr += data.toString()));
     bin.run();
   });
@@ -24,7 +26,7 @@ function assertExecError(cmd, desc) {
   desc = desc || 'Run ' + cmd;
   return new Promise((resolve, reject) => {
     let stderr = '';
-    console.log(`Executing: ${cmd}`);
+    // console.log(`Executing: ${cmd}`);
     const bin = jake.createExec([cmd]);
     bin.addListener('error', (msg, code) => {
       resolve(stderr);

--- a/test/jake-util/seeds-knexfile.js
+++ b/test/jake-util/seeds-knexfile.js
@@ -1,0 +1,9 @@
+module.exports = {
+  client: 'sqlite3',
+  connection: {
+    filename: __dirname + '/../test.sqlite3',
+  },
+  seeds: {
+    directory: __dirname + '/seeds',
+  },
+};

--- a/test/jake-util/seeds/first.js
+++ b/test/jake-util/seeds/first.js
@@ -1,0 +1,1 @@
+exports.seed = (knex, Promise) => {};

--- a/test/jake-util/seeds/second.js
+++ b/test/jake-util/seeds/second.js
@@ -1,0 +1,1 @@
+exports.seed = (knex, Promise) => {};

--- a/test/jake/jakelib/seed-test.js
+++ b/test/jake/jakelib/seed-test.js
@@ -4,6 +4,7 @@
 
 const path = require('path');
 const {
+  assertExec,
   assertExecError,
   test,
 } = require('../../jake-util/helpers/migration-test-helper');
@@ -13,6 +14,26 @@ const KNEX = path.normalize(__dirname + '/../../../bin/cli.js');
 
 const taskList = [];
 /* * * TESTS * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+test(taskList, 'seed:run prints non verbose logs', (temp) => {
+  return assertExec(
+    `node ${KNEX} seed:run --knexfile=test/jake-util/seeds-knexfile.js --knexpath=../knex.js`
+  ).then(({ stdout }) => {
+    assert.include(stdout, 'Ran 2 seed files');
+    assert.notInclude(stdout, 'first.js');
+    assert.notInclude(stdout, 'second.js');
+  });
+});
+
+test(taskList, 'seed:run prints verbose logs', (temp) => {
+  return assertExec(
+    `node ${KNEX} seed:run --knexfile=test/jake-util/seeds-knexfile.js --knexpath=../knex.js --verbose`
+  ).then(({ stdout }) => {
+    assert.include(stdout, 'Ran 2 seed files');
+    assert.include(stdout, 'first.js');
+    assert.include(stdout, 'second.js');
+  });
+});
 
 test(taskList, 'Handles seeding errors correctly', (temp) => {
   return assertExecError(


### PR DESCRIPTION
The following CLI commands get a `--verbose` option, which is used to determine whether to output the resulting log from the command action:

- `migrate:latest`
- `migrate:rollback`
- `seed:run`