### PR TITLE
Fix issues around specifying default values for columns

### DIFF
--- a/src/dialects/mssql/schema/columncompiler.js
+++ b/src/dialects/mssql/schema/columncompiler.js
@@ -82,17 +82,6 @@ assign(ColumnCompiler_MSSQL.prototype, {
   // Modifiers
   // ------
 
-  defaultTo(value) {
-    const defaultVal = ColumnCompiler_MSSQL.super_.prototype.defaultTo.apply(
-      this,
-      arguments
-    );
-    if (this.type !== 'blob' && this.type.indexOf('text') === -1) {
-      return defaultVal;
-    }
-    return '';
-  },
-
   first() {
     this.client.logger.warn('Column first modifier not available for MSSQL');
     return '';

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -124,6 +124,7 @@ Object.assign(ColumnCompiler_MySQL.prototype, {
       return;
     }
     if ((this.type === 'json' || this.type === 'jsonb') && isObject(value)) {
+      // Default value for json will work only it is an expression
       return `default ('${JSON.stringify(value)}')`;
     }
     const defaultVal = ColumnCompiler_MySQL.super_.prototype.defaultTo.apply(

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -123,7 +123,9 @@ Object.assign(ColumnCompiler_MySQL.prototype, {
     if (value === null || value === undefined) {
       return;
     }
-
+    if ((this.type === 'json' || this.type === 'jsonb') && isObject(value)) {
+      return `default ('${JSON.stringify(value)}')`;
+    }
     const defaultVal = ColumnCompiler_MySQL.super_.prototype.defaultTo.apply(
       this,
       arguments

--- a/src/schema/columncompiler.js
+++ b/src/schema/columncompiler.js
@@ -154,8 +154,8 @@ ColumnCompiler.prototype.defaultTo = function(value) {
   } else if (this.type === 'bool') {
     if (value === 'false') value = 0;
     value = `'${value ? 1 : 0}'`;
-  } else if (this.type === 'json' && isObject(value)) {
-    return JSON.stringify(value);
+  } else if ((this.type === 'json' || this.type === 'jsonb') && isObject(value)) {
+    value = `'${JSON.stringify(value)}'`;
   } else {
     value = `'${value}'`;
   }

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -473,7 +473,30 @@ module.exports = function(knex) {
             tester('mssql', [
               'CREATE TABLE [test_table_three] ([main] int not null, [paragraph] nvarchar(max), [metadata] text default \'{"a":10}\', CONSTRAINT [test_table_three_pkey] PRIMARY KEY ([main]))',
             ]);
-          });
+          })
+          .then(function () {
+            return knex('test_table_three').insert([{
+              main: 1
+            }])
+          })
+          .then(function() {
+            return knex('test_table_three').where({main: 1}).first()
+          })
+          .then(function(result) {
+            expect(result.main).to.equal(1);
+            if (!knex.client.driverName.match(/^mysql/)) {
+              // MySQL doesn't support default values in text columns
+              expect(result.paragraph).to.eql(
+                'Lorem ipsum Qui quis qui in.'
+              );
+            }
+            if (knex.client.driverName === 'pg') {
+              expect(result.metadata).to.eql({ a: 10 });
+              expect(result.details).to.eql({ b: { d: 20 } });
+            } else {
+              expect(result.metadata).to.eql('{"a":10}');
+            }
+          })
       });
 
       it('handles numeric length correctly', function() {

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -445,29 +445,33 @@ module.exports = function(knex) {
               .notNullable()
               .primary();
             table.text('paragraph').defaultTo('Lorem ipsum Qui quis qui in.');
+            table.json('metadata').defaultTo({a: 10});
+            if (knex.client.driverName === 'pg') {
+              table.jsonb('details').defaultTo({b: {d: 20}});
+            }
           })
           .testSql(function(tester) {
             tester('mysql', [
-              'create table `test_table_three` (`main` int not null, `paragraph` text) default character set utf8 engine = InnoDB',
+              'create table `test_table_three` (`main` int not null, `paragraph` text, `metadata` json default (\'{"a":10}\')) default character set utf8 engine = InnoDB',
               'alter table `test_table_three` add primary key `test_table_three_pkey`(`main`)',
             ]);
             tester('pg', [
-              'create table "test_table_three" ("main" integer not null, "paragraph" text default \'Lorem ipsum Qui quis qui in.\')',
+              'create table "test_table_three" ("main" integer not null, "paragraph" text default \'Lorem ipsum Qui quis qui in.\', "metadata" json default \'{"a":10}\', "details" jsonb default \'{"b":{"d":20}}\')',
               'alter table "test_table_three" add constraint "test_table_three_pkey" primary key ("main")',
             ]);
             tester('pg-redshift', [
-              'create table "test_table_three" ("main" integer not null, "paragraph" varchar(max) default \'Lorem ipsum Qui quis qui in.\')',
+              'create table "test_table_three" ("main" integer not null, "paragraph" varchar(max) default \'Lorem ipsum Qui quis qui in.\',  "metadata" json default \'{"a":10}\', "details" jsonb default \'{"b":{"d":20}}\')',
               'alter table "test_table_three" add constraint "test_table_three_pkey" primary key ("main")',
             ]);
             tester('sqlite3', [
-              "create table `test_table_three` (`main` integer not null, `paragraph` text default 'Lorem ipsum Qui quis qui in.', primary key (`main`))",
+              "create table `test_table_three` (`main` integer not null, `paragraph` text default 'Lorem ipsum Qui quis qui in.', `metadata` json default '{\"a\":10}', primary key (`main`))",
             ]);
             tester('oracledb', [
-              'create table "test_table_three" ("main" integer not null, "paragraph" clob default \'Lorem ipsum Qui quis qui in.\')',
+              'create table "test_table_three" ("main" integer not null, "paragraph" clob default \'Lorem ipsum Qui quis qui in.\', "metadata" clob default \'{"a":10}\')',
               'alter table "test_table_three" add constraint "test_table_three_pkey" primary key ("main")',
             ]);
             tester('mssql', [
-              'CREATE TABLE [test_table_three] ([main] int not null, [paragraph] nvarchar(max), CONSTRAINT [test_table_three_pkey] PRIMARY KEY ([main]))',
+              'CREATE TABLE [test_table_three] ([main] int not null, [paragraph] nvarchar(max), [metadata] text default \'{"a":10}\', CONSTRAINT [test_table_three_pkey] PRIMARY KEY ([main]))',
             ]);
           });
       });

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -1162,7 +1162,21 @@ describe('PostgreSQL SchemaBuilder', function() {
       })
       .toSQL();
     expect(tableSql[0].sql).to.equal(
-      'alter table "user" add column "preferences" json not null {}'
+      'alter table "user" add column "preferences" json not null default \'{}\''
+    );
+  });
+
+  it('allows adding default jsonb objects when the column is json', function() {
+    tableSql = client
+      .schemaBuilder()
+      .table('user', function(t) {
+        t.jsonb('preferences')
+          .defaultTo({})
+          .notNullable();
+      })
+      .toSQL();
+    expect(tableSql[0].sql).to.equal(
+      'alter table "user" add column "preferences" jsonb not null default \'{}\''
     );
   });
 

--- a/test/unit/schema/redshift.js
+++ b/test/unit/schema/redshift.js
@@ -689,7 +689,7 @@ describe('Redshift SchemaBuilder', function() {
       })
       .toSQL();
     expect(tableSql[0].sql).to.equal(
-      'alter table "user" add column "preferences" varchar(max) not null {}'
+      'alter table "user" add column "preferences" varchar(max) not null default \'{}\''
     );
   });
 


### PR DESCRIPTION
This PR addresses following issues: 

1. SQL Server allows default values for BLOB/nvarchar but knex ignores defaults for these types. This PR removes that behavior.

2. Setting default value of JSON(B) fields don't work and results in invalid syntax for pretty much all dialects (unless knex.raw is explicitly used). 