### PR TITLE
adds stub to seeds type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1784,6 +1784,7 @@ declare namespace Knex {
 
   interface SeedsConfig {
     directory?: string;
+    stub?: string;
   }
 
   interface Migrator {


### PR DESCRIPTION
Looks like there was a missing type for `config.seeds.stub` used here: https://github.com/tgriesser/knex/blob/master/src/seed/Seeder.js#L102.