### PR TITLE
Include 'string' as accepted Knex constructor type definition

### DIFF
--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -62,7 +62,7 @@ interface Knex extends Knex.QueryInterface {
   on(eventName: string, callback: Function): Knex.QueryBuilder;
 }
 
-declare function Knex(config: Knex.Config): Knex;
+declare function Knex(config: Knex.Config | string): Knex;
 
 declare namespace Knex {
   //


### PR DESCRIPTION
Hopefully I got it right this time!

Allowing Knex() to accept string type as it does accept string configuration parameter: https://github.com/tgriesser/knex/blob/master/src/knex.js#L12