### PR TITLE
Improve count typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -452,16 +452,24 @@ declare namespace Knex {
     limit(limit: number): QueryBuilder<TRecord, TResult>;
 
     // Aggregation
-    count(...columnNames: (keyof TRecord)[]): CountQueryBuilder<TRecord, TResult>;
-    count(...columnNames: string[]): CountQueryBuilder<TRecord, TResult>;
-    count(
+    count<TResult2 = CountQueryResult<TResult>>(...columnNames: (keyof TRecord)[]): QueryBuilder<TRecord, TResult2>;
+    count<TResult2 = CountQueryResult<TResult>>(...columnNames: string[]): QueryBuilder<TRecord, TResult2>;
+    count<
+      TAliases = Record<string, string | string[] | Knex.Raw>,
+      TResult2 = ArrayIfAlready<TResult, {[k in keyof TAliases]: any}>
+    >(aliases: TAliases): QueryBuilder<TRecord, TResult2>;
+    count<TResult2 = CountQueryResult<TResult>>(
       columnName: Record<string, string | string[] | Knex.Raw> | Knex.Raw
-    ): CountQueryBuilder<TRecord, TResult>;
+    ): QueryBuilder<TRecord, TResult2>;
 
-    countDistinct(columnName: keyof TRecord): CountQueryBuilder<TRecord, TResult>;
-    countDistinct(
-      columnName: string | Record<string, string | Knex.Raw> | Knex.Raw
-    ): CountQueryBuilder<TRecord, TResult>;
+    countDistinct<TResult2 = CountQueryResult<TResult>>(columnName: keyof TRecord): QueryBuilder<TRecord, TResult2>;
+    countDistinct<
+      TAliases = Record<string, string | string[] | Knex.Raw>,
+      TResult2 = ArrayIfAlready<TResult, {[k in keyof TAliases]: any}>
+    >(alises: TAliases): QueryBuilder<TRecord, TResult2>;
+    countDistinct<TResult2 = CountQueryResult<TResult>>(
+      columnName: string | Knex.Raw | Record<string, string | string[] | Knex.Raw>
+    ): QueryBuilder<TRecord, TResult2>;
 
     min<TResult2 = ArrayIfAlready<TResult, ValueDict>>(
       columnName: keyof TRecord,
@@ -1327,10 +1335,7 @@ declare namespace Knex {
     queryContext(context: any): QueryBuilder<TRecord, TResult>;
   }
 
-  type CountQueryBuilder<TRecord, TResult> = QueryBuilder<
-    TRecord,
-    ArrayIfAlready<TResult, Dict<number|string>>
-  >;
+  type CountQueryResult<TResult> = ArrayIfAlready<TResult, Dict<number|string>>;
 
   interface Sql {
     method: string;

--- a/types/test.ts
+++ b/types/test.ts
@@ -461,6 +461,18 @@ const main = async () => {
   // $ExpectType Dict<string | number>[]
   await knex('users').count('age');
 
+  // $ExpectType { count: number; }
+  await knex('foo').first().count<{count: number}>({count: '*'});
+
+  // $ExpectType { count: number; }
+  await knex('foo').first().countDistinct<{count: number}>({count: '*'});
+
+  // $ExpectType { count: any; }
+  await knex('foo').first().count({count: '*'});
+
+  // $ExpectType { count: any; }
+  await knex('foo').first().countDistinct({count: '*'});
+
   // $ExpectType Dict<string | number>
   await knex<User>('users').first().count('age');
 


### PR DESCRIPTION
- Make count generic, especially useful when being used with an alias object argument
- In case of alias object, partially infer the return type from the input.

Addresses: https://github.com/tgriesser/knex/issues/3229#issuecomment-497866524