### PR TITLE
Fix for #2998 - Migrator & TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "pg-query-stream": "^1.1.2",
     "prettier": "^1.16.2",
     "rimraf": "^2.6.3",
-    "sinon": "^7.2.3",
+    "sinon": "^7.2.7",
     "sinon-chai": "^3.3.0",
     "source-map-support": "^0.5.10",
     "sqlite3": "^4.0.6",

--- a/src/migrate/migration-list-resolver.js
+++ b/src/migrate/migration-list-resolver.js
@@ -28,7 +28,7 @@ export function listCompleted(tableName, schemaName, trxOrKnex) {
 // the list of completed migrations to check what should be run.
 export function listAllAndCompleted(config, trxOrKnex) {
   return Promise.all([
-    listAll(config.migrationSource),
+    listAll(config.migrationSource, config.loadExtensions),
     listCompleted(config.tableName, config.schemaName, trxOrKnex),
   ]);
 }

--- a/test/unit/migrate/migration-list-resolver.js
+++ b/test/unit/migrate/migration-list-resolver.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const { expect } = require('chai');
+const sinon = require('sinon');
 const mockFs = require('mock-fs');
 const migrationListResolver = require('../../../lib/migrate/migration-list-resolver');
 const FsMigrations = require('../../../lib/migrate/sources/fs-migrations')
@@ -183,6 +184,25 @@ describe('migration-list-resolver', () => {
               file: '004_migration.js',
             },
           ]);
+        });
+    });
+  });
+
+  describe('listAllAndCompleted', () => {
+    it('should pass loadExtensions param to listAll', () => {
+      after(() => {
+        sinon.restore();
+      });
+
+      const migrationSource = new FsMigrations([], true);
+
+      const stub = sinon
+        .stub(migrationSource, 'getMigrations')
+        .callsFake(() => Promise.resolve(true));
+      return migrationListResolver
+        .listAll(migrationSource, ['.ts'])
+        .then(() => {
+          sinon.assert.calledWith(stub, ['.ts']);
         });
     });
   });

--- a/test/unit/migrate/migration-list-resolver.js
+++ b/test/unit/migrate/migration-list-resolver.js
@@ -2,6 +2,7 @@
 /*eslint no-var:0, indent:0, max-len:0 */
 'use strict';
 
+const Promise = require('bluebird');
 const { expect } = require('chai');
 const sinon = require('sinon');
 const mockFs = require('mock-fs');


### PR DESCRIPTION
As described in issue #2998, it seems that what we've found as a symptom (TypeScript migrations not working) is caused by the underlying `#listAllAndCompleted` function which doesn't properly relay the `config.loadExtensions` to `#listAll`.
With the little change in that PR things seem back to normal and the tests all pass as before.

Note: as this problem wasn't caught by the automated tests, eventually, the test suites should be augmented.