### PR TITLE
Align signature for PG datetime and timestamp methods with docs

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,7 +3,7 @@
 ### Upgrading to version 0.16.0+
 
 * MSSQL: DB versions older than 2008 are no longer supported, make sure to update your DB;
-* PostgreSQL: second argument for `table.datetime(name, [useTz], [precision])` and `table.timestamp(name, [useTz], [precision])` now correctly expects `TRUE` value for `timestamptz` and `FALSE` for `timestamp` type. In previous versions this behaviour was reversed. 
+* PostgreSQL|MySQL: it is recommended to use options object for `table.datetime` and `table.timestamp` methods instead of argument options. See documentation for these methods for more details. 
 
 ### Upgrading to version 0.15.0+
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,7 @@
 ### Upgrading to version 0.16.0+
 
 * MSSQL: DB versions older than 2008 are no longer supported, make sure to update your DB;
+* PostgreSQL: second argument for `table.datetime(name, [useTz], [precision])` and `table.timestamp(name, [useTz], [precision])` now correctly expects `TRUE` value for `timestamptz` and `FALSE` for `timestamp` type. In previous versions this behaviour was reversed. 
 
 ### Upgrading to version 0.15.0+
 

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -3,7 +3,7 @@
 import inherits from 'inherits';
 import ColumnCompiler from '../../../schema/columncompiler';
 
