### PR TITLE
remove useless 'use strict'

### DIFF
--- a/src/dialects/redshift/schema/columnbuilder.js
+++ b/src/dialects/redshift/schema/columnbuilder.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import inherits from 'inherits';
 import ColumnBuilder from '../../../schema/columnbuilder';
 

--- a/src/ref.js
+++ b/src/ref.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import Raw from './raw';
 
 class Ref extends Raw {


### PR DESCRIPTION
'use strict' and import/export are not meant to be together.