### PR TITLE
Proposal for supporting dynamic connection settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Boolean param for rollback() to rollback all migrations #2968
 - seed:run print the file name of the failing seed #2972 #2973
 - verbose option to CLI commands #2887
+- `getConnection` configuration option (function) to provide connection settings dynamically #2732
 
 ### Bug fixes:
 

--- a/src/dialects/mssql/index.js
+++ b/src/dialects/mssql/index.js
@@ -207,7 +207,7 @@ assign(Client_MSSQL.prototype, {
   // connection needs to be added to the pool.
   acquireRawConnection(settings) {
     return new Promise((resolver, rejecter) => {
-      const connectionSettings = Object.assign({}, connectionSettings);
+      const connectionSettings = Object.assign({}, settings);
       connectionSettings.pool = this.mssqlPoolSettings;
       // #1235 mssql module wants 'server', not 'host'. This is to enforce the same
       // options object across all dialects.

--- a/src/dialects/mysql/index.js
+++ b/src/dialects/mysql/index.js
@@ -59,9 +59,9 @@ assign(Client_MySQL.prototype, {
 
   // Get a raw connection, called by the `pool` whenever a new
   // connection needs to be added to the pool.
-  acquireRawConnection() {
+  acquireRawConnection(settings) {
     return new Promise((resolver, rejecter) => {
-      const connection = this.driver.createConnection(this.connectionSettings);
+      const connection = this.driver.createConnection(settings);
       connection.on('error', (err) => {
         connection.__knex__disposed = err;
       });

--- a/src/dialects/oracle/index.js
+++ b/src/dialects/oracle/index.js
@@ -77,21 +77,16 @@ assign(Client_Oracle.prototype, {
 
   // Get a raw connection, called by the `pool` whenever a new
   // connection needs to be added to the pool.
-  acquireRawConnection() {
+  acquireRawConnection(settings) {
     return new Promise((resolver, rejecter) => {
-      this.driver.connect(
-        this.connectionSettings,
-        (err, connection) => {
-          if (err) return rejecter(err);
-          Promise.promisifyAll(connection);
-          if (this.connectionSettings.prefetchRowCount) {
-            connection.setPrefetchRowCount(
-              this.connectionSettings.prefetchRowCount
-            );
-          }
-          resolver(connection);
+      this.driver.connect(settings, (err, connection) => {
+        if (err) return rejecter(err);
+        Promise.promisifyAll(connection);
+        if (settings.prefetchRowCount) {
+          connection.setPrefetchRowCount(settings.prefetchRowCount);
         }
-      );
+        resolver(connection);
+      });
     });
   },
 
@@ -99,11 +94,6 @@ assign(Client_Oracle.prototype, {
   // when a connection times out or the pool is shutdown.
   destroyRawConnection(connection) {
     return Promise.fromCallback(connection.close.bind(connection));
-  },
-
-  // Return the database for the Oracle client.
-  database() {
-    return this.connectionSettings.database;
   },
 
   // Position the bindings for the query.

--- a/src/dialects/oracledb/index.js
+++ b/src/dialects/oracledb/index.js
@@ -75,29 +75,28 @@ Client_Oracledb.prototype.prepBindings = function(bindings) {
 
 // Get a raw connection, called by the `pool` whenever a new
 // connection needs to be added to the pool.
-Client_Oracledb.prototype.acquireRawConnection = function() {
+Client_Oracledb.prototype.acquireRawConnection = function(settings) {
   const client = this;
   const asyncConnection = new Promise(function(resolver, rejecter) {
     // If external authentication dont have to worry about username/password and
     // if not need to set the username and password
-    const oracleDbConfig = client.connectionSettings.externalAuth
-      ? { externalAuth: client.connectionSettings.externalAuth }
+    const oracleDbConfig = settings.externalAuth
+      ? { externalAuth: settings.externalAuth }
       : {
-          user: client.connectionSettings.user,
-          password: client.connectionSettings.password,
+          user: settings.user,
+          password: settings.password,
         };
 
     // In the case of external authentication connection string will be given
     oracleDbConfig.connectString =
-      client.connectionSettings.connectString ||
-      client.connectionSettings.host + '/' + client.connectionSettings.database;
+      settings.connectString || settings.host + '/' + settings.database;
 
-    if (client.connectionSettings.prefetchRowCount) {
-      oracleDbConfig.prefetchRows = client.connectionSettings.prefetchRowCount;
+    if (settings.prefetchRowCount) {
+      oracleDbConfig.prefetchRows = settings.prefetchRowCount;
     }
 
-    if (!_.isUndefined(client.connectionSettings.stmtCacheSize)) {
-      oracleDbConfig.stmtCacheSize = client.connectionSettings.stmtCacheSize;
+    if (!_.isUndefined(settings.stmtCacheSize)) {
+      oracleDbConfig.stmtCacheSize = settings.stmtCacheSize;
     }
 
     client.driver.fetchAsString = client.fetchAsString;

--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -103,10 +103,10 @@ assign(Client_PG.prototype, {
 
   // Get a raw connection, called by the `pool` whenever a new
   // connection needs to be added to the pool.
-  acquireRawConnection() {
+  acquireRawConnection(settings) {
     const client = this;
     return new Promise(function(resolver, rejecter) {
-      const connection = new client.driver.Client(client.connectionSettings);
+      const connection = new client.driver.Client(settings);
       connection.connect(function(err, connection) {
         if (err) {
           return rejecter(err);

--- a/src/dialects/sqlite3/index.js
+++ b/src/dialects/sqlite3/index.js
@@ -59,17 +59,14 @@ assign(Client_SQLite3.prototype, {
   },
 
   // Get a raw connection from the database, returning a promise with the connection object.
-  acquireRawConnection() {
+  acquireRawConnection(settings) {
     return new Promise((resolve, reject) => {
-      const db = new this.driver.Database(
-        this.connectionSettings.filename,
-        (err) => {
-          if (err) {
-            return reject(err);
-          }
-          resolve(db);
+      const db = new this.driver.Database(settings.filename, (err) => {
+        if (err) {
+          return reject(err);
         }
-      );
+        resolve(db);
+      });
     });
   },
 

--- a/test/unit/knex.js
+++ b/test/unit/knex.js
@@ -3,7 +3,7 @@ const { expect } = require('chai');
 const bluebird = require('bluebird');
 const sqliteConfig = require('../knexfile').sqlite3;
 const sqlite3 = require('sqlite3');
-const { noop } = require('lodash');
+const { noop, omit } = require('lodash');
 const { isNode6 } = require('../../lib/util/version-helper');
 
 describe('knex', () => {
@@ -35,6 +35,18 @@ describe('knex', () => {
           expect(result[0].value).to.equal('0');
           done();
         });
+    });
+  });
+
+  it('supports getConnection for dynamic connection settings', (done) => {
+    const config = omit(sqliteConfig, ['connection']);
+
+    config.getConnection = () => bluebird.resolve(sqliteConfig.connection);
+
+    const knex = Knex(config);
+    knex.select(knex.raw('"0" as value')).then((result) => {
+      expect(result[0].value).to.equal('0');
+      done();
     });
   });
 

--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -233,7 +233,10 @@ declare namespace Knex {
 
   interface Join {
     (raw: Raw): QueryBuilder;
-    (tableName: TableName | Identifier | QueryCallback, clause: JoinCallback): QueryBuilder;
+    (
+      tableName: TableName | Identifier | QueryCallback,
+      clause: JoinCallback
+    ): QueryBuilder;
     (
       tableName: TableName | Identifier | QueryCallback,
       columns: { [key: string]: string | number | Raw }
@@ -386,7 +389,9 @@ declare namespace Knex {
 
   interface OrderBy {
     (columnName: string, order?: string): QueryBuilder;
-    (columnDefs: Array<string | { column: string; order?: string }>): QueryBuilder;
+    (
+      columnDefs: Array<string | { column: string; order?: string }>
+    ): QueryBuilder;
   }
 
   interface Union {
@@ -831,7 +836,6 @@ declare namespace Knex {
     schemaName?: string;
     disableTransactions?: boolean;
     sortDirsSeparately?: boolean;
-    
   }
 
   interface SeedsConfig {
@@ -861,7 +865,7 @@ declare namespace Knex {
     driverName: string;
     connectionSettings: object;
 
-    acquireRawConnection(): Promise<any>;
+    acquireRawConnection(settings: object): Promise<any>;
     destroyRawConnection(connection: any): Promise<void>;
     validateConnection(connection: any): Promise<boolean>;
   }


### PR DESCRIPTION
Knex has automatic pool management and reconnection, but it doesn't provide an easy way to provide dynamic connection settings. That becomes an issue when the DB server IP changes (would have to restart service or at least handle it manually and create new Knex instance), or when we want the pool to connect to different physical DB instances.

My proposed solution is to add an optional configuration option named `getConnection` which accepts a function that returns either the connection settings object or a promise that resolves to the connection settings.

That function (if provided) is called every time when getting a new raw connection from the dialect/driver.

Sample usage:
```js
const knex = require('knex')({
  client: 'mysql',
  connection: {
    database: 'db_name'
  },
  getConnection: async (settings) => {
    // Get instance of the DB asynchronously (from Consul for example)
    const {host, port, user, password} = await getDbInstance();
    // `settings` is the `connection` options property provided to Knex
    return { ...settings, host, port, user, password };
  }
});
```

That would probably also solve the problem described in #2732