### PR TITLE
Feature/add up for migrations

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -205,6 +205,28 @@ function invoke(env) {
     });
 
   commander
+    .command('migrate:up')
+    .description('        Run the next migration that has not yet been run.')
+    .action(() => {
+      pending = initKnex(env, commander.opts())
+        .migrate.up()
+        .spread((batchNo, log) => {
+          if (log.length === 0) {
+            success(color.cyan('Already up to date'));
+          }
+
+          success(
+            color.green(
+              `Batch ${batchNo} ran the following migrations:\n${log.join(
+                '\n'
+              )}`
+            )
+          );
+        })
+        .catch(exit);
+    });
+
+  commander
     .command('migrate:rollback')
     .description('        Rollback the last batch of migrations performed.')
     .option('--all', 'rollback all completed migrations')

--- a/src/migrate/Migrator.js
+++ b/src/migrate/Migrator.js
@@ -104,6 +104,43 @@ export default class Migrator {
       });
   }
 
+  // Runs the next migration that has not yet been run
+  up(config) {
+    this._disableProcessing();
+    this.config = getMergedConfig(config, this.config);
+
+    return migrationListResolver
+      .listAllAndCompleted(this.config, this.knex)
+      .tap((value) => validateMigrationList(this.config.migrationSource, value))
+      .spread((all, completed) => {
+        const migrationToRun = getNewMigrations(
+          this.config.migrationSource,
+          all,
+          completed
+        ).slice(0, 1);
+
+        const transactionForAll =
+          !this.config.disableTransactions &&
+          isEmpty(
+            filter(migrationToRun, (migration) => {
+              const migrationContents = this.config.migrationSource.getMigration(
+                migration
+              );
+
+              return !this._useTransaction(migrationContents);
+            })
+          );
+
+        if (transactionForAll) {
+          return this.knex.transaction((trx) => {
+            return this._runBatch(migrationToRun, 'up', trx);
+          });
+        } else {
+          return this._runBatch(migrationToRun, 'up');
+        }
+      });
+  }
+
   // Rollback the last "batch", or all, of migrations that were run.
   rollback(config, all = false) {
     this._disableProcessing();

--- a/src/migrate/migrate-stub.js
+++ b/src/migrate/migrate-stub.js
@@ -14,4 +14,5 @@ StubMigrate.prototype = {
   latest: noSuchMethod,
   rollback: noSuchMethod,
   currentVersion: noSuchMethod,
+  up: noSuchMethod,
 };

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -558,7 +558,7 @@ module.exports = function(knex) {
           });
       });
 
-      it('should not error and return a resolved promise if all migrations have already been run', function() {
+      it('should not error if all migrations have already been run', function() {
         return knex.migrate
           .latest({
             directory: 'test/integration/migrate/test',

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -507,6 +507,74 @@ module.exports = function(knex) {
       });
     });
 
+    describe('knex.migrate.up', () => {
+      afterEach(() => {
+        return knex.migrate.rollback(
+          { directory: 'test/integration/migrate/test' },
+          true
+        );
+      });
+
+      it('should only run the first migration if no migrations have run', function() {
+        return knex.migrate
+          .up({
+            directory: 'test/integration/migrate/test',
+          })
+          .then(() => {
+            return knex('knex_migrations')
+              .select('*')
+              .then(function(data) {
+                expect(data).to.have.length(1);
+                expect(path.basename(data[0].name)).to.equal(
+                  '20131019235242_migration_1.js'
+                );
+              });
+          });
+      });
+
+      it('should only run the next migration that has not yet run if other migrations have already run', function() {
+        return knex.migrate
+          .up({
+            directory: 'test/integration/migrate/test',
+          })
+          .then(() => {
+            return knex.migrate
+              .up({
+                directory: 'test/integration/migrate/test',
+              })
+              .then(() => {
+                return knex('knex_migrations')
+                  .select('*')
+                  .then(function(data) {
+                    expect(data).to.have.length(2);
+                    expect(path.basename(data[0].name)).to.equal(
+                      '20131019235242_migration_1.js'
+                    );
+                    expect(path.basename(data[1].name)).to.equal(
+                      '20131019235306_migration_2.js'
+                    );
+                  });
+              });
+          });
+      });
+
+      it('should not error and return a resolved promise if all migrations have already been run', function() {
+        return knex.migrate
+          .latest({
+            directory: 'test/integration/migrate/test',
+          })
+          .then(() => {
+            return knex.migrate
+              .up({
+                directory: 'test/integration/migrate/test',
+              })
+              .then((data) => {
+                expect(data).to.be.an('array');
+              });
+          });
+      });
+    });
+
     after(function() {
       rimraf.sync(path.join(__dirname, './migration'));
     });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1343,6 +1343,7 @@ declare namespace Knex {
     rollback(config?: MigratorConfig, all?: boolean): Bluebird<any>;
     status(config?: MigratorConfig): Bluebird<number>;
     currentVersion(config?: MigratorConfig): Bluebird<string>;
+    up(config?: MigratorConfig): Bluebird<any>;
   }
 
   interface FunctionHelper {


### PR DESCRIPTION
This pull request attempts to add a new feature requested in https://github.com/tgriesser/knex/issues/666 and briefly in https://github.com/tgriesser/knex/issues/352

The feature is adding a `migrate:up` functionality which would only migrate the next migration that has not been run yet to the Migrator API and the CLI

Documentation PR: https://github.com/knex/documentation/pull/194

Some other features that have been requested are a `migrate:down` and also being able to migrate up and migrate down to a specific version noted https://github.com/tgriesser/knex/issues/1550, https://github.com/tgriesser/knex/issues/352. I've started on these but don't want to put too much into one pull request