### PR TITLE
Fix error message bubbling up on seed error

### DIFF
--- a/src/seed/Seeder.js
+++ b/src/seed/Seeder.js
@@ -124,25 +124,26 @@ Seeder.prototype._waterfallBatch = function(seeds) {
     seed = require(name);
 
     // Run each seed file.
-    current = current
-      .then(() => seed.seed(knex, Promise))
-      .then(() => {
-        log.push(name);
-      })
-      .catch((originalError) => {
-        const error = new Error(
-          `Error while executing "${name}" seed: ${originalError.message}`
-        );
-        error.original = originalError;
-        error.stack =
-          error.stack
-            .split('\n')
-            .slice(0, 2)
-            .join('\n') +
-          '\n' +
-          originalError.stack;
-        throw error;
-      });
+    current = current.then(() =>
+      // Nesting promise to prevent bubbling up of error on catch
+      Promise.resolve()
+        .then(() => seed.seed(knex, Promise))
+        .then(() => log.push(name))
+        .catch((originalError) => {
+          const error = new Error(
+            `Error while executing "${name}" seed: ${originalError.message}`
+          );
+          error.original = originalError;
+          error.stack =
+            error.stack
+              .split('\n')
+              .slice(0, 2)
+              .join('\n') +
+            '\n' +
+            originalError.stack;
+          throw error;
+        })
+    );
   });
 
   return current.thenReturn([log]);

--- a/test/unit/seed/seeder.js
+++ b/test/unit/seed/seeder.js
@@ -7,7 +7,7 @@ var knex = require('../../../knex');
 
 describe('Seeder.loadExtensions', function() {
   var config = {
-    client: 'pg',
+    client: 'postgres',
     connection: {
       user: 'postgres',
       password: '',
@@ -64,6 +64,36 @@ describe('Seeder.loadExtensions', function() {
       ._listAll({ loadExtensions: ['.ts', '.js'] })
       .then(function(list) {
         expect(list).to.eql(['js-seed.js', 'ts-seed.ts']);
+      });
+  });
+});
+
+describe('Seeder._waterfallBatch', function() {
+  var config = {
+    client: 'postgres',
+    connection: {
+      user: 'postgres',
+      password: '',
+      host: '127.0.0.1',
+      database: 'knex_test',
+    },
+    seeds: {
+      directory: 'test/unit/seed/test',
+    },
+  };
+  var seeder;
+
+  beforeEach(function() {
+    seeder = knex(config).seed;
+  });
+
+  it('should throw an error with correct file name', () => {
+    return seeder
+      ._waterfallBatch(['1-first.js', '2-second.js'])
+      .catch((error) => {
+        expect(error.message).to.match(
+          /^Error while executing "(\/\w+)+\/1-first\.js" seed: throwing in first file$/
+        );
       });
   });
 });

--- a/test/unit/seed/seeder.js
+++ b/test/unit/seed/seeder.js
@@ -87,13 +87,12 @@ describe('Seeder._waterfallBatch', function() {
     seeder = knex(config).seed;
   });
 
-  it('should throw an error with correct file name', () => {
-    return seeder
-      ._waterfallBatch(['1-first.js', '2-second.js'])
-      .catch((error) => {
-        expect(error.message).to.match(
-          /^Error while executing "(\/\w+)+\/1-first\.js" seed: throwing in first file$/
-        );
-      });
+  it('should throw an error with correct file name', (done) => {
+    seeder._waterfallBatch(['1-first.js', '2-second.js']).catch((error) => {
+      expect(error.message).to.match(
+        /^Error while executing "(\/\w+)+\/1-first\.js" seed: throwing in first file$/
+      );
+      done();
+    });
   });
 });

--- a/test/unit/seed/test/1-first.js
+++ b/test/unit/seed/test/1-first.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.seed = function() {
+  throw new Error('throwing in first file');
+};

--- a/test/unit/seed/test/2-second.js
+++ b/test/unit/seed/test/2-second.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.seed = function() {
+  return 'doing nothing in second file';
+};


### PR DESCRIPTION
Problem: When the nth seed `throw`s an error, all subsequent seeds add an error message on top of original message which makes it less clear which seed the error originated from.

Solution: Nest promises and `catch` error inside the nested seed promise.

Before:
```
Error: Error while executing ".../knex/seeds/9-titres-activites.js" seed: Error while executing ".../knex/seeds/8-metas-activites.js" seed: Error while e
xecuting ".../knex/seeds/7-titres.js" seed: insert into "titres_points" ("contour", "coordonnees", "description", "groupe", "id", "nom", "point"
    at Object.current.then.then.catch.originalError (.../node_modules/knex/lib/seed/Seeder.js:166:23)
Error: Error while executing ".../knex/seeds/8-metas-activites.js" seed: Error while executing ".../knex/seeds/7-titres.js" seed: insert into "titres_poi
nts" ("contour", "coordonnees", "description", "groupe", "id", "nom", "point"
    at Object.current.then.then.catch.originalError (.../node_modules/knex/lib/seed/Seeder.js:166:23)
Error: Error while executing ".../knex/seeds/7-titres.js" seed: insert into "titres_points" ("contour", "coordonnees", "description", "groupe", "id", "nom", "point" [...]
    at Object.current.then.then.catch.originalError (.../node_modules/knex/lib/seed/Seeder.js:166:23)
```

After:
```
Error: Error while executing ".../knex/seeds/7-titres.js" seed: insert into "titres_points" ("contour", "coordonnees", "description", "groupe", "id", "nom", "point" [...]
    at Object.current.then.then.catch.originalError (.../node_modules/knex/lib/seed/Seeder.js:166:23)
```

LMKWYT,
Cheers.