### PR TITLE
Respect "loadExtensions" configuration

### DIFF
--- a/src/migrate/Migrator.js
+++ b/src/migrate/Migrator.js
@@ -423,7 +423,8 @@ export function getMergedConfig(config, currentConfig) {
   if (!mergedConfig.migrationSource) {
     mergedConfig.migrationSource = new FsMigrations(
       mergedConfig.directory,
-      mergedConfig.sortDirsSeparately
+      mergedConfig.sortDirsSeparately,
+      mergedConfig.loadExtensions
     );
   }
 


### PR DESCRIPTION
Upgrading from `^0.15.2` -> `^0.16.3` caused the `"loadExtensions"` option to no longer be respected. I think this is the cause, I'm not particularly familiar with the codebase.