### PR TITLE
Fix return duplicate transaction promise for standalone transactions

### DIFF
--- a/src/util/make-knex.js
+++ b/src/util/make-knex.js
@@ -53,7 +53,7 @@ function initContext(knexFn) {
       let trx;
       return () => {
         if (!trx) {
-          trx = this.transaction(config);
+          trx = this.transaction(undefined, config);
         }
         return trx;
       };

--- a/test/integration/builder/transaction.js
+++ b/test/integration/builder/transaction.js
@@ -377,11 +377,10 @@ module.exports = function(knex) {
 
     it('does not reject promise when rolling back a transaction', async () => {
       const trxProvider = knex.transactionProvider();
-      const trxPromise = trxProvider();
+      const trx = await trxProvider();
 
-      await trxPromise.then((trx) => {
-        return trx.rollback();
-      });
+      await trx.rollback();
+      await trx.executionPromise;
     });
 
     it('should allow for nested transactions', function() {

--- a/test/unit/knex.js
+++ b/test/unit/knex.js
@@ -323,6 +323,9 @@ describe('knex', () => {
       .then((rows) => {
         expect(rows[0].result).to.equal(1);
         return transaction.commit();
+      })
+      .then(() => {
+        return transaction.executionPromise;
       });
   });
 
@@ -405,11 +408,10 @@ describe('knex', () => {
   it('does not reject promise when rolling back a transaction', async () => {
     const knex = Knex(sqliteConfig);
     const trxProvider = knex.transactionProvider();
-    const trxPromise = trxProvider();
+    const trx = await trxProvider();
 
-    await trxPromise.then((trx) => {
-      return trx.rollback();
-    });
+    await trx.rollback();
+    await trx.executionPromise;
   });
 
   it('creating transaction copy with user params should throw an error', () => {


### PR DESCRIPTION
So it seems like #3319 was a mistake and having a duplicate is needed because original execution promise does have `catch` [attached](https://github.com/tgriesser/knex/blob/4cde0fcb84071989811cfe1c17d001f1230a7b29/src/transaction.js#L106) so it will never produce unhandled rejections. So if you do not attach `catch` to `executionPromise` nobody will tell you that your transaction queries are failing (except this [debug statement](https://github.com/tgriesser/knex/blob/4cde0fcb84071989811cfe1c17d001f1230a7b29/src/transaction.js#L172)).

Solution: promise duplication but only for standalone transactions.