### PR TITLE
Disable propagateCreateError by default

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -222,7 +222,7 @@ assign(Client.prototype, {
   },
 
   poolDefaults() {
-    return { min: 2, max: 10, propagateCreateError: true };
+    return { min: 2, max: 10, propagateCreateError: false };
   },
 
   getPoolSettings(poolConfig) {


### PR DESCRIPTION
The attribute **_propagateCreateError_** should be set to **_false_** by default to prevent unexpected `Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call?` error.

### Explanation: 

The **propagateCreateError** is [set to _true_ by default in **Knex**](https://github.com/tgriesser/knex/blob/1948c3d423b812e33c38da435bc449d3d898f5d7/src/client.js#L225) and throws a [TimeoutError](https://github.com/tgriesser/knex/blob/1948c3d423b812e33c38da435bc449d3d898f5d7/src/client.js#L312) if the first _create connection_ to the database fails, [preventing **tarn**](https://github.com/Vincit/tarn.js/blame/d2553fe92d07616fbaa0fd2cc4913a100f445597/README.md#L71) (the connection pool manager) from re-connecting automatically. 

The solution is to set **_propagateCreateError_** to **_false_** thus enabling **knex** to automatically reconnect on _create connection_ failure, instead of throwing the error, and only throwing it when the **_acquireTimeoutMillis_** has passed, [as defined by tarn](https://github.com/Vincit/tarn.js/blame/master/README.md#L73)

#### Related issues:
#1381 #1382 #1655 #2445 https://github.com/strapi/strapi/issues/2790 #1875 #1909 #2302 #2141 #1264