### PR TITLE
make unionAll()'s call signature match union()

### DIFF
--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -634,12 +634,12 @@ assign(Builder.prototype, {
 
   // Add a union statement to the query.
   union(...args) {
-    return this._union('union', ...args);
+    return this._union('union', args);
   },
 
   // Adds a union all statement to the query.
   unionAll(...args) {
-    return this._union('union all', ...args);
+    return this._union('union all', args);
   },
 
   // Adds a `having` clause to the query.

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -605,7 +605,7 @@ assign(Builder.prototype, {
     return this;
   },
 
-  _union(args, clause) {
+  _union(clause, args) {
     let callbacks = args[0];
     let wrap = args[1];
     if (args.length === 1 || (args.length === 2 && isBoolean(wrap))) {
@@ -627,19 +627,19 @@ assign(Builder.prototype, {
         callbacks.push(wrap);
         wrap = false;
       }
-      this._union([callbacks, wrap], clause);
+      this._union(clause, [callbacks, wrap]);
     }
     return this;
   },
 
   // Add a union statement to the query.
-  union() {
-    return this._union(arguments, 'union');
+  union(...args) {
+    return this._union('union', ...args);
   },
 
   // Adds a union all statement to the query.
-  unionAll(callbacks, wrap) {
-    return this._union(arguments, 'union all');
+  unionAll(...args) {
+    return this._union('union all', ...args);
   },
 
   // Adds a `having` clause to the query.

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -605,41 +605,41 @@ assign(Builder.prototype, {
     return this;
   },
 
-  // Add a union statement to the query.
-  union(callbacks, wrap) {
-    if (arguments.length === 1 || (arguments.length === 2 && isBoolean(wrap))) {
+  _union(args, clause) {
+    let callbacks = args[0];
+    let wrap = args[1];
+    if (args.length === 1 || (args.length === 2 && isBoolean(wrap))) {
       if (!Array.isArray(callbacks)) {
         callbacks = [callbacks];
       }
       for (let i = 0, l = callbacks.length; i < l; i++) {
         this._statements.push({
           grouping: 'union',
-          clause: 'union',
+          clause: clause,
           value: callbacks[i],
           wrap: wrap || false,
         });
       }
     } else {
-      callbacks = toArray(arguments).slice(0, arguments.length - 1);
-      wrap = arguments[arguments.length - 1];
+      callbacks = toArray(args).slice(0, args.length - 1);
+      wrap = args[args.length - 1];
       if (!isBoolean(wrap)) {
         callbacks.push(wrap);
         wrap = false;
       }
-      this.union(callbacks, wrap);
+      this._union([callbacks, wrap], clause);
     }
     return this;
   },
 
+  // Add a union statement to the query.
+  union() {
+    return this._union(arguments, 'union');
+  },
+
   // Adds a union all statement to the query.
-  unionAll(callback, wrap) {
-    this._statements.push({
-      grouping: 'union',
-      clause: 'union all',
-      value: callback,
-      wrap: wrap || false,
-    });
-    return this;
+  unionAll(callbacks, wrap) {
+    return this._union(arguments, 'union all');
   },
 
   // Adds a `having` clause to the query.

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -1997,6 +1997,124 @@ describe('QueryBuilder', function() {
     });
   });
 
+  it('wraps union alls', function() {
+    var wrappedChain = qb()
+      .select('*')
+      .from('users')
+      .where('id', 'in', function() {
+        this.table('users')
+          .max('id')
+          .unionAll(function() {
+            this.table('users').min('id');
+          }, true);
+      });
+    testsql(wrappedChain, {
+      mysql: {
+        sql:
+          'select * from `users` where `id` in (select max(`id`) from `users` union all (select min(`id`) from `users`))',
+        bindings: [],
+      },
+      mssql: {
+        sql:
+          'select * from [users] where [id] in (select max([id]) from [users] union all (select min([id]) from [users]))',
+        bindings: [],
+      },
+      pg: {
+        sql:
+          'select * from "users" where "id" in (select max("id") from "users" union all (select min("id") from "users"))',
+        bindings: [],
+      },
+      'pg-redshift': {
+        sql:
+          'select * from "users" where "id" in (select max("id") from "users" union all (select min("id") from "users"))',
+        bindings: [],
+      },
+    });
+
+    // worthwhile since we're playing games with the 'wrap' specification with arguments
+    var multipleArgumentsWrappedChain = qb()
+      .select('*')
+      .from('users')
+      .where({ id: 1 })
+      .unionAll(
+        function() {
+          this.select('*')
+            .from('users')
+            .where({ id: 2 });
+        },
+        function() {
+          this.select('*')
+            .from('users')
+            .where({ id: 3 });
+        },
+        true
+      );
+    testsql(multipleArgumentsWrappedChain, {
+      mysql: {
+        sql:
+          'select * from `users` where `id` = ? union all (select * from `users` where `id` = ?) union all (select * from `users` where `id` = ?)',
+        bindings: [1, 2, 3],
+      },
+      mssql: {
+        sql:
+          'select * from [users] where [id] = ? union all (select * from [users] where [id] = ?) union all (select * from [users] where [id] = ?)',
+        bindings: [1, 2, 3],
+      },
+      pg: {
+        sql:
+          'select * from "users" where "id" = ? union all (select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)',
+        bindings: [1, 2, 3],
+      },
+      'pg-redshift': {
+        sql:
+          'select * from "users" where "id" = ? union all (select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)',
+        bindings: [1, 2, 3],
+      },
+    });
+
+    var arrayWrappedChain = qb()
+      .select('*')
+      .from('users')
+      .where({ id: 1 })
+      .unionAll(
+        [
+          function() {
+            this.select('*')
+              .from('users')
+              .where({ id: 2 });
+          },
+          function() {
+            this.select('*')
+              .from('users')
+              .where({ id: 3 });
+          },
+        ],
+        true
+      );
+    testsql(arrayWrappedChain, {
+      mysql: {
+        sql:
+          'select * from `users` where `id` = ? union all (select * from `users` where `id` = ?) union all (select * from `users` where `id` = ?)',
+        bindings: [1, 2, 3],
+      },
+      mssql: {
+        sql:
+          'select * from [users] where [id] = ? union all (select * from [users] where [id] = ?) union all (select * from [users] where [id] = ?)',
+        bindings: [1, 2, 3],
+      },
+      pg: {
+        sql:
+          'select * from "users" where "id" = ? union all (select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)',
+        bindings: [1, 2, 3],
+      },
+      'pg-redshift': {
+        sql:
+          'select * from "users" where "id" = ? union all (select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)',
+        bindings: [1, 2, 3],
+      },
+    });
+  });
+
   // it("handles grouped mysql unions", function() {
   //   chain = myqb().union(
   //     raw(myqb().select('*').from('users').where('id', '=', 1)).wrap('(', ')'),
@@ -2036,6 +2154,84 @@ describe('QueryBuilder', function() {
         sql:
           'select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
         bindings: [1, 2],
+      },
+    });
+
+    var multipleArgumentsChain = qb()
+      .select('*')
+      .from('users')
+      .where({ id: 1 })
+      .unionAll(
+        function() {
+          this.select('*')
+            .from('users')
+            .where({ id: 2 });
+        },
+        function() {
+          this.select('*')
+            .from('users')
+            .where({ id: 3 });
+        }
+      );
+    testsql(multipleArgumentsChain, {
+      mysql: {
+        sql:
+          'select * from `users` where `id` = ? union all select * from `users` where `id` = ? union all select * from `users` where `id` = ?',
+        bindings: [1, 2, 3],
+      },
+      mssql: {
+        sql:
+          'select * from [users] where [id] = ? union all select * from [users] where [id] = ? union all select * from [users] where [id] = ?',
+        bindings: [1, 2, 3],
+      },
+      pg: {
+        sql:
+          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
+        bindings: [1, 2, 3],
+      },
+      'pg-redshift': {
+        sql:
+          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
+        bindings: [1, 2, 3],
+      },
+    });
+
+    var arrayChain = qb()
+      .select('*')
+      .from('users')
+      .where({ id: 1 })
+      .unionAll([
+        function() {
+          this.select('*')
+            .from('users')
+            .where({ id: 2 });
+        },
+        function() {
+          this.select('*')
+            .from('users')
+            .where({ id: 3 });
+        },
+      ]);
+    testsql(arrayChain, {
+      mysql: {
+        sql:
+          'select * from `users` where `id` = ? union all select * from `users` where `id` = ? union all select * from `users` where `id` = ?',
+        bindings: [1, 2, 3],
+      },
+      mssql: {
+        sql:
+          'select * from [users] where [id] = ? union all select * from [users] where [id] = ? union all select * from [users] where [id] = ?',
+        bindings: [1, 2, 3],
+      },
+      pg: {
+        sql:
+          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
+        bindings: [1, 2, 3],
+      },
+      'pg-redshift': {
+        sql:
+          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
+        bindings: [1, 2, 3],
       },
     });
   });
@@ -2185,6 +2381,74 @@ describe('QueryBuilder', function() {
       'pg-redshift': {
         sql:
           'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
+        bindings: [1, 2, 3],
+      },
+    });
+
+    var arrayChain = qb()
+      .select('*')
+      .from('users')
+      .where({ id: 1 })
+      .unionAll([
+        qb()
+          .select('*')
+          .from('users')
+          .where({ id: 2 }),
+        raw('select * from users where id = ?', [3]),
+      ]);
+    testsql(arrayChain, {
+      mysql: {
+        sql:
+          'select * from `users` where `id` = ? union all select * from `users` where `id` = ? union all select * from users where id = ?',
+        bindings: [1, 2, 3],
+      },
+      mssql: {
+        sql:
+          'select * from [users] where [id] = ? union all select * from [users] where [id] = ? union all select * from users where id = ?',
+        bindings: [1, 2, 3],
+      },
+      pg: {
+        sql:
+          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from users where id = ?',
+        bindings: [1, 2, 3],
+      },
+      'pg-redshift': {
+        sql:
+          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from users where id = ?',
+        bindings: [1, 2, 3],
+      },
+    });
+
+    var multipleArgumentsChain = qb()
+      .select('*')
+      .from('users')
+      .where({ id: 1 })
+      .unionAll(
+        qb()
+          .select('*')
+          .from('users')
+          .where({ id: 2 }),
+        raw('select * from users where id = ?', [3])
+      );
+    testsql(multipleArgumentsChain, {
+      mysql: {
+        sql:
+          'select * from `users` where `id` = ? union all select * from `users` where `id` = ? union all select * from users where id = ?',
+        bindings: [1, 2, 3],
+      },
+      mssql: {
+        sql:
+          'select * from [users] where [id] = ? union all select * from [users] where [id] = ? union all select * from users where id = ?',
+        bindings: [1, 2, 3],
+      },
+      pg: {
+        sql:
+          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from users where id = ?',
+        bindings: [1, 2, 3],
+      },
+      'pg-redshift': {
+        sql:
+          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from users where id = ?',
         bindings: [1, 2, 3],
       },
     });

--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -138,7 +138,7 @@ declare namespace Knex {
 
     // Union
     union: Union;
-    unionAll(callback: QueryCallback): QueryBuilder;
+    unionAll: Union;
 
     // Having
     having: Having;


### PR DESCRIPTION
Consolidates the logic used by union() and unionAll(), allowing the two to be used interchangeably (which is the current behavior claimed by the docs).

This allows `.unionAll()` to be called on multiple subqueries (rather than having to repeatedly call `.unionAll()` for each one).

Additionally, this adds test-coverage for the undocumented `wrap` argument on `.unionAll()` (which  is already documented for `.union()`).

---

### Before: 

This was the only allowable call-signature (apart from a second undocumented `wrap` parameter):
```js
qb.unionAll(subQuery);
```

If I wanted to write the `.unionAll()` equivalent of `qb.union([sq1, sq2])`, I would have needed to write something like:

```js
[s1, sq2].reduce((qb, sq) => qb.unionAll(sq), qb);
```

### After

Any valid call to `.union()` should now work with `.unionAll()`
```js
qb.unionAll(sq1);
qb.unionAll(sq1, wrap);
qb.unionAll(sq1, sq2);
qb.unionAll(sq1, sq2, wrap);
qb.unionAll([sq1, sq2]);
qb.unionAll([sq1, sq2], wrap);
```

---

Fixes #3054 