### PR TITLE
Typescript type ability to select aliases with ColumnName

### DIFF
--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -216,7 +216,7 @@ declare namespace Knex {
   }
 
   interface Select extends ColumnNameQueryBuilder {
-    (aliases: { [alias: string]: string }): QueryBuilder;
+    (aliases: { [alias: string]: ColumnName }): QueryBuilder;
   }
 
   interface Table {


### PR DESCRIPTION
I know it's not documented, nor do I know if this is something you guys "officially" support. But we've been using them with PostgreSQL and knex seems to handle it fine.

Basically allows for something like:
```
knex('users').select({
   'zap': 'users.name',
   'foo': knex.raw('select bar from boz')
});
```