### PR TITLE
Add "constraintName" arg to TS definition

### DIFF
--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -583,7 +583,7 @@ declare namespace Knex {
     uuid(columnName: string): ColumnBuilder;
     comment(val: string): TableBuilder;
     specificType(columnName: string, type: string): ColumnBuilder;
-    primary(columnNames: string[]): TableBuilder;
+    primary(columnNames: string[], constraintName?: string): TableBuilder;
     index(
       columnNames: (string | Raw)[],
       indexName?: string,


### PR DESCRIPTION
Add `constraintName` optional argument to `TableBuilder.primary()` TypeScript definition.
Currently, if you give the second argument, TS will tell that `primary()` expects only 1 argument, when in fact it supports the second optional argument to define the constraint name into the database.