### PR TITLE
Typescript type definition for `.asCallback()`

### DIFF
--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -498,6 +498,7 @@ declare namespace Knex {
       writable: T,
       options?: { [key: string]: any }
     ): stream.PassThrough;
+    asCallback(callback: Function): this;
   }
 
   interface Transaction extends Knex {


### PR DESCRIPTION
In Knex version 0.16.2,

we are using Knex.js with Typescript + callback style code.

As I upgrade Knex version 0.15.0 -> 0.16.2, now it cannot be compiled typescript files anymore because of no type definition for `.asCallback()`.

Therefore, I added `.asCallback()` type definition in `ChainableInterface`