### PR TITLE
Fix fs-migrations breaking docs

### DIFF
--- a/src/migrate/sources/fs-migrations.js
+++ b/src/migrate/sources/fs-migrations.js
@@ -3,7 +3,7 @@ import path from 'path';
 import Promise from 'bluebird';
 import { sortBy, filter } from 'lodash';
 
-const readDirAsync = Promise.promisify(fs.readdir, { context: fs });
+const readDirAsync = (path) => Promise.promisify(fs.readdir, { context: fs })(path);
 
 export const DEFAULT_LOAD_EXTENSIONS = Object.freeze([
   '.co',


### PR DESCRIPTION
`fs` does not exist in the browser, causing errors such as: 

```javascript
Uncaught TypeError: expecting a function but got [object Undefined]
    at Function.t.promisify (bluebird.js:4020)
    at Object.<anonymous> (fs-migrations.js:18)
    at Object.<anonymous> (fs-migrations.js:83)
    at n (bootstrap:19)
    at Object.<anonymous> (Migrator.js:21)
    at n (bootstrap:19)
    at Object.<anonymous> (make-knex.js:10)
    at n (bootstrap:19)
    at Object.<anonymous> (transaction.js:14)
    at n (bootstrap:19)
    at Object.<anonymous> (client.js:18)
    at n (bootstrap:19)
    at Object.<anonymous> (knex.js:10)
    at n (bootstrap:19)
    at Object.<anonymous> (index.js:8)
    at n (bootstrap:19)
```

Currently this blocks examples in docs and also viewing full changelog.