### PR TITLE
Include 'string' as accepted constructor type definition

### DIFF
--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -875,7 +875,7 @@ declare namespace Knex {
   //
 
   class Client extends events.EventEmitter {
-    constructor(config: Config);
+    constructor(config: Config | string);
     config: Config;
     dialect: string;
     driverName: string;


### PR DESCRIPTION
Hi there,
I'm totally new to TS so I'm sorry if this is unexpected/unwanted.
I was wiring TS into my codebase and my config call - which happens via knex constructor) was failing type validations because it's set to only accept `Config` interface but I'm currently using a string (via https://github.com/tgriesser/knex/blob/master/src/util/parse-connection.js)