### PR TITLE
Fix failed migration filename

### DIFF
--- a/src/migrate/Migrator.js
+++ b/src/migrate/Migrator.js
@@ -190,15 +190,14 @@ export default class Migrator {
       this._getLock(trx)
         // When there is a wrapping transaction, some migrations
         // could have been done while waiting for the lock:
-        .then(
-          () =>
-            trx
-              ? migrationListResolver.listCompleted(
-                  this.config.tableName,
-                  this.config.schemaName,
-                  trx
-                )
-              : []
+        .then(() =>
+          trx
+            ? migrationListResolver.listCompleted(
+                this.config.tableName,
+                this.config.schemaName,
+                trx
+              )
+            : []
         )
         .then(
           (completed) =>
@@ -336,6 +335,7 @@ export default class Migrator {
       // We're going to run each of the migrations in the current "up".
       current = current
         .then(() => {
+          this._activeMigration.fileName = name;
           if (
             !trx &&
             this._useTransaction(migrationContent, disableTransactions)

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -176,13 +176,15 @@ module.exports = function(knex) {
 
       it('should release lock if non-locking related error is thrown', function() {
         return knex.migrate
-          .latest({ directory: 'test/integration/migrate/test' })
+          .latest({ directory: 'test/integration/migrate/test_with_invalid' })
           .then(function() {
             throw new Error('then should not execute');
           })
           .catch(function(error) {
             // This will fail because of the invalid migration
-            expect(error).to.have.property('message');
+            expect(error)
+              .to.have.property('message')
+              .that.includes('unknown_table');
             return knex('knex_migrations_lock').select('*');
           })
           .then(function(data) {
@@ -606,7 +608,7 @@ module.exports = function(knex) {
 
     it('should not create unexpected tables', function() {
       const table = 'migration_test_2_1';
-      knex.schema.hasTable(table).then(function(exists) {
+      return knex.schema.hasTable(table).then(function(exists) {
         expect(exists).to.equal(false);
       });
     });


### PR DESCRIPTION
re: #2602 

Failing migrations report that the *latest* migration file failed, rather than the migration file that was being applied when the error occurred.

The existing test suite shows this behaviour:
```
migration file "20150109095253_migration_after_invalid.js" failed
migration failed with error: SELECT foo FROM unknown_table - SQLITE_ERROR: no such table: unknown_table
```

After:
```
migration file "20150109002832_invalid_migration.js" failed
migration failed with error: SELECT foo FROM unknown_table - SQLITE_ERROR: no such table: unknown_table
```