### PR TITLE
Add typing for RawBinding and ValueMap

### DIFF
--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -27,7 +27,6 @@ type Value =
   | Array<boolean>
   | Buffer
   | Knex.Raw;
-type ValueMap = { [key: string]: Value | Knex.QueryBuilder };
 type ColumnName =
   | string
   | Knex.Raw
@@ -306,6 +305,10 @@ declare namespace Knex {
     type(type: string): JoinClause;
   }
 
+  interface ValueMap {
+    [key: string]: Value | Knex.QueryBuilder;
+  }
+
   interface JoinRaw {
     (tableName: string, binding?: Value | ValueMap): QueryBuilder;
   }
@@ -422,9 +425,11 @@ declare namespace Knex {
     (columnNames: ColumnName[]): QueryBuilder;
   }
 
+  type RawBinding = (Value | QueryBuilder)[];
+
   interface RawQueryBuilder {
-    (sql: string, ...bindings: (Value | QueryBuilder)[]): QueryBuilder;
-    (sql: string, bindings: (Value | QueryBuilder)[] | ValueMap): QueryBuilder;
+    (sql: string, ...bindings: RawBinding): QueryBuilder;
+    (sql: string, bindings: RawBinding | ValueMap): QueryBuilder;
     (raw: Raw): QueryBuilder;
   }
 
@@ -438,8 +443,8 @@ declare namespace Knex {
 
   interface RawBuilder {
     (value: Value): Raw;
-    (sql: string, ...bindings: (Value | QueryBuilder)[]): Raw;
-    (sql: string, bindings: (Value | QueryBuilder)[] | ValueMap): Raw;
+    (sql: string, ...bindings: RawBinding): Raw;
+    (sql: string, bindings: RawBinding | ValueMap): Raw;
   }
 
   //

--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -428,8 +428,8 @@ declare namespace Knex {
   type RawBinding = (Value | QueryBuilder)[];
 
   interface RawQueryBuilder {
-    (sql: string, ...bindings: RawBinding): QueryBuilder;
-    (sql: string, bindings: RawBinding | ValueMap): QueryBuilder;
+    (sql: string, ...bindings: (Value | QueryBuilder)[] | RawBinding): QueryBuilder;
+    (sql: string, bindings: (Value | QueryBuilder)[] | RawBinding | ValueMap): QueryBuilder;
     (raw: Raw): QueryBuilder;
   }
 
@@ -443,8 +443,8 @@ declare namespace Knex {
 
   interface RawBuilder {
     (value: Value): Raw;
-    (sql: string, ...bindings: RawBinding): Raw;
-    (sql: string, bindings: RawBinding | ValueMap): Raw;
+    (sql: string, ...bindings: (Value | QueryBuilder)[] | RawBinding): Raw;
+    (sql: string, bindings: (Value | QueryBuilder)[] | RawBinding | ValueMap): Raw;
   }
 
   //


### PR DESCRIPTION
Add typing for RawBinding and ValueMap

This was the error I was facing. Since, its type was not exported I had to include it in my codebase.
```ts
[ts]
Argument of type 'object' is not assignable to parameter of type '(string | number | boolean | Raw | QueryBuilder | string[] | number[] | Date | Date[] | boolean[] | Buffer)[] | ValueMap'.
  Type 'object' is not assignable to type 'ValueMap'.
    Index signature is missing in type '{}'. [2345]
(parameter) params: object
```

I've added `RawBinding` and `ValueMap`.