### PR TITLE
Fix remove duplicate transaction rejection

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -98,9 +98,6 @@ class Transaction extends EventEmitter {
             return null;
           })
           .catch((e) => {
-            if (this.initRejectFn) {
-              this.initRejectFn(e);
-            }
             return this._rejecter(e);
           });
 
@@ -109,8 +106,9 @@ class Transaction extends EventEmitter {
     ).catch((err) => {
       if (this.initRejectFn) {
         this.initRejectFn(err);
+      } else {
+        throw err;
       }
-      throw err;
     });
 
     this._completed = false;


### PR DESCRIPTION
An attempt to fix third reported issue from #3309.

Basically, if there is `initRejectFn` it means a transaction is used without a container, it means that `_promise` is not exposed, it means that if `_promise` is rejected there will be an unhandled rejection, it means that we should not reject that promise.

`initRejectFn` will do fine by itself. If an error happens before a transactor resolved (some problem with a connection) then it will reject `initPromise` which is returned for `knex.transaction()` so it is exposed and handled easily. If an error happens after a transactor resolved, it means that `initPromise` is already resolved (with said transactor) and calling `initRejectFn` will do nothing, but it is ok since only way to get here is from `executionPromise` rejection and it is exposed too and it will reject only after calls to `commit`/`rollback`.

(Ideally though `commit` and `rollback` for standalone transactors should reject themselves instead of `executionPromise` then it will be easier to handle with `async`/`await` and no need to expose `executionPromise`, but that is another issue...)

(Also removed unneeded duplicate call to `initRejectFn` since `_rejecter` will call it anyway)  