### PR TITLE
Fix backward-incompatibility in type definitions

### DIFF
--- a/types/test.ts
+++ b/types/test.ts
@@ -183,4 +183,12 @@ const main = async () => {
 
   // $ExpectType { [key: string]: string | number; }[]
   await knex('users').count('age');
+
+  // $ExpectType any[]
+  await knex('users').select(knex('foo').select('bar').as('colName'));
+
+  // $ExpectType any[]
+  await knex('users').whereNot(function() {
+    this.where('id', 1).orWhereNot('id', '>', 10);
+  });
 };


### PR DESCRIPTION
Changes in https://github.com/tgriesser/knex/pull/3168 introduces  backward incompatibility causing some other type definitions on DefinitivelyTyped to break when used with latest Knex. 

This PR (tested with all the external type definitions in DefinitivelyTyped having knex as dependency) addresses them by: 

- Adding defaults for parameters of all exposed types which are now generic
- Allowing query builders to be used as select arguments (to accomodate as usage).
