### PR TITLE
WIP: Feature/add rollback all to cli

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -206,11 +206,14 @@ function invoke(env) {
 
   commander
     .command('migrate:rollback')
-    .description('        Rollback the last set of migrations performed.')
+    .description('        Rollback the last batch of migrations performed.')
+    .option('--all', 'rollback all completed migrations')
     .option('--verbose', 'verbose')
-    .action(() => {
+    .action((cmd) => {
+      const { all } = cmd;
+
       pending = initKnex(env, commander.opts())
-        .migrate.rollback()
+        .migrate.rollback(null, all)
         .spread((batchNo, log) => {
           if (log.length === 0) {
             success(color.cyan('Already at the base migration'));

--- a/test/jake/jakelib/migrate-test.js
+++ b/test/jake/jakelib/migrate-test.js
@@ -152,120 +152,139 @@ test('migrate:rollback prints verbose logs', (temp) => {
 });
 
 test('migrate:rollback --all rolls back all completed migrations', (temp) => {
-  return (
-    new Promise((resolve, reject) => {
-      fs.writeFile(
-        `${temp}/migrations/000_create_users_table.js`,
-        `
-        exports.up = (knex) => knex.schema
-          .createTable('users', (table) => {
-            table.integer('id');
-          });
+  const migrationFile1 = '001_create_users_table.js';
+  const migrationFile2 = '002_add_age_column_to_users_table.js';
+  const migrationFile3 = '003_add_last_name_column_to_users_table.js';
+  const migrationFile4 = '004_add_email_to_users_table.js';
 
-        exports.down = (knex) => knex.schema.dropTable('users');
-      `,
-        (err) => (err ? reject(err) : resolve())
-      );
-    })
-      .then(() => {
-        return assertExec(
-          `${KNEX} migrate:latest \
-      --client=sqlite3 \
-      --connection=${temp}/db \
-      --migrations-directory=${temp}/migrations`,
-          'create_users_table'
-        );
-      })
-
-      // .then(() => {
-      //   console.log(fs.readdirSync(`${temp}/migrations`));
-
-      //   return new sqlite3.Database(temp + '/db')
-      // })
-      // .then((db) => {
-      //   return new Promise((resolve, reject) => {
-      //     db.get('SELECT * FROM knex_migrations', function(err, row) {
-      //       console.log(err);
-      //       console.log(row)
-
-      //       return err ? reject(err) : resolve(row);
-      //     })
-      //   });
-      // })
-
-      .then(() => {
-        return new Promise((resolve, reject) => {
-          fs.writeFile(
-            `${temp}/migrations/001_add_columns_to_user_table.js`,
-            `
-          exports.up = (knex) => knex.schema
-            .table('users', (table) => {
-              table.string('name');
-            });
-
-          exports.down = (knex) => knex.schema
-            .table('users', (table) => {
-              table.dropColumn('name');
-            });
-        `,
-            (err) => (err ? reject(err) : resolve())
-          );
+  fs.writeFileSync(
+    `${temp}/migrations/${migrationFile1}`,
+    `
+      exports.up = (knex) => knex.schema
+        .createTable('users', (table) => {
+          table.string('first_name');
         });
-      })
-      .then(() => {
-        return assertExec(
-          `${KNEX} migrate:latest \
-      --client=sqlite3 \
-      --connection=${temp}/db \
-      --migrations-directory=${temp}/migrations`,
-          'add_columns_to_user_table'
-        );
-      })
 
-      // .then(() => {
-      //   console.log(fs.readdirSync(`${temp}/migrations`));
+      exports.down = (knex) => knex.schema.dropTable('users');
+    `
+  );
 
-      //   return new sqlite3.Database(temp + '/db')
-      // })
-      // .then((db) => {
-      //   return new Promise((resolve, reject) => {
-      //     db.get('SELECT * FROM knex_migrations', function(err, row) {
-      //       console.log(err);
-      //       console.log(row)
-
-      //       return err ? reject(err) : resolve(row);
-      //     })
-      //   });
-      // })
-
-      .then(() => {
-        return new Promise((resolve, reject) => {
-          fs.writeFile(
-            `${temp}/migrations/003_add_age_to_user_table.js`,
-            `
+  return assertExec(
+    `node ${KNEX} migrate:latest \
+    --client=sqlite3 \
+    --connection=${temp}/db \
+    --migrations-directory=${temp}/migrations`,
+    'create_users_table'
+  )
+    .then(() => {
+      fs.writeFileSync(
+        `${temp}/migrations/${migrationFile2}`,
+        `
           exports.up = (knex) => knex.schema
             .table('users', (table) => {
               table.integer('age');
             });
-  
+    
           exports.down = (knex) => knex.schema
             .table('users', (table) => {
               table.dropColumn('age');
             });
-        `,
-            (err) => (err ? reject(err) : resolve())
-          );
-        });
-      })
-      .then(() => {
-        return assertExec(
-          `node ${KNEX} migrate:rollback --all --knexfile=test/jake-util/knexfile/knexfile.js --knexpath=../knex.js`
-        ).then(({ stdout }) => {
-          assert.include(stdout, 'Batch 2 rolled back: 2 migrations');
-          assert.notInclude(stdout, 'simple_migration.js');
-        });
-      })
-  );
+        `
+      );
+
+      return assertExec(
+        `node ${KNEX} migrate:latest \
+        --client=sqlite3 \
+        --connection=${temp}/db \
+        --migrations-directory=${temp}/migrations`,
+        'add_age_column_to_users_table'
+      );
+    })
+    .then(() => {
+      fs.writeFileSync(
+        `${temp}/migrations/${migrationFile3}`,
+        `
+        exports.up = (knex) => knex.schema
+          .table('users', (table) => {
+            table.string('last_name');
+          });
+  
+        exports.down = (knex) => knex.schema
+          .table('users', (table) => {
+            table.dropColumn('last_name');
+          });
+      `
+      );
+
+      return assertExec(
+        `node ${KNEX} migrate:latest \
+      --client=sqlite3 \
+      --connection=${temp}/db \
+      --migrations-directory=${temp}/migrations`,
+        'add_last_name_column_to_user_table'
+      );
+    })
+    .then(() => {
+      fs.writeFileSync(
+        `${temp}/migrations/${migrationFile4}`,
+        `
+        exports.up = (knex) => knex.schema
+          .table('users', (table) => {
+            table.string('email');
+          });
+  
+        exports.down = (knex) => knex.schema
+          .table('users', (table) => {
+            table.dropColumn('email');
+          });
+      `
+      );
+    })
+    .then(() => {
+      const db = new sqlite3.Database(`${temp}/db`);
+
+      return new Promise((resolve, reject) =>
+        db.all('SELECT * FROM knex_migrations', (err, rows) => {
+          const migrationsWithoutMigrationTime = rows.map((row) => {
+            return {
+              id: row.id,
+              name: row.name,
+              batch: row.batch,
+            };
+          });
+
+          assert.includeDeepOrderedMembers(migrationsWithoutMigrationTime, [
+            {
+              id: 1,
+              name: migrationFile1,
+              batch: 1,
+            },
+            {
+              id: 2,
+              name: migrationFile2,
+              batch: 2,
+            },
+            {
+              id: 3,
+              name: migrationFile3,
+              batch: 3,
+            },
+          ]);
+
+          err ? reject(err) : resolve(rows);
+        })
+      );
+    })
+    .then(() => {
+      return assertExec(
+        `node ${KNEX} migrate:rollback --all \
+      --client=sqlite3 \
+      --connection=${temp}/db \
+      --migrations-directory=${temp}/migrations`
+      ).then(({ stdout }) => {
+        assert.include(stdout, 'Batch 3 rolled back: 3 migrations');
+      });
+    });
 });
 
 module.exports = {


### PR DESCRIPTION
This pull request adds support for rolling back all completed migrations to the CLI.

This would, in part, address the feature requests in the following issues: https://github.com/tgriesser/knex/issues/783 and https://github.com/tgriesser/knex/issues/2907

I've labeled this still a work in progress because I'm having difficulty getting the test to work the way I want. Perhaps that's me just not understanding how the testing is set up but here's what I'm trying to accomplish:
1. Create migration 001
1. Run `migration:latest`
1. Create migration 002
1. Run `migration:latest`
1. Create migration 003
1. Run the cli for `migrate:rollback --all` to ensure that migrations 002 and 001 were run in that order and it did not run 003.

The problem is that it only runs the first migration (i.e. migration 001) and no additional migrations.

The reason behind having to create and run them incrementally like that is because running `migrate:latest` would just create one batch and rolling back all wouldn't really be testing it correctly since we want to make sure it rolls back all batches. I've left some commented out code (e.g. console.logs) in there in case it might help troubleshoot.

@kibertoad any instruction you might be able to provide around the testing would be appreciated!