### PR TITLE
Do not reset prior Promise overrides on knex import

### DIFF
--- a/knex.js
+++ b/knex.js
@@ -5,7 +5,14 @@
 //     For details and documentation:
 //     http://knexjs.org
 
+const oldPromise = global.Promise;
+
 // Should be safe to remove after support for Node.js 6 is dropped
 require('@babel/polyfill');
+
+// Preserve any Promise overrides set globally prior to importing knex
+if (oldPromise) {
+  global.Promise = oldPromise;
+}
 
 module.exports = require('./lib/index');

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "chai-subset-in-order": "^2.1.2",
     "coveralls": "^3.0.2",
     "cross-env": "^5.2.0",
-    "eslint": "5.9.0",
+    "eslint": "5.10.0",
     "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-import": "^2.14.0",
     "husky": "^1.2.0",

--- a/test/unit/knex.js
+++ b/test/unit/knex.js
@@ -7,10 +7,12 @@ const { noop } = require('lodash');
 
 describe('knex', () => {
   it('preserves global Bluebird Promise', () => {
+    const oldPromise = global.Promise;
     global.Promise = bluebird;
     expect(Promise.map).to.be.a('function'); // eslint-disable-line no-undef
     require('../../knex');
     expect(Promise.map).to.be.a('function'); // eslint-disable-line no-undef
+    global.Promise = oldPromise;
   });
 
   describe('supports passing existing connection', () => {

--- a/test/unit/knex.js
+++ b/test/unit/knex.js
@@ -1,11 +1,18 @@
 const Knex = require('../../lib/index');
 const { expect } = require('chai');
-const Promise = require('bluebird');
+const bluebird = require('bluebird');
 const sqliteConfig = require('../knexfile').sqlite3;
 const sqlite3 = require('sqlite3');
 const { noop } = require('lodash');
 
 describe('knex', () => {
+  it('preserves global Bluebird Promise', () => {
+    global.Promise = bluebird;
+    expect(Promise.map).to.be.a('function'); // eslint-disable-line no-undef
+    require('../../knex');
+    expect(Promise.map).to.be.a('function'); // eslint-disable-line no-undef
+  });
+
   describe('supports passing existing connection', () => {
     let connection;
     beforeEach(() => {
@@ -143,7 +150,7 @@ describe('knex', () => {
         userParam: '451',
       });
       done();
-      return Promise.resolve();
+      return bluebird.resolve();
     });
   });
 
@@ -157,7 +164,7 @@ describe('knex', () => {
         /Cannot set user params on a transaction - it can only inherit params from main knex instance/
       );
       done();
-      return Promise.resolve();
+      return bluebird.resolve();
     });
   });
 


### PR DESCRIPTION
fixes #2942 
This makes behavior consistent with Knex before 0.16.x