### PR TITLE
Fix comments that were modified by a find & replace

### DIFF
--- a/src/dialects/oracle/index.js
+++ b/src/dialects/oracle/index.js
@@ -162,7 +162,7 @@ assign(Client_Oracle.prototype, {
       });
   },
 
-  // Process the response as returned = require(the query.
+  // Process the response as returned from the query.
   processResponse(obj, runner) {
     let { response } = obj;
     const { method } = obj;

--- a/src/dialects/oracledb/index.js
+++ b/src/dialects/oracledb/index.js
@@ -365,7 +365,7 @@ function readStream(stream, cb) {
   });
 }
 
-// Process the response as returned = require(the query.
+// Process the response as returned from the query.
 Client_Oracledb.prototype.processResponse = function(obj, runner) {
   let response = obj.response;
   const method = obj.method;

--- a/src/migrate/Migrator.js
+++ b/src/migrate/Migrator.js
@@ -31,12 +31,12 @@ function LockError(msg) {
 
 inherits(LockError, Error);
 
-// The new migration we're performing, typically called = require(the `knex.migrate`
+// The new migration we're performing, typically called from the `knex.migrate`
 // interface on the main `knex` object. Passes the `knex` instance performing
 // the migration.
 class Migrator {
   constructor(knex) {
-    // Clone knex instance and remove post-processing that is unnecessary for internal queries = require(a cloned config
+    // Clone knex instance and remove post-processing that is unnecessary for internal queries from a cloned config
     if (isFunction(knex)) {
       if (!knex.isTransaction) {
         this.knex = knex.withUserParams({

--- a/src/migrate/migration-list-resolver.js
+++ b/src/migrate/migration-list-resolver.js
@@ -24,7 +24,7 @@ function listCompleted(tableName, schemaName, trxOrKnex) {
     );
 }
 
-// Gets the migration list = require(the migration directory specified in config, as well as
+// Gets the migration list from the migration directory specified in config, as well as
 // the list of completed migrations to check what should be run.
 function listAllAndCompleted(config, trxOrKnex) {
   return Bluebird.all([

--- a/src/query/methods.js
+++ b/src/query/methods.js
@@ -1,5 +1,5 @@
 // All properties we can use to start a query chain
-// = require(the `knex` object, e.g. `knex.select('*').from(...`
+// from the `knex` object, e.g. `knex.select('*').from(...`
 module.exports = [
   'with',
   'withRecursive',

--- a/src/runner.js
+++ b/src/runner.js
@@ -235,7 +235,7 @@ assign(Runner.prototype, {
 
   // Check whether there's a transaction flag, and that it has a connection.
   ensureConnection() {
-    // Use override = require(a builder if passed
+    // Use override from a builder if passed
     if (this.builder._connection) {
       return Bluebird.resolve(this.builder._connection);
     }
@@ -253,7 +253,7 @@ assign(Runner.prototype, {
         throw error;
       })
       .disposer(() => {
-        // need to return promise or null = require(handler to prevent warning = require(bluebird
+        // need to return promise or null from handler to prevent warning from bluebird
         return this.client.releaseConnection(this.connection);
       });
   },

--- a/src/schema/tablecompiler.js
+++ b/src/schema/tablecompiler.js
@@ -149,7 +149,7 @@ TableCompiler.prototype.getColumnTypes = (columns) =>
     { sql: [], bindings: [] }
   );
 
-// Adds all of the additional queries = require(the "column"
+// Adds all of the additional queries from the "column"
 TableCompiler.prototype.columnQueries = function(columns) {
   const queries = reduce(
     map(columns, tail),

--- a/src/seed/Seeder.js
+++ b/src/seed/Seeder.js
@@ -15,7 +15,7 @@ const {
   extend,
 } = require('lodash');
 
-// The new seeds we're performing, typically called = require(the `knex.seed`
+// The new seeds we're performing, typically called from the `knex.seed`
 // interface on the main `knex` object. Passes the `knex` instance performing
 // the seeds.
 function Seeder(knex) {
@@ -62,7 +62,7 @@ Seeder.prototype._listAll = async function(config) {
     );
 };
 
-// Gets the seed file list = require(the specified seed directory.
+// Gets the seed file list from the specified seed directory.
 Seeder.prototype._seedData = function() {
   return Bluebird.join(this._listAll());
 };

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -76,7 +76,7 @@ class Transaction extends EventEmitter {
               this.executionResolveFn = resolve;
             });
 
-            // If we've returned a "thenable" = require(the transaction container, assume
+            // If we've returned a "thenable" from the transaction container, assume
             // the rollback and commit are chained to this object's success / failure.
             // Directly thrown errors are treated as automatic rollbacks.
             let result;

--- a/src/util/make-knex.js
+++ b/src/util/make-knex.js
@@ -128,7 +128,7 @@ function _copyEventListeners(eventName, sourceKnex, targetKnex) {
 }
 
 function redefineProperties(knex, client) {
-  // Allow chaining methods = require(the root object, before
+  // Allow chaining methods from the root object, before
   // any other information is specified.
   QueryInterface.forEach(function(method) {
     knex[method] = function() {
@@ -145,7 +145,7 @@ function redefineProperties(knex, client) {
       set(context) {
         knex._context = context;
 
-        // Redefine public API for knex instance that would be proxying methods = require(correct context
+        // Redefine public API for knex instance that would be proxying methods from correct context
         knex.raw = context.raw;
         knex.batchInsert = context.batchInsert;
         knex.transaction = context.transaction;
@@ -221,7 +221,7 @@ function redefineProperties(knex, client) {
     knex[key] = ee[key];
   }
 
-  // Unfortunately, something seems to be broken in Node 6 and removing events = require(a clone also mutates original Knex,
+  // Unfortunately, something seems to be broken in Node 6 and removing events from a clone also mutates original Knex,
   // which is highly undesireable
   if (knex._internalListeners) {
     knex._internalListeners.forEach(({ eventName, listener }) => {


### PR DESCRIPTION
The find & replace of ES module import syntax to cjs `require`s in #3227 modified some comments.