### PR TITLE
Expose executionPromise for transactors

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1401,6 +1401,8 @@ declare namespace Knex {
 
   interface Transaction<TRecord extends {} = any, TResult = any>
     extends Knex<TRecord, TResult> {
+    executionPromise: Promise<TResult>;
+
     query<TRecord extends {} = any, TResult = void>(
       conn: any,
       sql: any,


### PR DESCRIPTION
Exposed both on callback and non-callback versions for consistency, even though it isn't very useful for callback ones (you always had access to promise for them).