### PR TITLE
Fix issues with typings of joins and some conflicts with Bluebird

### DIFF
--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -11,6 +11,7 @@
     "baseUrl": ".",
     "paths": {
       "knex": ["."]
-    }
+    },
+    "esModuleInterop": false
   }
 }

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -8,6 +8,7 @@
     "no-empty-interface": false,
     "unified-signatures": false,
     "no-unnecessary-qualifier": false,
-    "strict-export-declare-modifiers": false
+    "strict-export-declare-modifiers": false,
+    "only-arrow-functions": false
   }
 }


### PR DESCRIPTION
- Joins would result in previous result type to not be propagated through the fluent chain in non-inferrable scenarios. This fixes https://github.com/tgriesser/knex/pull/3168#issuecomment-493671389. 

- Removed unnecessary generics from with* functions and added tests.

- Fixed incompatibility with `esModuleInterop: true`. Bluebird typings use `export =` and thus we need to be import through `import =` to be compatible to both modes. This fixes https://github.com/tgriesser/knex/pull/3168#issuecomment-493661498 and https://github.com/tgriesser/knex/issues/3210