-import { assign } from 'lodash';
+import { isObject } from 'lodash';
 
 function ColumnCompiler_MySQL() {
   ColumnCompiler.apply(this, arguments);
@@ -22,7 +22,7 @@ inherits(ColumnCompiler_MySQL, ColumnCompiler);
 // Types
 // ------
 
-assign(ColumnCompiler_MySQL.prototype, {
+Object.assign(ColumnCompiler_MySQL.prototype, {
   increments: 'int unsigned not null auto_increment primary key',
 
   bigincrements: 'bigint unsigned not null auto_increment primary key',
@@ -74,18 +74,30 @@ assign(ColumnCompiler_MySQL.prototype, {
   },
 
   datetime(precision) {
+    if (isObject(precision)) {
+      ({ precision } = precision);
+    }
+
     return typeof precision === 'number'
       ? `datetime(${precision})`
       : 'datetime';
   },
 
   timestamp(precision) {
+    if (isObject(precision)) {
+      ({ precision } = precision);
+    }
+
     return typeof precision === 'number'
       ? `timestamp(${precision})`
       : 'timestamp';
   },
 
   time(precision) {
+    if (isObject(precision)) {
+      ({ precision } = precision);
+    }
+
     return typeof precision === 'number' ? `time(${precision})` : 'time';
   },
 

--- a/src/dialects/postgres/schema/columncompiler.js
+++ b/src/dialects/postgres/schema/columncompiler.js
@@ -63,20 +63,26 @@ Object.assign(ColumnCompiler_PG.prototype, {
   smallint: 'smallint',
   tinyint: 'smallint',
   datetime(withoutTz = false, precision) {
+    let useTz;
     if (isObject(withoutTz)) {
-      ({ withoutTz, precision } = withoutTz);
+      ({ useTz, precision } = withoutTz);
+    } else {
+      useTz = !withoutTz;
     }
 
-    return `${withoutTz ? 'timestamp' : 'timestamptz'}${
+    return `${useTz ? 'timestamptz' : 'timestamp'}${
       precision ? '(' + precision + ')' : ''
     }`;
   },
   timestamp(withoutTz = false, precision) {
+    let useTz;
     if (isObject(withoutTz)) {
-      ({ withoutTz, precision } = withoutTz);
+      ({ useTz, precision } = withoutTz);
+    } else {
+      useTz = !withoutTz;
     }
 
-    return `${withoutTz ? 'timestamp' : 'timestamptz'}${
+    return `${useTz ? 'timestamptz' : 'timestamp'}${
       precision ? '(' + precision + ')' : ''
     }`;
   },

--- a/src/dialects/postgres/schema/columncompiler.js
+++ b/src/dialects/postgres/schema/columncompiler.js
@@ -63,11 +63,15 @@ assign(ColumnCompiler_PG.prototype, {
   },
   smallint: 'smallint',
   tinyint: 'smallint',
-  datetime(without) {
-    return without ? 'timestamp' : 'timestamptz';
+  datetime(useTz = true, precision) {
+    return `${useTz ? 'timestamptz' : 'timestamp'}${
+      precision ? '(' + precision + ')' : ''
+    }`;
   },
-  timestamp(without) {
-    return without ? 'timestamp' : 'timestamptz';
+  timestamp(useTz = true, precision) {
+    return `${useTz ? 'timestamptz' : 'timestamp'}${
+      precision ? '(' + precision + ')' : ''
+    }`;
   },
   uuid: 'uuid',
 

--- a/src/dialects/postgres/schema/columncompiler.js
+++ b/src/dialects/postgres/schema/columncompiler.js
@@ -3,8 +3,7 @@
 
 import inherits from 'inherits';
 import ColumnCompiler from '../../../schema/columncompiler';
-
-import { assign } from 'lodash';
+import { isObject } from 'lodash';
 
 function ColumnCompiler_PG() {
   ColumnCompiler.apply(this, arguments);
@@ -12,7 +11,7 @@ function ColumnCompiler_PG() {
 }
 inherits(ColumnCompiler_PG, ColumnCompiler);
 
-assign(ColumnCompiler_PG.prototype, {
+Object.assign(ColumnCompiler_PG.prototype, {
   // Types
   // ------
   bigincrements: 'bigserial primary key',
@@ -63,13 +62,21 @@ assign(ColumnCompiler_PG.prototype, {
   },
   smallint: 'smallint',
   tinyint: 'smallint',
-  datetime(useTz = true, precision) {
-    return `${useTz ? 'timestamptz' : 'timestamp'}${
+  datetime(withoutTz = false, precision) {
+    if (isObject(withoutTz)) {
+      ({ withoutTz, precision } = withoutTz);
+    }
+
+    return `${withoutTz ? 'timestamp' : 'timestamptz'}${
       precision ? '(' + precision + ')' : ''
     }`;
   },
-  timestamp(useTz = true, precision) {
-    return `${useTz ? 'timestamptz' : 'timestamp'}${
+  timestamp(withoutTz = false, precision) {
+    if (isObject(withoutTz)) {
+      ({ withoutTz, precision } = withoutTz);
+    }
+
+    return `${withoutTz ? 'timestamp' : 'timestamptz'}${
       precision ? '(' + precision + ')' : ''
     }`;
   },

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -1,7 +1,5 @@
 /*global describe, expect, it*/
 
-'use strict';
-
 const sinon = require('sinon');
 const MySQL_Client = require('../../../lib/dialects/mysql');
 const MySQL2_Client = require('../../../lib/dialects/mysql2');
@@ -719,11 +717,11 @@ module.exports = function(dialect) {
       );
     });
 
-    it('test adding date', function() {
+    it('test adding date', () => {
       tableSql = client
         .schemaBuilder()
-        .table('users', function() {
-          this.date('foo');
+        .table('users', (table) => {
+          table.date('foo');
         })
         .toSQL();
 
@@ -731,11 +729,11 @@ module.exports = function(dialect) {
       expect(tableSql[0].sql).to.equal('alter table `users` add `foo` date');
     });
 
-    it('test adding date time', function() {
+    it('test adding date time', () => {
       tableSql = client
         .schemaBuilder()
-        .table('users', function() {
-          this.dateTime('foo');
+        .table('users', (table) => {
+          table.dateTime('foo');
         })
         .toSQL();
 
@@ -745,11 +743,25 @@ module.exports = function(dialect) {
       );
     });
 
-    it('test adding time', function() {
+    it('test adding date time with options object', () => {
       tableSql = client
         .schemaBuilder()
-        .table('users', function() {
-          this.time('foo');
+        .table('users', (table) => {
+          table.dateTime('foo', { precision: 3 });
+        })
+        .toSQL();
+
+      equal(1, tableSql.length);
+      expect(tableSql[0].sql).to.equal(
+        'alter table `users` add `foo` datetime(3)'
+      );
+    });
+
+    it('test adding time', () => {
+      tableSql = client
+        .schemaBuilder()
+        .table('users', (table) => {
+          table.time('foo');
         })
         .toSQL();
 
@@ -757,17 +769,43 @@ module.exports = function(dialect) {
       expect(tableSql[0].sql).to.equal('alter table `users` add `foo` time');
     });
 
-    it('test adding time stamp', function() {
+    it('test adding time with options object', () => {
       tableSql = client
         .schemaBuilder()
-        .table('users', function() {
-          this.timestamp('foo');
+        .table('users', (table) => {
+          table.time('foo', { precision: 3 });
+        })
+        .toSQL();
+
+      equal(1, tableSql.length);
+      expect(tableSql[0].sql).to.equal('alter table `users` add `foo` time(3)');
+    });
+
+    it('test adding time stamp', () => {
+      tableSql = client
+        .schemaBuilder()
+        .table('users', (table) => {
+          table.timestamp('foo');
         })
         .toSQL();
 
       equal(1, tableSql.length);
       expect(tableSql[0].sql).to.equal(
         'alter table `users` add `foo` timestamp'
+      );
+    });
+
+    it('test adding time stamp with options object', () => {
+      tableSql = client
+        .schemaBuilder()
+        .table('users', (table) => {
+          table.timestamp('foo', { precision: 3 });
+        })
+        .toSQL();
+
+      equal(1, tableSql.length);
+      expect(tableSql[0].sql).to.equal(
+        'alter table `users` add `foo` timestamp(3)'
       );
     });
 

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -9,7 +9,6 @@ const PG_Client = require('../../../lib/dialects/postgres');
 const client = new PG_Client({ client: 'pg' });
 const knex = require('../../../knex');
 
-const { expect } = require('chai');
 const equal = require('chai').assert.equal;
 
 describe('PostgreSQL Config', function() {

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -1033,12 +1033,12 @@ describe('PostgreSQL SchemaBuilder', function() {
     tableSql = client
       .schemaBuilder()
       .table('users', (table) => {
-        table.timestamp('foo', { useTz: true, precision: 3 });
+        table.timestamp('foo', { useTz: false, precision: 3 });
       })
       .toSQL();
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
-      'alter table "users" add column "foo" timestamptz(3)'
+      'alter table "users" add column "foo" timestamp(3)'
     );
   });
 
@@ -1046,12 +1046,12 @@ describe('PostgreSQL SchemaBuilder', function() {
     tableSql = client
       .schemaBuilder()
       .table('users', (table) => {
-        table.datetime('foo', { useTz: true, precision: 3 });
+        table.datetime('foo', { useTz: false, precision: 3 });
       })
       .toSQL();
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
-      'alter table "users" add column "foo" timestamptz(3)'
+      'alter table "users" add column "foo" timestamp(3)'
     );
   });
 

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -9,6 +9,7 @@ const PG_Client = require('../../../lib/dialects/postgres');
 const client = new PG_Client({ client: 'pg' });
 const knex = require('../../../knex');
 
+const { expect } = require('chai');
 const equal = require('chai').assert.equal;
 
 describe('PostgreSQL Config', function() {
@@ -953,10 +954,10 @@ describe('PostgreSQL SchemaBuilder', function() {
     );
   });
 
-  it('adding date time', function() {
+  it('adding date time', () => {
     tableSql = client
       .schemaBuilder()
-      .table('users', function(table) {
+      .table('users', (table) => {
         table.dateTime('foo');
       })
       .toSQL();
@@ -966,10 +967,10 @@ describe('PostgreSQL SchemaBuilder', function() {
     );
   });
 
-  it('adding time', function() {
+  it('adding time', () => {
     tableSql = client
       .schemaBuilder()
-      .table('users', function(table) {
+      .table('users', (table) => {
         table.time('foo');
       })
       .toSQL();
@@ -979,10 +980,10 @@ describe('PostgreSQL SchemaBuilder', function() {
     );
   });
 
-  it('adding timestamp', function() {
+  it('adding default timestamp', () => {
     tableSql = client
       .schemaBuilder()
-      .table('users', function(table) {
+      .table('users', (table) => {
         table.timestamp('foo');
       })
       .toSQL();
@@ -992,10 +993,49 @@ describe('PostgreSQL SchemaBuilder', function() {
     );
   });
 
-  it('adding timestamps', function() {
+  it('adding timestamp with timezone', () => {
     tableSql = client
       .schemaBuilder()
-      .table('users', function(table) {
+      .table('users', (table) => {
+        table.timestamp('foo', true);
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamptz'
+    );
+  });
+
+  it('adding timestamp without timezone', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
+        table.timestamp('foo', false);
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamp'
+    );
+  });
+
+  it('adding timestamp with precision', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
+        table.timestamp('foo', undefined, 2);
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamptz(2)'
+    );
+  });
+
+  it('adding timestamps', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
         table.timestamps();
       })
       .toSQL();
@@ -1005,10 +1045,10 @@ describe('PostgreSQL SchemaBuilder', function() {
     );
   });
 
-  it('adding timestamps with defaults', function() {
+  it('adding timestamps with defaults', () => {
     tableSql = client
       .schemaBuilder()
-      .table('users', function(table) {
+      .table('users', (table) => {
         table.timestamps(false, true);
       })
       .toSQL();

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -1,7 +1,5 @@
 /*global describe, expect, it*/
 
-'use strict';
-
 let tableSql;
 
 const sinon = require('sinon');
@@ -996,7 +994,7 @@ describe('PostgreSQL SchemaBuilder', function() {
     tableSql = client
       .schemaBuilder()
       .table('users', (table) => {
-        table.timestamp('foo', true);
+        table.timestamp('foo', false);
       })
       .toSQL();
     equal(1, tableSql.length);
@@ -1009,7 +1007,7 @@ describe('PostgreSQL SchemaBuilder', function() {
     tableSql = client
       .schemaBuilder()
       .table('users', (table) => {
-        table.timestamp('foo', false);
+        table.timestamp('foo', true);
       })
       .toSQL();
     equal(1, tableSql.length);
@@ -1028,6 +1026,32 @@ describe('PostgreSQL SchemaBuilder', function() {
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
       'alter table "users" add column "foo" timestamptz(2)'
+    );
+  });
+
+  it('adding timestamp with options object', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
+        table.timestamp('foo', { useTz: true, precision: 3 });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamptz(3)'
+    );
+  });
+
+  it('adding datetime with options object', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
+        table.datetime('foo', { useTz: true, precision: 3 });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamptz(3)'
     );
   });
 


### PR DESCRIPTION
fixes #2916 
Also I've noticed that PG also supports precision, and there was no good reason not to add it :)