### PR TITLE
CLI: Fix empty --version output

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -135,11 +135,11 @@ function invoke(env) {
 
   const localVersion = [
     color.blue('Knex Local version:'),
-    color.green(env.modulePackage.version),
+    color.green(env.modulePackage.version || 'None'),
   ].join(' ');
 
   commander
-    .version([cliVersion, localVersion].join('\n'))
+    .version(`${cliVersion}\n${localVersion}`)
     .option('--debug', 'Run with debugging.')
     .option('--knexfile [path]', 'Specify the knexfile path.')
     .option('--knexpath [path]', 'Specify the path to knex instance.')

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -128,16 +128,18 @@ function invoke(env) {
   const filetypes = ['js', 'coffee', 'ts', 'eg', 'ls'];
   let pending = null;
 
+  const cliVersion = [
+    color.blue('Knex CLI version:'),
+    color.green(cliPkg.version),
+  ].join(' ');
+
+  const localVersion = [
+    color.blue('Knex Local version:'),
+    color.green(env.modulePackage.version),
+  ].join(' ');
+
   commander
-    .version(
-      color.blue('Knex CLI version: ', color.green(cliPkg.version)) +
-        '\n' +
-        color.blue(
-          'Local Knex version: ',
-          color.green(env.modulePackage.version)
-        ) +
-        '\n'
-    )
+    .version([cliVersion, localVersion].join('\n'))
     .option('--debug', 'Run with debugging.')
     .option('--knexfile [path]', 'Specify the knexfile path.')
     .option('--knexpath [path]', 'Specify the path to knex instance.')

--- a/test/cli/version.spec.js
+++ b/test/cli/version.spec.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const path = require('path');
+const { execCommand } = require('cli-testlab');
+
+const cliPkg = require('../../package');
+const KNEX = path.normalize(__dirname + '/../../bin/cli.js');
+
+describe('version', () => {
+  it('Print correct knex CLI version', () => {
+    const expectedKnexCliVersion = cliPkg.version;
+
+    return execCommand(`node ${KNEX} --version`, {
+      expectedOutput: expectedKnexCliVersion,
+    });
+  });
+
+  it('Print correct knex CLI version using -V flag', () => {
+    const expectedKnexCliVersion = cliPkg.version;
+
+    return execCommand(`node ${KNEX} -V`, {
+      expectedOutput: expectedKnexCliVersion,
+    });
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -63,4 +63,5 @@ describe('CLI tests', function() {
   this.timeout(process.env.KNEX_TEST_TIMEOUT || 5000);
   require('./cli/knexfile-test.spec');
   require('./cli/migrate-make.spec');
+  require('./cli/version.spec');
 });


### PR DESCRIPTION
Currently, `--version/-V` output looks broken (empty output):

```sh
knex --version

Knex CLI version: 
Local Knex version: 
```

#3311