### PR TITLE
Added option to pass indexType for MySQL dialect

### DIFF
--- a/src/dialects/mysql/schema/tablecompiler.js
+++ b/src/dialects/mysql/schema/tablecompiler.js
@@ -199,8 +199,9 @@ assign(TableCompiler_MySQL.prototype, {
       ? this.formatter.wrap(indexName)
       : this._indexCommand('index', this.tableNameRaw, columns);
     this.pushQuery(
-      `alter table ${this.tableName()} add ${indexType ||
-        ''} index ${indexName}(${this.formatter.columnize(columns)})`
+      `alter table ${this.tableName()} add${
+        indexType ? ` ${indexType}` : ''
+      } index ${indexName}(${this.formatter.columnize(columns)})`
     );
   },
 

--- a/src/dialects/mysql/schema/tablecompiler.js
+++ b/src/dialects/mysql/schema/tablecompiler.js
@@ -194,14 +194,13 @@ assign(TableCompiler_MySQL.prototype, {
       })
     );
   },
-  index(columns, indexName) {
+  index(columns, indexName, indexType) {
     indexName = indexName
       ? this.formatter.wrap(indexName)
       : this._indexCommand('index', this.tableNameRaw, columns);
     this.pushQuery(
-      `alter table ${this.tableName()} add index ${indexName}(${this.formatter.columnize(
-        columns
-      )})`
+      `alter table ${this.tableName()} add ${indexType ||
+        ''} index ${indexName}(${this.formatter.columnize(columns)})`
     );
   },
 

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -300,7 +300,7 @@ module.exports = function(dialect) {
       );
     });
 
-    it('test adding index with type', function() {
+    it('test adding index with an index type', function() {
       tableSql = client
         .schemaBuilder()
         .table('users', function() {

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -300,6 +300,20 @@ module.exports = function(dialect) {
       );
     });
 
+    it('test adding index with type', function() {
+      tableSql = client
+        .schemaBuilder()
+        .table('users', function() {
+          this.index(['foo', 'bar'], 'baz', 'FULLTEXT');
+        })
+        .toSQL();
+
+      equal(1, tableSql.length);
+      expect(tableSql[0].sql).to.equal(
+        'alter table `users` add FULLTEXT index `baz`(`foo`, `bar`)'
+      );
+    });
+
     it('test adding foreign key', function() {
       tableSql = client
         .schemaBuilder()


### PR DESCRIPTION
I followed the [MySQL Reference](https://dev.mysql.com/doc/refman/8.0/en/create-index.html).

```sql
CREATE [UNIQUE | FULLTEXT | SPATIAL] INDEX index_name
    [index_type]
    ON tbl_name (key_part,...)
    [index_option]
    [algorithm_option | lock_option] ...

key_part: {col_name [(length)] | (expr)} [ASC | DESC]

index_option:
    KEY_BLOCK_SIZE [=] value
  | index_type
  | WITH PARSER parser_name
  | COMMENT 'string'
  | {VISIBLE | INVISIBLE}

index_type:
    USING {BTREE | HASH}

algorithm_option:
    ALGORITHM [=] {DEFAULT | INPLACE | COPY}

lock_option:
    LOCK [=] {DEFAULT | NONE | SHARED | EXCLUSIVE}
```

No changes are required in `types/knex.d.ts`.

I'm not sure if I need to write tests for this, I could not find where the MySQL schema tests are written.

Steps to reproduce:

1. Add my fork as dependency in package.json:
```json
"knex": "git+https://github.com/douglasjunior/knex.git#custom"
```

2. Create a migration file:
```js
exports.up = (knex, Promise) => {
    return  knex.schema.createTable('my_table', table => {
        table.bigIncrements('id');

        table.string('my_long_text_column', 1000).notNullable();

        table.index('my_long_text_column', null, 'FULLTEXT'); // <= here
    });
};

exports.down = (knex, Promise) => {
    return knex.schema.dropTableIfExists('my_table');
};
```

3. Run `npx knex migrate:latest`.

4. See the generated schema:
```sql
CREATE TABLE `my_table` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  `my_long_text_column` varchar(1000) NOT NULL,
  PRIMARY KEY (`id`),
  FULLTEXT KEY `my_table_my_long_text_column_index` (`nome_original`)
) 
```

Related to #1840 

