### PR TITLE
Bugfix/rollback all wrong order

### DIFF
--- a/src/migrate/Migrator.js
+++ b/src/migrate/Migrator.js
@@ -115,7 +115,17 @@ export default class Migrator {
         .tap((value) =>
           validateMigrationList(this.config.migrationSource, value)
         )
-        .then((val) => (all ? val[0] : this._getLastBatch(val)))
+        .then((val) => {
+          const [allMigrations, completedMigrations] = val;
+
+          return all
+            ? allMigrations
+                .filter((migration) => {
+                  return completedMigrations.includes(migration.file);
+                })
+                .reverse()
+            : this._getLastBatch(val);
+        })
         .then((migrations) => {
           return this._runBatch(migrations, 'down');
         });

--- a/test/integration/migrate/test/20131019235306_migration_2.js
+++ b/test/integration/migrate/test/20131019235306_migration_2.js
@@ -12,12 +12,22 @@ exports.up = function(knex, promise) {
         t.increments();
         t.string('name');
       })
-    );
+    )
+    .then(() => {
+      return knex.schema.table('migration_test_1', function(t) {
+        t.integer('age');
+      });
+    });
 };
 
 exports.down = function(knex, promise) {
   const tableName2 = knex.userParams.customTableName || 'migration_test_2_1';
   return knex.schema
     .dropTable('migration_test_2')
-    .then(() => knex.schema.dropTable(tableName2));
+    .then(() => knex.schema.dropTable(tableName2))
+    .then(() => {
+      return knex.schema.table('migration_test_1', function(t) {
+        t.dropColumn('age');
+      });
+    });
 };


### PR DESCRIPTION
This pull request should address, and fix, the bug reported in https://github.com/tgriesser/knex/issues/3131

This bug looks like when trying to rollback all migrations it's running them in chronological order and, I think, attempting to rollback **all** migrations and not just the ones completed (which is also a problem). From [this](https://github.com/tgriesser/knex/blob/master/src/migrate/Migrator.js#L118) line in the `Migrator`, `val[0]` I think is a list of all migrations in chronological order rather than only attempting to rollback the completed migrations in reverse chronological order.

I updated the functionality, if `all=true` is passed in, to rollback all `completed` migrations in reverse chronological order

I updated the tests for the second migration to depend on the first. The reason I think these tests may have been passing previously is because each migration file was creating (on `up`) and dropping (on `down`) a distinct database table so the rollback order the migrations ran in didn't matter at all since no migration impacted something in another migration

It doesn't appear that the documentation found [here](https://github.com/knex/documentation/blob/gh-pages/sections/migrations.js#L311-L312) needs any updates as the language seems correct

Happy to make any additional changes and/or updates