### PR TITLE
Always use well documented pg client query() config argument

### DIFF
--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -222,10 +222,17 @@ assign(Client_PG.prototype, {
   // Runs the query on the specified connection, providing the bindings
   // and any other necessary prep work.
   _query(connection, obj) {
-    let sql = obj.sql;
-    if (obj.options) sql = extend({ text: sql }, obj.options);
+    let queryConfig = {
+      text: obj.sql,
+      values: obj.bindings || [],
+    };
+
+    if (obj.opts) {
+      queryConfig = extend(queryConfig, obj.options);
+    }
+
     return new Promise(function(resolver, rejecter) {
-      connection.query(sql, obj.bindings, function(err, response) {
+      connection.query(queryConfig, function(err, response) {
         if (err) return rejecter(err);
         obj.response = response;
         resolver(obj);

--- a/test/unit/dialects/postgres.js
+++ b/test/unit/dialects/postgres.js
@@ -7,7 +7,7 @@ const Promise = require('bluebird');
 const _ = require('lodash');
 
 describe('Postgres Unit Tests', function() {
-  let checkVersionStub;
+  let checkVersionStub, querySpy;
   before(() => {
     const fakeConnection = {
       query: (...args) => {
@@ -18,6 +18,7 @@ describe('Postgres Unit Tests', function() {
       },
       on: _.noop,
     };
+    querySpy = sinon.spy(fakeConnection, 'query');
 
     checkVersionStub = sinon
       .stub(pgDialect.prototype, 'checkVersion')
@@ -28,6 +29,9 @@ describe('Postgres Unit Tests', function() {
     sinon.stub(pg.Client.prototype, 'connect').callsFake(function(cb) {
       cb(null, fakeConnection);
     });
+  });
+  afterEach(() => {
+    querySpy.resetHistory();
   });
   after(() => {
     sinon.restore();
@@ -102,5 +106,24 @@ describe('Postgres Unit Tests', function() {
           'public'
         );
       });
+  });
+  it('Uses documented query config as param when providing bindings', (done) => {
+    const knexInstance = knex({
+      client: 'postgresql',
+      connection: {},
+    });
+    knexInstance.raw('select 1 as ?', ['foo']).then((result) => {
+      sinon.assert.calledOnce(querySpy);
+      sinon.assert.calledWithExactly(
+        querySpy,
+        {
+          text: 'select 1 as $1',
+          values: ['foo'],
+        },
+        sinon.match.func
+      );
+      knexInstance.destroy();
+      done();
+    });
   });
 });


### PR DESCRIPTION
For queries that included bindings, I found that arguments were sent in this form:

```
pg.query({ text: 'SELECT ....' }, ['some', 'bindings'], callback);
```

Technically, this works when calling out to the Node.js Postgres client directly. However, it is not documented publicly (see [here](https://node-postgres.com/api/client#-code-client-query-config-queryconfig-callback-err-error-result-result-gt-void-gt-void-code-)). This change just adopts an approach that is public documented and therefore less prone to breaking in the future. After this change, the above becomes:

```
pg.query({ text: 'SELECT ....', values: ['some', 'bindings']}, callback);
```

The motivation behind this change was for other libraries that try to instrument the postgres client in between. Using undocumented inputs can lead to issues if the library didn't consider all possible undocumented input patterns. My particular usecase was an AWS X-Ray instrumentation package, [`aws-sdk-xray-postgres`](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/postgres)

note: I was only able to get a subset of tests to pass on my local machine. I added a unit test for explicit arg checking, but am relying on existing integration tests to ensure no regressions in basic querying functionality. I'm relying on the CI job to run the remainder of tests. If something fails, I may need pointers on how to get the full suite running locally - I wasn't able to get everything running using the existing docs... but perhaps I missed some steps.