### PR TITLE
mysql warn `.returning()` does not have any effect.

### DIFF
--- a/src/dialects/mysql/query/compiler.js
+++ b/src/dialects/mysql/query/compiler.js
@@ -7,6 +7,14 @@ import { assign, identity } from 'lodash';
 
 function QueryCompiler_MySQL(client, builder) {
   QueryCompiler.call(this, client, builder);
+
+  const { returning } = this.single;
+
+  if (returning) {
+    this.client.logger.warn(
+      '.returning() is not supported by mysql and will not have any effect.'
+    );
+  }
 }
 inherits(QueryCompiler_MySQL, QueryCompiler);
 

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -8677,6 +8677,80 @@ describe('QueryBuilder', function() {
     });
   });
 
+  it('should warn to user when use `.returning()` function in MySQL', function() {
+    var loggerConfigForTestingWarnings = {
+      log: {
+        warn: function(message) {
+          if (
+            message ===
+            '.returning() is not supported by mysql and will not have any effect.'
+          ) {
+            throw new Error(message);
+          }
+        },
+      },
+    };
+
+    var mysqlClientForWarnings = new MySQL_Client(
+      Object.assign({ client: 'mysql' }, loggerConfigForTestingWarnings)
+    );
+
+    expect(function() {
+      testsql(
+        qb()
+          .into('users')
+          .insert({ email: 'foo' })
+          .returning('id'),
+        {
+          mysql: {
+            sql: 'insert into `users` (`email`) values (?)',
+            bindings: ['foo'],
+          },
+        },
+        {
+          mysql: mysqlClientForWarnings,
+        }
+      );
+    }).to.throw(Error);
+  });
+
+  it('should warn to user when use `.returning()` function in SQLite3', function() {
+    var loggerConfigForTestingWarnings = {
+      log: {
+        warn: function(message) {
+          if (
+            message ===
+            '.returning() is not supported by sqlite3 and will not have any effect.'
+          ) {
+            throw new Error(message);
+          }
+        },
+      },
+    };
+
+    var sqlite3ClientForWarnings = new SQLite3_Client(
+      Object.assign({ client: 'sqlite3' }, loggerConfigForTestingWarnings)
+    );
+
+    expect(function() {
+      testsql(
+        qb()
+          .into('users')
+          .insert({ email: 'foo' })
+          .returning('id'),
+        {
+          sqlite3: {
+            sql: 'insert into `users` (`email`) values (?)',
+            bindings: ['foo'],
+          },
+        },
+        {
+          sqlite3: sqlite3ClientForWarnings,
+        }
+      );
+    }).to.throw(Error);
+  });
+
   it('join with subquery using .withSchema', function() {
     testsql(
       qb()


### PR DESCRIPTION
In SQLite3, users can be warned that `.returning()` has no effect.

https://github.com/tgriesser/knex/blob/master/src/dialects/sqlite3/query/compiler.js#L18

For consistency, how about MySQL users to be warned as well?