### PR TITLE
Fix some more cases of missing typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -265,7 +265,7 @@ interface Knex<TRecord extends {} = any, TResult = unknown[]>
   VERSION: string;
   __knex__: string;
 
-  raw: Knex.RawBuilder;
+  raw: Knex.RawBuilder<TRecord, TResult>;
   transaction<T>(
     transactionScope: (trx: Knex.Transaction) => Promise<T> | Bluebird<T> | void
   ): Bluebird<T>;
@@ -1227,18 +1227,18 @@ declare namespace Knex {
     ): QueryBuilder<TRecord, TResult2>;
   }
 
-  type RawBinding = Value | QueryBuilder;
+  type RawBinding = Value | QueryBuilder<any, any>;
 
   interface RawQueryBuilder<TRecord = any, TResult = unknown[]> {
-    <TResult2 = SafePartial<TRecord>[]>(
+    <TResult2 = UnknownToAny<TResult>>(
       sql: string,
       ...bindings: RawBinding[]
     ): QueryBuilder<TRecord, TResult2>;
-    <TResult2 = SafePartial<TRecord>[]>(
+    <TResult2 = UnknownToAny<TResult>>(
       sql: string,
       bindings: RawBinding[] | ValueDict
     ): QueryBuilder<TRecord, TResult2>;
-    <TResult2 = SafePartial<TRecord>[]>(raw: Raw<TResult2>): QueryBuilder<
+    <TResult2 = UnknownToAny<TResult>>(raw: Raw<TResult2>): QueryBuilder<
       TRecord,
       TResult2
     >;
@@ -1254,18 +1254,10 @@ declare namespace Knex {
     queryContext(context: any): Raw<TResult>;
   }
 
-  interface RawBuilder {
-    <TResult>(value: Value): Raw<TResult>;
-    <TResult>(sql: string, ...bindings: Value[]): Raw<TResult>;
-    <TResult>(sql: string, bindings: Value[] | ValueDict): Raw<TResult>;
-    <TRecord, TResult>(
-      sql: string,
-      ...bindings: QueryBuilder<TRecord, TResult>[]
-    ): Raw<TResult>;
-    <TRecord, TResult>(
-      sql: string,
-      bindings: QueryBuilder<TRecord, TResult>[] | ValueDict
-    ): Raw<TResult>;
+  interface RawBuilder<TRecord extends {} = any, TResult = unknown[]> {
+    <TResult2 = UnknownToAny<TResult>>(value: Value): Raw<TResult2>;
+    <TResult2 = UnknownToAny<TResult>>(sql: string, ...bindings: RawBinding[]): Raw<TResult2>;
+    <TResult2 = UnknownToAny<TResult>>(sql: string, bindings: RawBinding[] | ValueDict): Raw<TResult2>;
   }
 
   interface Ref<TSrc extends string, TMapping extends {}> extends Raw<string> {

--- a/types/test.ts
+++ b/types/test.ts
@@ -11,6 +11,9 @@ const knex = Knex({
   },
 });
 
+knex.initialize();
+knex.initialize({});
+
 interface User {
   id: number;
   age: number;
@@ -597,6 +600,11 @@ const main = async () => {
   // $ExpectType number[]
   await knex<User>('users').insert({ id: 10 });
 
+  const qb2 = knex<User>('users');
+  qb2.returning(['id', 'name']);
+  // $ExpectType Partial<User>[]
+  await qb2.insert<Partial<User>[]>({ id: 10 });
+
   // ## With returning
 
   // $ExpectType any[]
@@ -657,6 +665,11 @@ const main = async () => {
   await knex('users')
     .where('id', 10)
     .update({ active: true });
+
+  const qb1 = knex('users').where('id', 10);
+  qb1.returning(['id', 'name']);
+  // $ExpectType Partial<User>[]
+  await qb1.update<Partial<User>[]>({ active: true });
 
   // $ExpectType number
   await knex<User>('users')
@@ -915,4 +928,24 @@ const main = async () => {
     .withSchema('public')
     .select('*')
     .from<User>('users');
+
+  // Seed:
+
+  // $ExpectType string
+  await knex.seed.make('test');
+
+  // $ExpectType string
+  await knex.seed.make('test', {
+      extension: 'ts',
+      directory: 'src/seeds'
+  });
+
+  // $ExpectType string[]
+  await knex.seed.run();
+
+  // $ExpectType string[]
+  await knex.seed.run({
+      extension: 'ts',
+      directory: 'src/seeds'
+  });
 };


### PR DESCRIPTION
- Add types for Seed API
- Add Knex#initialize (Closes #3192)
- Mark Knex interface as EventEmitter (because it does support the full EventEmitter API) 
- Provide more control over TResult for insert/update for cases where the return type of some intermediate mutating functions was left unused.
- Relax constraints on raw queries and add tests for mixed bindings