### PR TITLE
Allow users to specify the migrations "tableName" parameter via the CLI.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -124,6 +124,10 @@ function invoke(env) {
       'Set migrations directory without a knexfile.'
     )
     .option(
+      '--migrations-table-name [path]',
+      'Set migrations table name without a knexfile.'
+    )
+    .option(
       '--env [name]',
       'environment, default: process.env.NODE_ENV || development'
     );

--- a/bin/utils/cli-config-utils.js
+++ b/bin/utils/cli-config-utils.js
@@ -1,4 +1,4 @@
-const { DEFAULT_EXT } = require('./constants');
+const { DEFAULT_EXT, DEFAULT_TABLE_NAME } = require('./constants');
 const { resolveClientNameWithAliases } = require('../../lib/helpers');
 const fs = require('fs');
 
@@ -21,7 +21,7 @@ function mkConfigObj(opts) {
       connection: opts.connection,
       migrations: {
         directory: opts.migrationsDirectory,
-        tableName: opts.migrationsTableName,
+        tableName: opts.migrationsTableName || DEFAULT_TABLE_NAME,
       },
     },
   };

--- a/bin/utils/cli-config-utils.js
+++ b/bin/utils/cli-config-utils.js
@@ -21,6 +21,7 @@ function mkConfigObj(opts) {
       connection: opts.connection,
       migrations: {
         directory: opts.migrationsDirectory,
+        tableName: opts.migrationsTableName,
       },
     },
   };

--- a/bin/utils/constants.js
+++ b/bin/utils/constants.js
@@ -1,5 +1,7 @@
 const DEFAULT_EXT = 'js';
+const DEFAULT_TABLE_NAME = 'knex_migrations';
 
 module.exports = {
   DEFAULT_EXT,
+  DEFAULT_TABLE_NAME,
 };

--- a/test/jake/jakelib/migrate-test.js
+++ b/test/jake/jakelib/migrate-test.js
@@ -94,9 +94,9 @@ test('Run migrations', (temp) =>
   )
     .then(() =>
       assertExec(`${KNEX} migrate:latest \
-                   --client=sqlite3 --connection=${temp}/db \
-                   --migrations-directory=${temp}/migrations \
-                   create_rule_table`)
+                 --client=sqlite3 --connection=${temp}/db \
+                 --migrations-directory=${temp}/migrations \
+                 create_rule_table`)
     )
     .then(() => assertExec(`ls ${temp}/db`, 'Find the database file'))
     .then(() => new sqlite3.Database(temp + '/db'))
@@ -109,6 +109,25 @@ test('Run migrations', (temp) =>
         )
     )
     .then((row) => assert.equal(row.name, '000_create_rule_table.js')));
+
+test('run migrations without knexfile and with --migrations-table-name', (temp) =>
+  assertExec(`${KNEX} migrate:latest \
+              --client=sqlite3  --connection=${temp}/db \
+              --migrations-directory=test/jake-util/knexfile_migrations \
+              --migrations-table-name=custom_migrations_table`)
+    .then(() => new sqlite3.Database(temp + '/db'))
+    .then(
+      (db) =>
+        new Promise((resolve, reject) =>
+          db.get(
+            "SELECT name FROM sqlite_master where type='table' AND name='custom_migrations_table'",
+            function(err, row) {
+              err ? reject(err) : resolve(row);
+            }
+          )
+        )
+    )
+    .then((row) => assert.equal(row.name, 'custom_migrations_table')));
 
 test('migrate:latest prints non verbose logs', (temp) => {
   const db = knexfile.connection.filename;


### PR DESCRIPTION
I am using Knex to migrate several projects from MongoDB to PostgreSQL. Since these projects already have a means of storing connection configuration, the `knexfile` is redundant. Instead, I can read my existing configuration and generate the appropriate Knex migration command dynamically. 

However, because my projects share the same PostgreSQL database, I need to namespace their migration histories so that they don't conflict. In order to do that, I need to be able to specify the `tableName` configuration option via the command line, which this PR introduces support for.