### PR TITLE
CLI/add stub option

### DIFF
--- a/bin/utils/cli-config-utils.js
+++ b/bin/utils/cli-config-utils.js
@@ -1,6 +1,10 @@
 const { DEFAULT_EXT, DEFAULT_TABLE_NAME } = require('./constants');
 const { resolveClientNameWithAliases } = require('../../src/helpers');
 const fs = require('fs');
+const path = require('path');
+const tildify = require('tildify');
+const color = require('colorette');
+const argv = require('getopts')(process.argv.slice(2));
 
 function mkConfigObj(opts) {
   if (!opts.client) {
@@ -55,7 +59,94 @@ function resolveDefaultKnexfilePath(extension) {
   return process.cwd() + `/knexfile.${extension}`;
 }
 
+function resolveEnvironmentConfig(opts, allConfigs) {
+  const environment = opts.env || process.env.NODE_ENV || 'development';
+  const result = allConfigs[environment] || allConfigs;
+
+  if (allConfigs[environment]) {
+    console.log('Using environment:', color.magenta(environment));
+  }
+
+  if (!result) {
+    console.log(color.red('Warning: unable to read knexfile config'));
+    process.exit(1);
+  }
+
+  if (argv.debug !== undefined) {
+    result.debug = argv.debug;
+  }
+
+  return result;
+}
+
+function exit(text) {
+  if (text instanceof Error) {
+    console.error(
+      color.red(`${text.detail ? `${text.detail}\n` : ''}${text.stack}`)
+    );
+  } else {
+    console.error(color.red(text));
+  }
+  process.exit(1);
+}
+
+function success(text) {
+  console.log(text);
+  process.exit(0);
+}
+
+function checkLocalModule(env) {
+  if (!env.modulePath) {
+    console.log(
+      color.red('No local knex install found in:'),
+      color.magenta(tildify(env.cwd))
+    );
+    exit('Try running: npm install knex');
+  }
+}
+
+function getMigrationExtension(env, opts) {
+  const config = resolveEnvironmentConfig(opts, env.configuration);
+
+  let ext = DEFAULT_EXT;
+  if (argv.x) {
+    ext = argv.x;
+  } else if (config.migrations && config.migrations.extension) {
+    ext = config.migrations.extension;
+  } else if (config.ext) {
+    ext = config.ext;
+  }
+  return ext.toLowerCase();
+}
+
+function getStubPath(env, opts) {
+  const config = resolveEnvironmentConfig(opts, env.configuration);
+  const stubDirectory = config.migrations && config.migrations.directory;
+
+  const { stub } = argv;
+  if (!stub) {
+    return null;
+  } else if (stub.includes('/')) {
+    // relative path to stub
+    return stub;
+  }
+
+  // using stub <name> must have config.migrations.directory defined
+  if (!stubDirectory) {
+    console.log(color.red('Failed to load stub'), color.magenta(stub));
+    exit('config.migrations.directory in knexfile must be defined');
+  }
+
+  return path.join(stubDirectory, stub);
+}
+
 module.exports = {
   mkConfigObj,
   resolveKnexFilePath,
+  resolveEnvironmentConfig,
+  exit,
+  success,
+  checkLocalModule,
+  getMigrationExtension,
+  getStubPath,
 };

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "JSONStream": "^1.3.5",
     "chai": "^4.2.0",
     "chai-subset-in-order": "^2.1.3",
-    "cli-testlab": "^1.6.0",
+    "cli-testlab": "^1.7.0",
     "coveralls": "^3.0.4",
     "cross-env": "^5.2.0",
     "dtslint": "^0.8.0",

--- a/test/cli/cli-test-utils.js
+++ b/test/cli/cli-test-utils.js
@@ -1,3 +1,8 @@
+'use strict';
+
+const path = require('path');
+const { FileTestHelper } = require('cli-testlab');
+
 function migrationStubOptionSetup(fileHelper) {
   const migrationGlobPath = 'test/jake-util/knexfile_migrations/*_somename.js';
 
@@ -34,7 +39,18 @@ function migrationMatchesStub(stubPath, migrationGlobPath, fileHelper) {
   return stubContent === migrationContent;
 }
 
+function setupFileHelper() {
+  const fileHelper = new FileTestHelper(
+    path.resolve(__dirname, '../jake-util')
+  );
+  fileHelper.deleteFile('test.sqlite3');
+  fileHelper.registerForCleanup('test.sqlite3');
+
+  return fileHelper;
+}
+
 module.exports = {
   migrationStubOptionSetup,
   migrationMatchesStub,
+  setupFileHelper,
 };

--- a/test/cli/cli-test-utils.js
+++ b/test/cli/cli-test-utils.js
@@ -1,0 +1,40 @@
+function migrationStubOptionSetup(fileHelper) {
+  const migrationGlobPath = 'test/jake-util/knexfile_migrations/*_somename.js';
+
+  fileHelper.registerGlobForCleanup(migrationGlobPath);
+  fileHelper.createFile(
+    process.cwd() + '/knexfile.js',
+    `
+      module.exports = {
+        development: {
+          client: 'sqlite3',
+          connection: {
+            filename: __dirname + '/test/jake-util/test.sqlite3',
+          },
+          migrations: {
+            directory: __dirname + '/test/jake-util/knexfile_migrations',
+          },
+        }
+      };
+      `,
+    { isPathAbsolute: true }
+  );
+
+  return { migrationGlobPath };
+}
+
+function migrationMatchesStub(stubPath, migrationGlobPath, fileHelper) {
+  // accepts full or relative stub path
+  const relativeStubPath = stubPath.replace('test/jake-util/', '');
+  const stubContent = fileHelper.getFileTextContent(relativeStubPath);
+  const [migrationContent] = fileHelper.getFileGlobTextContent(
+    migrationGlobPath
+  );
+
+  return stubContent === migrationContent;
+}
+
+module.exports = {
+  migrationStubOptionSetup,
+  migrationMatchesStub,
+};

--- a/test/cli/migrate-make.spec.js
+++ b/test/cli/migrate-make.spec.js
@@ -1,10 +1,56 @@
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const { FileTestHelper, execCommand } = require('cli-testlab');
 const expect = require('chai').expect;
 
 const KNEX = path.normalize(__dirname + '/../../bin/cli.js');
+
+// start: utils for --stub option tests //
+const migrationStubSetup = (fileHelper) => {
+  fileHelper.registerGlobForCleanup(
+    'test/jake-util/knexfile_migrations/*_somename.js'
+  );
+  fileHelper.createFile(
+    process.cwd() + '/knexfile.js',
+    `
+      module.exports = {
+        development: {
+          client: 'sqlite3',
+          connection: {
+            filename: __dirname + '/test/jake-util/test.sqlite3',
+          },
+          migrations: {
+            directory: __dirname + '/test/jake-util/knexfile_migrations',
+          },
+        }
+      };
+      `,
+    { isPathAbsolute: true }
+  );
+};
+
+const getMigrationFileContents = (fileHelper) => {
+  const [migrationFileName] = fs
+    .readdirSync(path.resolve(__dirname, '../jake-util/knexfile_migrations'))
+    .filter((fileName) => /\d+_somename\.js/.test(fileName));
+
+  return fileHelper.getFileTextContent(
+    `knexfile_migrations/${migrationFileName}`
+  );
+};
+
+const migrationMatchesStub = (stubPath, fileHelper) => {
+  // accepts full or relative stub path
+  const relativeStubPath = stubPath.replace('test/jake-util/', '');
+
+  const migrationContents = getMigrationFileContents(fileHelper);
+  const stubContents = fileHelper.getFileTextContent(relativeStubPath);
+  return stubContents === migrationContents;
+};
+
+// end: utils for --stub option tests //
 
 describe('migrate:make', () => {
   /**
@@ -212,5 +258,95 @@ development: {
       'test/jake-util/knexfile_migrations/*_somename.ts'
     );
     expect(fileCount).to.equal(1);
+  });
+
+  it('Create a new migration using --stub </file/path> relative to the knexfile', async () => {
+    migrationStubSetup(fileHelper);
+
+    const stubPath = 'test/jake-util/migration-stubs/table.stub';
+
+    await execCommand(
+      `node ${KNEX} migrate:make somename --stub ${stubPath} --knexpath=../knex.js`,
+      {
+        expectedOutput: 'Created Migration',
+      }
+    );
+
+    const fileCount = fileHelper.fileGlobExists(
+      'test/jake-util/knexfile_migrations/*_somename.js'
+    );
+    expect(fileCount).to.equal(1);
+    expect(migrationMatchesStub(stubPath, fileHelper)).equal(true);
+  });
+
+  it('Create a new migration with --stub <name> in config.migrations.directory', async () => {
+    migrationStubSetup(fileHelper);
+
+    const stubName = 'table-foreign.stub';
+    const stubPath = `test/jake-util/knexfile_migrations/${stubName}`;
+
+    await execCommand(
+      `node ${KNEX} migrate:make somename --stub ${stubName} --knexpath=../knex.js`,
+      {
+        expectedOutput: 'Created Migration',
+      }
+    );
+
+    const fileCount = fileHelper.fileGlobExists(
+      'test/jake-util/knexfile_migrations/*_somename.js'
+    );
+    expect(fileCount).to.equal(1);
+    expect(migrationMatchesStub(stubPath, fileHelper)).equal(true);
+  });
+
+  it('Create a new migration with --stub <name> when file does not exist', async () => {
+    migrationStubSetup(fileHelper);
+    const stubName = 'non-existat.stub';
+    await execCommand(
+      `node ${KNEX} migrate:make somename --stub ${stubName} --knexpath=../knex.js`,
+      {
+        expectedErrorMessage: 'ENOENT:',
+      }
+    );
+  });
+
+  it('Create a new migration with --stub </file/path> when file does not exist', async () => {
+    migrationStubSetup(fileHelper);
+    const stubPath = '/path/non-existat.stub';
+    await execCommand(
+      `node ${KNEX} migrate:make somename --stub ${stubPath} --knexpath=../knex.js`,
+      {
+        expectedErrorMessage: 'ENOENT:',
+      }
+    );
+  });
+
+  it('Create a new migration with --stub <name> when config.migrations.directory not defined', async () => {
+    fileHelper.createFile(
+      process.cwd() + '/knexfile.js',
+      `
+module.exports = {
+  development: {
+    client: 'sqlite3',
+    connection: {
+      filename: __dirname + '/test/jake-util/test.sqlite3',
+    },
+    migrations: {
+      // directory not defined
+    },
+  }
+};
+    `,
+      { isPathAbsolute: true }
+    );
+
+    const stubName = 'table-foreign.stub';
+    await execCommand(
+      `node ${KNEX} migrate:make somename --stub ${stubName} --knexpath=../knex.js`,
+      {
+        expectedErrorMessage:
+          'config.migrations.directory in knexfile must be defined',
+      }
+    );
   });
 });

--- a/test/cli/migrate-make.spec.js
+++ b/test/cli/migrate-make.spec.js
@@ -1,86 +1,86 @@
 'use strict';
 
 const path = require('path');
-const { FileTestHelper, execCommand } = require('cli-testlab');
+const { execCommand } = require('cli-testlab');
 const expect = require('chai').expect;
 
 const KNEX = path.normalize(__dirname + '/../../bin/cli.js');
 const {
   migrationStubOptionSetup,
   migrationMatchesStub,
+  setupFileHelper,
 } = require('./cli-test-utils');
 
 describe('migrate:make', () => {
-  /**
-   * @type FileTestHelper
-   */
-  let fileHelper;
-  beforeEach(() => {
-    fileHelper = new FileTestHelper(path.resolve(__dirname, '../jake-util'));
-    fileHelper.deleteFile('test.sqlite3');
-    fileHelper.registerForCleanup('test.sqlite3');
-  });
+  describe('-x option: make migration using a specific extension', () => {
+    /**
+     * @type FileTestHelper
+     */
+    let fileHelper;
+    beforeEach(() => {
+      fileHelper = setupFileHelper();
+    });
 
-  afterEach(() => {
-    fileHelper.cleanup();
-  });
+    afterEach(() => {
+      fileHelper.cleanup();
+    });
 
-  before(() => {
-    process.env.KNEX_PATH = '../knex.js';
-  });
+    before(() => {
+      process.env.KNEX_PATH = '../knex.js';
+    });
 
-  it('Create new migration without knexfile passed or existing in default location', () => {
-    return execCommand(
-      `node ${KNEX} migrate:make somename --knexpath=../knex.js`,
-      {
-        expectedErrorMessage:
-          'Failed to resolve config file, knex cannot determine where to generate migrations',
-      }
-    );
-  });
+    it('Create new migration without knexfile passed or existing in default location', () => {
+      return execCommand(
+        `node ${KNEX} migrate:make somename --knexpath=../knex.js`,
+        {
+          expectedErrorMessage:
+            'Failed to resolve config file, knex cannot determine where to generate migrations',
+        }
+      );
+    });
 
-  it('Create new migration with js knexfile passed', async () => {
-    fileHelper.registerGlobForCleanup(
-      'test/jake-util/knexfile_migrations/*_somename.js'
-    );
+    it('Create new migration with js knexfile passed', async () => {
+      fileHelper.registerGlobForCleanup(
+        'test/jake-util/knexfile_migrations/*_somename.js'
+      );
 
-    await execCommand(
-      `node ${KNEX} migrate:make somename --knexfile=test/jake-util/knexfile/knexfile.js --knexpath=../knex.js`,
-      {
-        expectedOutput: 'Created Migration',
-      }
-    );
+      await execCommand(
+        `node ${KNEX} migrate:make somename --knexfile=test/jake-util/knexfile/knexfile.js --knexpath=../knex.js`,
+        {
+          expectedOutput: 'Created Migration',
+        }
+      );
 
-    const fileCount = fileHelper.fileGlobExists(
-      'test/jake-util/knexfile_migrations/*_somename.js'
-    );
-    expect(fileCount).to.equal(1);
-  });
+      const fileCount = fileHelper.fileGlobExists(
+        'test/jake-util/knexfile_migrations/*_somename.js'
+      );
+      expect(fileCount).to.equal(1);
+    });
 
-  it('Create new migration with ts knexfile passed', async () => {
-    fileHelper.registerGlobForCleanup(
-      'test/jake-util/knexfile_migrations/*_somename.ts'
-    );
-    await execCommand(
-      `node ${KNEX} migrate:make somename --knexfile=test/jake-util/knexfile-ts/knexfile.ts --knexpath=../knex.js`,
-      {
-        expectedOutput: 'Created Migration',
-      }
-    );
+    it('Create new migration with ts knexfile passed', async () => {
+      fileHelper.registerGlobForCleanup(
+        'test/jake-util/knexfile_migrations/*_somename.ts'
+      );
+      await execCommand(
+        `node ${KNEX} migrate:make somename --knexfile=test/jake-util/knexfile-ts/knexfile.ts --knexpath=../knex.js`,
+        {
+          expectedOutput: 'Created Migration',
+        }
+      );
 
-    const fileCount = fileHelper.fileGlobExists(
-      'test/jake-util/knexfile_migrations/*_somename.ts'
-    );
-    expect(fileCount).to.equal(1);
-  });
+      const fileCount = fileHelper.fileGlobExists(
+        'test/jake-util/knexfile_migrations/*_somename.ts'
+      );
+      expect(fileCount).to.equal(1);
+    });
 
-  it('Create new migration with default knexfile', () => {
-    fileHelper.registerGlobForCleanup(
-      'test/jake-util/knexfile_migrations/*_somename.js'
-    );
-    fileHelper.createFile(
-      process.cwd() + '/knexfile.js',
-      `
+    it('Create new migration with default knexfile', () => {
+      fileHelper.registerGlobForCleanup(
+        'test/jake-util/knexfile_migrations/*_somename.js'
+      );
+      fileHelper.createFile(
+        process.cwd() + '/knexfile.js',
+        `
 module.exports = {
   client: 'sqlite3',
   connection: {
@@ -91,23 +91,23 @@ module.exports = {
   },
 };    
     `,
-      { isPathAbsolute: true }
-    );
-    return execCommand(
-      `node ${KNEX} migrate:make somename --knexpath=../knex.js`,
-      {
-        expectedOutput: 'Created Migration',
-      }
-    );
-  });
+        { isPathAbsolute: true }
+      );
+      return execCommand(
+        `node ${KNEX} migrate:make somename --knexpath=../knex.js`,
+        {
+          expectedOutput: 'Created Migration',
+        }
+      );
+    });
 
-  it('Create new migration with default ts knexfile', async () => {
-    fileHelper.registerGlobForCleanup(
-      'test/jake-util/knexfile_migrations/*_somename.ts'
-    );
-    fileHelper.createFile(
-      process.cwd() + '/knexfile.ts',
-      `
+    it('Create new migration with default ts knexfile', async () => {
+      fileHelper.registerGlobForCleanup(
+        'test/jake-util/knexfile_migrations/*_somename.ts'
+      );
+      fileHelper.createFile(
+        process.cwd() + '/knexfile.ts',
+        `
 module.exports = {
   client: 'sqlite3',
   connection: {
@@ -118,45 +118,45 @@ module.exports = {
   },
 };    
     `,
-      { isPathAbsolute: true }
-    );
-    await execCommand(
-      `node ${KNEX} migrate:make somename --knexpath=../knex.js`,
-      {
-        expectedOutput: 'Created Migration',
-      }
-    );
+        { isPathAbsolute: true }
+      );
+      await execCommand(
+        `node ${KNEX} migrate:make somename --knexpath=../knex.js`,
+        {
+          expectedOutput: 'Created Migration',
+        }
+      );
 
-    const fileCount = fileHelper.fileGlobExists(
-      'test/jake-util/knexfile_migrations/*_somename.ts'
-    );
-    expect(fileCount).to.equal(1);
-  });
+      const fileCount = fileHelper.fileGlobExists(
+        'test/jake-util/knexfile_migrations/*_somename.ts'
+      );
+      expect(fileCount).to.equal(1);
+    });
 
-  it('Create new migration with ts extension using -x switch', async () => {
-    fileHelper.registerGlobForCleanup(
-      'test/jake-util/knexfile_migrations/*_somename.ts'
-    );
-    await execCommand(
-      `node ${KNEX} migrate:make somename -x ts --knexfile=test/jake-util/knexfile/knexfile.js --knexpath=../knex.js`,
-      {
-        expectedOutput: 'Created Migration',
-      }
-    );
+    it('Create new migration with ts extension using -x switch', async () => {
+      fileHelper.registerGlobForCleanup(
+        'test/jake-util/knexfile_migrations/*_somename.ts'
+      );
+      await execCommand(
+        `node ${KNEX} migrate:make somename -x ts --knexfile=test/jake-util/knexfile/knexfile.js --knexpath=../knex.js`,
+        {
+          expectedOutput: 'Created Migration',
+        }
+      );
 
-    const fileCount = fileHelper.fileGlobExists(
-      'test/jake-util/knexfile_migrations/*_somename.ts'
-    );
-    expect(fileCount).to.equal(1);
-  });
+      const fileCount = fileHelper.fileGlobExists(
+        'test/jake-util/knexfile_migrations/*_somename.ts'
+      );
+      expect(fileCount).to.equal(1);
+    });
 
-  it('Create new migration with ts extension using "extension" knexfile param', async () => {
-    fileHelper.registerGlobForCleanup(
-      'test/jake-util/knexfile_migrations/*_somename.ts'
-    );
-    fileHelper.createFile(
-      process.cwd() + '/knexfile.js',
-      `
+    it('Create new migration with ts extension using "extension" knexfile param', async () => {
+      fileHelper.registerGlobForCleanup(
+        'test/jake-util/knexfile_migrations/*_somename.ts'
+      );
+      fileHelper.createFile(
+        process.cwd() + '/knexfile.js',
+        `
 module.exports = {
   client: 'sqlite3',
   connection: {
@@ -168,28 +168,28 @@ module.exports = {
   },
 };    
     `,
-      { isPathAbsolute: true }
-    );
-    await execCommand(
-      `node ${KNEX} migrate:make somename --knexpath=../knex.js`,
-      {
-        expectedOutput: 'Created Migration',
-      }
-    );
+        { isPathAbsolute: true }
+      );
+      await execCommand(
+        `node ${KNEX} migrate:make somename --knexpath=../knex.js`,
+        {
+          expectedOutput: 'Created Migration',
+        }
+      );
 
-    const fileCount = fileHelper.fileGlobExists(
-      'test/jake-util/knexfile_migrations/*_somename.ts'
-    );
-    expect(fileCount).to.equal(1);
-  });
+      const fileCount = fileHelper.fileGlobExists(
+        'test/jake-util/knexfile_migrations/*_somename.ts'
+      );
+      expect(fileCount).to.equal(1);
+    });
 
-  it('Create new migration with ts extension using environment "extension" knexfile param', async () => {
-    fileHelper.registerGlobForCleanup(
-      'test/jake-util/knexfile_migrations/*_somename.ts'
-    );
-    fileHelper.createFile(
-      process.cwd() + '/knexfile.js',
-      `
+    it('Create new migration with ts extension using environment "extension" knexfile param', async () => {
+      fileHelper.registerGlobForCleanup(
+        'test/jake-util/knexfile_migrations/*_somename.ts'
+      );
+      fileHelper.createFile(
+        process.cwd() + '/knexfile.js',
+        `
 module.exports = {
 development: {
   client: 'sqlite3',
@@ -203,112 +203,131 @@ development: {
   }
 };    
     `,
-      { isPathAbsolute: true }
-    );
-    await execCommand(
-      `node ${KNEX} migrate:make somename --knexpath=../knex.js`,
-      {
-        expectedOutput: 'Created Migration',
-      }
-    );
+        { isPathAbsolute: true }
+      );
+      await execCommand(
+        `node ${KNEX} migrate:make somename --knexpath=../knex.js`,
+        {
+          expectedOutput: 'Created Migration',
+        }
+      );
 
-    const fileCount = fileHelper.fileGlobExists(
-      'test/jake-util/knexfile_migrations/*_somename.ts'
-    );
-    expect(fileCount).to.equal(1);
+      const fileCount = fileHelper.fileGlobExists(
+        'test/jake-util/knexfile_migrations/*_somename.ts'
+      );
+      expect(fileCount).to.equal(1);
+    });
   });
 
-  it('Create a new migration using --stub </file/path> relative to the knexfile', async () => {
-    const { migrationGlobPath } = migrationStubOptionSetup(fileHelper);
+  describe('--stub option: make migration using specific stub file', () => {
+    /**
+     * @type FileTestHelper
+     */
+    let fileHelper;
+    beforeEach(() => {
+      fileHelper = setupFileHelper();
+    });
 
-    const stubPath = 'test/jake-util/migration-stubs/table.stub';
+    afterEach(() => {
+      fileHelper.cleanup();
+    });
 
-    await execCommand(
-      `node ${KNEX} migrate:make somename --stub ${stubPath} --knexpath=../knex.js`,
-      {
-        expectedOutput: 'Created Migration',
-      }
-    );
+    before(() => {
+      process.env.KNEX_PATH = '../knex.js';
+    });
 
-    const fileCount = fileHelper.fileGlobExists(
-      'test/jake-util/knexfile_migrations/*_somename.js'
-    );
-    expect(fileCount).to.equal(1);
-    expect(migrationMatchesStub(stubPath, migrationGlobPath, fileHelper)).equal(
-      true
-    );
-  });
+    it('Create a new migration using --stub </file/path> relative to the knexfile', async () => {
+      const { migrationGlobPath } = migrationStubOptionSetup(fileHelper);
 
-  it('Create a new migration with --stub <name> in config.migrations.directory', async () => {
-    const { migrationGlobPath } = migrationStubOptionSetup(fileHelper);
+      const stubPath = 'test/jake-util/migration-stubs/table.stub';
 
-    const stubName = 'table-foreign.stub';
-    const stubPath = `test/jake-util/knexfile_migrations/${stubName}`;
+      await execCommand(
+        `node ${KNEX} migrate:make somename --stub ${stubPath} --knexpath=../knex.js`,
+        {
+          expectedOutput: 'Created Migration',
+        }
+      );
 
-    await execCommand(
-      `node ${KNEX} migrate:make somename --stub ${stubName} --knexpath=../knex.js`,
-      {
-        expectedOutput: 'Created Migration',
-      }
-    );
+      const fileCount = fileHelper.fileGlobExists(
+        'test/jake-util/knexfile_migrations/*_somename.js'
+      );
+      expect(fileCount).to.equal(1);
+      expect(
+        migrationMatchesStub(stubPath, migrationGlobPath, fileHelper)
+      ).equal(true);
+    });
 
-    const fileCount = fileHelper.fileGlobExists(
-      'test/jake-util/knexfile_migrations/*_somename.js'
-    );
-    expect(fileCount).to.equal(1);
-    expect(migrationMatchesStub(stubPath, migrationGlobPath, fileHelper)).equal(
-      true
-    );
-  });
+    it('Create a new migration with --stub <name> in config.migrations.directory', async () => {
+      const { migrationGlobPath } = migrationStubOptionSetup(fileHelper);
 
-  it('Create a new migration with --stub <name> when file does not exist', async () => {
-    migrationStubOptionSetup(fileHelper);
-    const stubName = 'non-existat.stub';
-    await execCommand(
-      `node ${KNEX} migrate:make somename --stub ${stubName} --knexpath=../knex.js`,
-      {
-        expectedErrorMessage: 'ENOENT:',
-      }
-    );
-  });
+      const stubName = 'table-foreign.stub';
+      const stubPath = `test/jake-util/knexfile_migrations/${stubName}`;
 
-  it('Create a new migration with --stub </file/path> when file does not exist', async () => {
-    migrationStubOptionSetup(fileHelper);
-    const stubPath = '/path/non-existat.stub';
-    await execCommand(
-      `node ${KNEX} migrate:make somename --stub ${stubPath} --knexpath=../knex.js`,
-      {
-        expectedErrorMessage: 'ENOENT:',
-      }
-    );
-  });
+      await execCommand(
+        `node ${KNEX} migrate:make somename --stub ${stubName} --knexpath=../knex.js`,
+        {
+          expectedOutput: 'Created Migration',
+        }
+      );
 
-  it('Create a new migration with --stub <name> when config.migrations.directory not defined', async () => {
-    fileHelper.createFile(
-      process.cwd() + '/knexfile.js',
-      `
-module.exports = {
-  development: {
-    client: 'sqlite3',
-    connection: {
-      filename: __dirname + '/test/jake-util/test.sqlite3',
-    },
-    migrations: {
-      // directory not defined
-    },
-  }
-};
-    `,
-      { isPathAbsolute: true }
-    );
+      const fileCount = fileHelper.fileGlobExists(
+        'test/jake-util/knexfile_migrations/*_somename.js'
+      );
+      expect(fileCount).to.equal(1);
+      expect(
+        migrationMatchesStub(stubPath, migrationGlobPath, fileHelper)
+      ).equal(true);
+    });
 
-    const stubName = 'table-foreign.stub';
-    await execCommand(
-      `node ${KNEX} migrate:make somename --stub ${stubName} --knexpath=../knex.js`,
-      {
-        expectedErrorMessage:
-          'config.migrations.directory in knexfile must be defined',
-      }
-    );
+    it('Create a new migration with --stub <name> when file does not exist', async () => {
+      migrationStubOptionSetup(fileHelper);
+      const stubName = 'non-existat.stub';
+      await execCommand(
+        `node ${KNEX} migrate:make somename --stub ${stubName} --knexpath=../knex.js`,
+        {
+          expectedErrorMessage: 'ENOENT:',
+        }
+      );
+    });
+
+    it('Create a new migration with --stub </file/path> when file does not exist', async () => {
+      migrationStubOptionSetup(fileHelper);
+      const stubPath = '/path/non-existat.stub';
+      await execCommand(
+        `node ${KNEX} migrate:make somename --stub ${stubPath} --knexpath=../knex.js`,
+        {
+          expectedErrorMessage: 'ENOENT:',
+        }
+      );
+    });
+
+    it('Create a new migration with --stub <name> when config.migrations.directory not defined', async () => {
+      fileHelper.createFile(
+        process.cwd() + '/knexfile.js',
+        `
+  module.exports = {
+    development: {
+      client: 'sqlite3',
+      connection: {
+        filename: __dirname + '/test/jake-util/test.sqlite3',
+      },
+      migrations: {
+        // directory not defined
+      },
+    }
+  };
+      `,
+        { isPathAbsolute: true }
+      );
+
+      const stubName = 'table-foreign.stub';
+      await execCommand(
+        `node ${KNEX} migrate:make somename --stub ${stubName} --knexpath=../knex.js`,
+        {
+          expectedErrorMessage:
+            'config.migrations.directory in knexfile must be defined',
+        }
+      );
+    });
   });
 });

--- a/test/jake-util/knexfile_migrations/table-foreign.stub
+++ b/test/jake-util/knexfile_migrations/table-foreign.stub
@@ -1,0 +1,20 @@
+/* eslint func-names:0 */
+
+exports.up = function (knex) {
+  return knex.schema.createTable("", (table) => {
+    table.increments();
+    table
+      .integer("") // foreign_key_name
+      .unsigned()
+      .notNullable()
+      .references("") // table.primary_key_name
+      .onDelete("CASCADE"); // RESTRICT, CASCADE, SET NULL, NO ACTION
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable("");
+};
+
+// exports.config = { transaction: false };

--- a/test/jake-util/migration-stubs/table.stub
+++ b/test/jake-util/migration-stubs/table.stub
@@ -1,0 +1,15 @@
+/* eslint func-names:0 */
+
+exports.up = function (knex) {
+  return knex.schema.createTable("table_name", (table) => {
+    table.increments();
+
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable("table_name");
+};
+
+// exports.config = { transaction: false };


### PR DESCRIPTION
closes #3219 

adds `--stub` option to `migration:make` CLI command

**usage**
- `--stub <name>` looks for stub file by name in `config.migrations.directory`
- `--stub </file/path>` looks for stub file by path relative to `knexfile.*`