### PR TITLE
Adds stub type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1767,6 +1767,7 @@ declare namespace Knex {
     database?: string;
     directory?: string | string[];
     extension?: string;
+    stub?: string;
     tableName?: string;
     schemaName?: string;
     disableTransactions?: boolean;


### PR DESCRIPTION
Is this excluded intentionally? For my projects, I share this type between knexfile and service level.