### PR TITLE
Add withRecursive()

### DIFF
--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -47,7 +47,7 @@ inherits(Builder, EventEmitter);
 
 const validateWithArgs = function(alias, statement, method) {
   if (typeof alias !== 'string') {
-    throw new Error(method + '() first argument must be a string');
+    throw new Error(`${method}() first argument must be a string`);
   }
   if (
     typeof statement === 'function' ||
@@ -57,7 +57,7 @@ const validateWithArgs = function(alias, statement, method) {
     return;
   }
   throw new Error(
-    method + '() second argument must be a function / QueryBuilder or a raw'
+    `${method}() second argument must be a function / QueryBuilder or a raw`
   );
 };
 

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -678,14 +678,16 @@ assign(QueryCompiler.prototype, {
     if (!withs) return;
     const sql = [];
     let i = -1;
-    let recursive = '';
+    let isRecursive = false;
     while (++i < withs.length) {
       const stmt = withs[i];
-      if (stmt.recursive) recursive = 'recursive ';
+      if (stmt.recursive) {
+        isRecursive = true;
+      }
       const val = this[stmt.type](stmt);
       sql.push(val);
     }
-    return 'with ' + recursive + sql.join(', ') + ' ';
+    return `with ${isRecursive ? 'recursive ' : ''}${sql.join(', ')} `;
   },
 
   withWrapped(statement) {

--- a/src/query/compiler.js
+++ b/src/query/compiler.js
@@ -678,12 +678,14 @@ assign(QueryCompiler.prototype, {
     if (!withs) return;
     const sql = [];
     let i = -1;
+    let recursive = '';
     while (++i < withs.length) {
       const stmt = withs[i];
+      if (stmt.recursive) recursive = 'recursive ';
       const val = this[stmt.type](stmt);
       sql.push(val);
     }
-    return 'with ' + sql.join(', ') + ' ';
+    return 'with ' + recursive + sql.join(', ') + ' ';
   },
 
   withWrapped(statement) {

--- a/src/query/methods.js
+++ b/src/query/methods.js
@@ -2,6 +2,7 @@
 // from the `knex` object, e.g. `knex.select('*').from(...`
 export default [
   'with',
+  'withRecursive',
   'select',
   'as',
   'columns',

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -8308,6 +8308,44 @@ describe('QueryBuilder', function() {
     );
   });
 
+  it("nested and chained wrapped 'withRecursive' clause", function() {
+    testsql(
+      qb()
+        .withRecursive('firstWithClause', function() {
+          this.withRecursive('firstWithSubClause', function() {
+            this.select('foo')
+              .as('foz')
+              .from('users');
+          })
+            .select('*')
+            .from('firstWithSubClause');
+        })
+        .withRecursive('secondWithClause', function() {
+          this.withRecursive('secondWithSubClause', function() {
+            this.select('bar')
+              .as('baz')
+              .from('users');
+          })
+            .select('*')
+            .from('secondWithSubClause');
+        })
+        .select('*')
+        .from('secondWithClause'),
+      {
+        mssql:
+          'with recursive [firstWithClause] as (with recursive [firstWithSubClause] as ((select [foo] from [users]) as [foz]) select * from [firstWithSubClause]), [secondWithClause] as (with recursive [secondWithSubClause] as ((select [bar] from [users]) as [baz]) select * from [secondWithSubClause]) select * from [secondWithClause]',
+        sqlite3:
+          'with recursive `firstWithClause` as (with recursive `firstWithSubClause` as ((select `foo` from `users`) as `foz`) select * from `firstWithSubClause`), `secondWithClause` as (with recursive `secondWithSubClause` as ((select `bar` from `users`) as `baz`) select * from `secondWithSubClause`) select * from `secondWithClause`',
+        pg:
+          'with recursive "firstWithClause" as (with recursive "firstWithSubClause" as ((select "foo" from "users") as "foz") select * from "firstWithSubClause"), "secondWithClause" as (with recursive "secondWithSubClause" as ((select "bar" from "users") as "baz") select * from "secondWithSubClause") select * from "secondWithClause"',
+        'pg-redshift':
+          'with recursive "firstWithClause" as (with recursive "firstWithSubClause" as ((select "foo" from "users") as "foz") select * from "firstWithSubClause"), "secondWithClause" as (with recursive "secondWithSubClause" as ((select "bar" from "users") as "baz") select * from "secondWithSubClause") select * from "secondWithClause"',
+        oracledb:
+          'with recursive "firstWithClause" as (with recursive "firstWithSubClause" as ((select "foo" from "users") "foz") select * from "firstWithSubClause"), "secondWithClause" as (with recursive "secondWithSubClause" as ((select "bar" from "users") "baz") select * from "secondWithSubClause") select * from "secondWithClause"',
+      }
+    );
+  });
+
   describe('#2263, update / delete queries in with syntax', () => {
     it('with update query passed as raw', () => {
       testquery(


### PR DESCRIPTION
Closes  #1755, an alternative to #2218

I needed `WITH RECURSIVE` in a project recently so I monkey patched this in and it works great 👌, figured I'd help out the upstream.

I noticed the other PR tried to handle the `UNION ALL` automatically for the recursive section, but in my case I actually wanted just a `UNION`. I think simply having this method add the `RECURSIVE` keyword is the way to go since it's trivial to do the `.union(...)` or `.unionAll(...)` or whatever one needs in the query section of the `.withRecursive()` method.

Future improvements might include a `raw` version, but I think getting this added in its simplest form is an easy win.