### PR TITLE
Add new command to print migrations

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -26,6 +26,15 @@ function success(text) {
   process.exit(0);
 }
 
+function checkMigrationDirection(direction) {
+  if (!direction) return;
+
+  if (direction !== 'up' && direction !== 'down') {
+    console.log(chalk.red('Direction is invalid'));
+    exit('Try to pass: up or down.');
+  }
+}
+
 function checkLocalModule(env) {
   if (!env.modulePath) {
     console.log(
@@ -239,8 +248,12 @@ function invoke(env) {
   commander
     .command('migrate:print')
     .description('Print all migrations in directory')
-    .option('--direction', 'Specify migration direction to print. It can be "up" or "down"')
+    .option(
+      '--direction',
+      'Specify migration direction to print. It can be "up" or "down"'
+    )
     .action(function() {
+      checkMigrationDirection(argv.direction);
       const direction = argv.direction || 'all';
 
       pending = initKnex(env)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -237,14 +237,14 @@ function invoke(env) {
     });
 
   commander
-    .command('migrate:printAll')
+    .command('migrate:print')
     .description('Print all migrations on directory')
     .option('--direction', 'Specify migration direction to print')
     .action(function() {
       const direction = argv.direction || 'all';
 
       pending = initKnex(env)
-        .migrate.printAll(direction)
+        .migrate.print(direction)
         .then(function() {
           process.exit(0);
         })

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -238,8 +238,8 @@ function invoke(env) {
 
   commander
     .command('migrate:print')
-    .description('Print all migrations on directory')
-    .option('--direction', 'Specify migration direction to print')
+    .description('Print all migrations in directory')
+    .option('--direction', 'Specify migration direction to print. It can be "up" or "down"')
     .action(function() {
       const direction = argv.direction || 'all';
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -237,6 +237,21 @@ function invoke(env) {
     });
 
   commander
+    .command('migrate:printAll')
+    .description('Print all migrations on directory')
+    .option('--direction', 'Specify migration direction to print')
+    .action(function() {
+      const direction = argv.direction || 'all';
+
+      pending = initKnex(env)
+        .migrate.printAll(direction)
+        .then(function() {
+          process.exit(0);
+        })
+        .catch(exit);
+    });
+
+  commander
     .command('seed:make <name>')
     .description('        Create a named seed file.')
     .option(

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -27,11 +27,13 @@ function success(text) {
 }
 
 function checkMigrationDirection(direction) {
-  if (!direction) return;
+  if (!direction) {
+    return;
+  }
 
   if (direction !== 'up' && direction !== 'down') {
     console.log(chalk.red('Direction is invalid'));
-    exit('Try to pass: up or down.');
+    exit('Supported directions: up, down');
   }
 }
 
@@ -252,13 +254,14 @@ function invoke(env) {
       '--direction',
       'Specify migration direction to print. It can be "up" or "down"'
     )
-    .action(function() {
-      checkMigrationDirection(argv.direction);
-      const direction = argv.direction || 'all';
+    .action(() => {
+      const directionOption = argv.direction && argv.direction.toLowerCase();
+      checkMigrationDirection(directionOption);
+      const direction = directionOption || 'all';
 
-      pending = initKnex(env)
+      pending = initKnex(env, commander.opts())
         .migrate.print(direction)
-        .then(function() {
+        .then(() => {
           process.exit(0);
         })
         .catch(exit);

--- a/src/migrate/MigrationGenerator.js
+++ b/src/migrate/MigrationGenerator.js
@@ -24,33 +24,36 @@ export default class MigrationGenerator {
       .then((val) => this._writeNewMigration(name, val));
   }
 
-  print(migrationListResolver, config, direction) {
+  print(migrationListResolver, knex, config, direction) {
     return migrationListResolver
       .listAll(config.migrationSource)
       .then((migrationFiles) => {
         let current = Promise.bind({ failed: false, failedOn: 0 });
 
         each(migrationFiles, (migrationFile) => {
-          const directory = config.directory;
-          const migration = require(directory + '/' + migrationFile);
+          const directory = path.resolve(
+            process.cwd(),
+            migrationFile.directory
+          );
+          const migration = require(directory + '/' + migrationFile.file);
 
           if (direction === 'up' || direction === 'all') {
             current = current.then(() => {
               /* eslint-disable no-console */
-              console.log(`\n${migrationFile}`);
+              console.log(`\n${migrationFile.file}`);
               console.log('======== UP ==========');
               /* eslint-enable no-console */
-              return migration['up'](this.knex, Promise);
+              return migration['up'](knex, Promise);
             });
           }
 
           if (direction === 'down' || direction === 'all') {
             current = current.then(() => {
               /* eslint-disable no-console */
-              console.log(`\n${migrationFile}`);
+              console.log(`\n${migrationFile.file}`);
               console.log('======== DOWN ==========');
               /* eslint-enable no-console */
-              return migration['down'](this.knex, Promise);
+              return migration['down'](knex, Promise);
             });
           }
         });

--- a/src/migrate/Migrator.js
+++ b/src/migrate/Migrator.js
@@ -155,7 +155,9 @@ export default class Migrator {
   print(direction) {
     global.print = true;
 
-    return this.generator.print(migrationListResolver, this.config, direction);
+    return this.generator
+      .print(migrationListResolver, this.knex, this.config, direction)
+      .finally(() => delete global.print);
   }
 
   _isLocked(trx) {

--- a/src/migrate/Migrator.js
+++ b/src/migrate/Migrator.js
@@ -152,6 +152,12 @@ export default class Migrator {
     return this.generator.make(name, this.config);
   }
 
+  print(direction) {
+    global.print = true;
+
+    return this.generator.print(migrationListResolver, this.config, direction);
+  }
+
   _isLocked(trx) {
     const tableName = getLockTableName(this.config.tableName);
     return getTable(this.knex, tableName, this.config.schemaName)

--- a/src/migrate/Migrator.js
+++ b/src/migrate/Migrator.js
@@ -204,7 +204,6 @@ export default class Migrator {
                 trx
               )
             : []
-<<<<<<< HEAD:src/migrate/Migrator.js
         )
         .then(
           (completed) =>
@@ -213,8 +212,6 @@ export default class Migrator {
               migrations,
               completed
             ))
-=======
->>>>>>> Added new command to print migrations:src/migrate/index.js
         )
         .then(() =>
           Promise.all(

--- a/src/migrate/Migrator.js
+++ b/src/migrate/Migrator.js
@@ -204,6 +204,7 @@ export default class Migrator {
                 trx
               )
             : []
+<<<<<<< HEAD:src/migrate/Migrator.js
         )
         .then(
           (completed) =>
@@ -212,6 +213,8 @@ export default class Migrator {
               migrations,
               completed
             ))
+=======
+>>>>>>> Added new command to print migrations:src/migrate/index.js
         )
         .then(() =>
           Promise.all(

--- a/src/runner.js
+++ b/src/runner.js
@@ -133,7 +133,7 @@ assign(Runner.prototype, {
 
     const runner = this;
 
-    if (global.printAll) {
+    if (global.print) {
       runner.client.logger.debug(obj.sql);
 
       return;

--- a/src/runner.js
+++ b/src/runner.js
@@ -132,6 +132,13 @@ assign(Runner.prototype, {
     this.builder.emit('query', assign({ __knexUid, __knexTxId }, obj));
 
     const runner = this;
+
+    if (global.printAll) {
+      runner.client.logger.debug(obj.sql);
+
+      return;
+    }
+
     let queryPromise = this.client.query(this.connection, obj);
 
     if (obj.timeout) {

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -331,6 +331,22 @@ module.exports = function(knex) {
       });
     });
 
+    describe('knex.migrate.print', function() {
+      before(function() {
+        return knex.migrate.print('all');
+      });
+      after(function() {
+        delete global.print;
+      });
+      it('should not execute the migrations', function() {
+        return knex('knex_migrations')
+          .select('*')
+          .then(function(data) {
+            expect(data.length).to.equal(0);
+          });
+      });
+    });
+
     after(function() {
       rimraf.sync(path.join(__dirname, './migration'));
     });


### PR DESCRIPTION
This PR adds the `print` option to the `migrate` command. When this option is used the migrations will be printed as SQL, so who don't know the knex interface but know SQL (ex: DBA) can verify the migrations created.

![screenshot_20181130_111949](https://user-images.githubusercontent.com/139354/49291551-dec9c300-f491-11e8-924a-e7a394f434f4.png)
