### PR TITLE
Use URI mode with sqlite3 dialect

### DIFF
--- a/src/dialects/sqlite3/index.js
+++ b/src/dialects/sqlite3/index.js
@@ -63,6 +63,9 @@ assign(Client_SQLite3.prototype, {
     return new Promise((resolve, reject) => {
       const db = new this.driver.Database(
         this.connectionSettings.filename,
+        this.driver.OPEN_URI |
+          this.driver.OPEN_READWRITE |
+          this.driver.OPEN_CREATE,
         (err) => {
           if (err) {
             return reject(err);


### PR DESCRIPTION
When sqlite3 database object is created pass 2nd parameter mode
with value

   OPEN_URI | OPEN_READWRITE | OPEN_CREATE

This will enable URI parsing of filename. If filename is not a valid URI
then things will work as if OPEN_URI was not passed.

This allows following use to be possible with sqlite3:

  In memory db with shared cache (different connections to same URI will
  connect to same in-memory db and will see same content):

     filename: "file:./db-file1.sqlite3?mode=memory&cache=shared"

  In memory db with private cache (different connections to same file will
  not connect to same in-memory db and therefore will see different content):

     filename: "file:./db-file1.sqlite3?mode=memory&cache=private"


Sample test (requires chai-as-promised):
```
knex = require("./lib/knex");
util = require("util");
chai = require("chai");
chai.use(require('chai-as-promised'));

describe("sqlite with uri and mode=memory", () => {

    it("mixed shared/private cache", async () => {
        const conf1 = {
            client: "sqlite3",
            connection: {
                filename: "file:./db-file1.sqlite3?mode=memory&cache=shared"
            },
            useNullAsDefault: true,
        };
        const conf2 = {
            client: "sqlite3",
            connection: {
                filename: "file:./db-file1.sqlite3?mode=memory&cache=private"
            },
            useNullAsDefault: true,
        };
        const client1 = knex(conf1);
        const client2 = knex(conf2);
        try {
            await client1.schema.createTable("test", function (table) {
                table.increments();
                table.string("s");
            });

            await client1("test").insert({ s: "foo" });
            await client1("test").insert({ s: "bar" });

            console.log("-- p1 --");
            const p1_rows = await client1("test").select();
            p1_rows.forEach(x => console.log(`row: ${util.inspect(x)}`));
            chai.expect(p1_rows.length).to.equals(2);

            console.log("-- p2 --");
            const f = async () => (await client2("test").select()).forEach(x => console.log(`row: ${util.inspect(x)}`));
            await chai.expect(f()).to.be.rejectedWith('SQLITE_ERROR: no such table: test');
        } finally {
            client1.destroy();
            client2.destroy();
        }
    })

    it("shared cache", async () => {
        const conf1 = {
            client: "sqlite3",
            connection: {
                filename: "file:./db-file1.sqlite3?mode=memory&cache=shared"
            },
            useNullAsDefault: true,
        };
        const conf2 = {
            client: "sqlite3",
            connection: {
                filename: "file:./db-file1.sqlite3?mode=memory&cache=shared"
            },
            useNullAsDefault: true,
        };
        const client1 = knex(conf1);
        const client2 = knex(conf2);
        try {
            await client1.schema.createTable("test", function (table) {
                table.increments();
                table.string("s");
            });

            await client1("test").insert({ s: "foo" });
            await client1("test").insert({ s: "bar" });

            console.log("-- p1 --");
            const p1_rows = await client1("test").select();
            p1_rows.forEach(x => console.log(`row: ${util.inspect(x)}`));
            chai.expect(p1_rows.length).to.equals(2);

            console.log("-- p2 --");
            const p2_rows = await client2("test").select();
            p2_rows.forEach(x => console.log(`row: ${util.inspect(x)}`));
            chai.expect(p2_rows.length).to.equals(2);
        } finally {
            client1.destroy();
            client2.destroy();
        }
    })
})

```