### PR TITLE
schemaName is missing in MigratorConfig typings

### DIFF
--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -825,11 +825,13 @@ declare namespace Knex {
 
   interface MigratorConfig {
     database?: string;
-    directory?: string;
+    directory?: string | string[];
     extension?: string;
     tableName?: string;
-    disableTransactions?: boolean;
     schemaName?: string;
+    disableTransactions?: boolean;
+    sortDirsSeparately?: boolean;
+    
   }
 
   interface SeedsConfig {

--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -829,6 +829,7 @@ declare namespace Knex {
     extension?: string;
     tableName?: string;
     disableTransactions?: boolean;
+    schemaName?: string;
   }
 
   interface SeedsConfig {


### PR DESCRIPTION
add a schemaName value to MigratorConfig.