### PR TITLE
Issue 2970: Add toNative() definition in typescript

### DIFF
--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -477,6 +477,12 @@ declare namespace Knex {
     options: any;
     bindings: Value[];
     sql: string;
+    toNative(): SqlNative;
+  }
+
+  interface SqlNative {
+    bindings: Value[];
+    sql: string;
   }
 
   //


### PR DESCRIPTION
This PR resolves Issue https://github.com/tgriesser/knex/issues/2970

It adds a typescript definition in the types file to expose the toNative functionality available in Knex
https://knexjs.org/#Interfaces-toSQL