### PR TITLE
Add pgsql specific table builder method typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1520,9 +1520,15 @@ declare namespace Knex {
     collate(val: string): CreateTableBuilder;
   }
 
+  interface PostgreSqlTableBuilder extends CreateTableBuilder {
+    inherits(val: string): CreateTableBuilder;
+  }
+
   interface AlterTableBuilder extends TableBuilder {}
 
   interface MySqlAlterTableBuilder extends AlterTableBuilder {}
+
+  interface PostgreSqlAlterTableBuilder extends AlterTableBuilder {}
 
   interface ColumnBuilder {
     index(indexName?: string): ColumnBuilder;


### PR DESCRIPTION
I created `PostgreSqlTableBuilder` and `PostgreSqlAlterTableBuilder` interfaces, similar to the existing MySQL counterparts `MySqlTableBuilder` and `MySqlAlterTableBuilder`. 

They include the currently missing [inherits()](https://knexjs.org/#Schema-inherits) method.
