### PR TITLE
add missing types to MigratorConfig

### DIFF
--- a/types/knex.d.ts
+++ b/types/knex.d.ts
@@ -869,6 +869,8 @@ declare namespace Knex {
     schemaName?: string;
     disableTransactions?: boolean;
     sortDirsSeparately?: boolean;
+    loadExtensions?: string[];
+    migrationSource?: any;
   }
 
   interface SeedsConfig {


### PR DESCRIPTION
I'm still relatively new to TypeScript but these types seem to be missing compared to the docs ❤️ 