### PR TITLE
Include @types/bluebird as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
+    "@types/bluebird": "^3.5.3",
     "bluebird": "^3.5.3",
     "chalk": "2.4.1",
     "commander": "^2.19.0",


### PR DESCRIPTION
This fixes #2948 by including `@types/bluebird` as dependency of Knex.

We must use `dependencies` rather than `devDependencies` so that `@types/bluebird` gets installed when `knex` is added as regular dependency of another project, and not just when developing Knex itself—since the type definitions are exported as-is.