### PR TITLE
add `.queryContext()` type definition Knex.Raw

### DIFF
--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -433,6 +433,7 @@ declare namespace Knex {
   interface Raw extends events.EventEmitter, ChainableInterface {
     wrap(before: string, after: string): Raw;
     toSQL(): Sql;
+    queryContext(context: any): Raw;
   }
 
   interface RawBuilder {


### PR DESCRIPTION
resolves #3001 
