### PR TITLE
add test that clearing offset

### DIFF
--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -6476,6 +6476,33 @@ describe('QueryBuilder', function() {
     );
   });
 
+  it('should clear offset when passing null', function() {
+    testsql(
+      qb()
+        .from('test')
+        .offset(10)
+        .offset(null),
+      {
+        mysql: {
+          sql: 'select * from `test`',
+          bindings: [],
+        },
+        mssql: {
+          sql: 'select * from [test]',
+          bindings: [],
+        },
+        pg: {
+          sql: 'select * from "test"',
+          bindings: [],
+        },
+        'pg-redshift': {
+          sql: 'select * from "test"',
+          bindings: [],
+        },
+      },
+    );
+  });
+
   it('allows passing builder into where clause, #162', function() {
     var chain = qb()
       .from('chapter')

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -6499,7 +6499,7 @@ describe('QueryBuilder', function() {
           sql: 'select * from "test"',
           bindings: [],
         },
-      },
+      }
     );
   });
 


### PR DESCRIPTION
According to https://github.com/tgriesser/knex/pull/2908,

clearing offset is valid case for Knex.js, but there's no test for it.