### PR TITLE
feat: Run specific seed file (closes #801)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -289,9 +289,10 @@ function invoke(env) {
     .command('seed:run')
     .description('        Run seed files.')
     .option('--verbose', 'verbose')
+    .option('--specific', 'run specific seed file')
     .action(() => {
       pending = initKnex(env, commander.opts())
-        .seed.run()
+        .seed.run({ specific: argv.specific })
         .then(([log]) => {
           if (log.length === 0) {
             success(color.cyan('No seed files exist'));

--- a/src/seed/Seeder.js
+++ b/src/seed/Seeder.js
@@ -23,13 +23,18 @@ function Seeder(knex) {
   this.config = this.setConfig(knex.client.config.seeds);
 }
 
-// Runs all seed files for the given environment.
+// Runs seed files for the given environment.
 Seeder.prototype.run = async function(config) {
   this.config = this.setConfig(config);
   return this._seedData()
     .bind(this)
     .then(([all]) => {
-      return this._runSeeds(all);
+      const files =
+        config && config.specific
+          ? all.filter((file) => file === config.specific)
+          : all;
+
+      return this._runSeeds(files);
     });
 };
 

--- a/test/integration/seed/index.js
+++ b/test/integration/seed/index.js
@@ -6,31 +6,32 @@ const rimraf = require('rimraf');
 
 module.exports = function(knex) {
   describe('knex.seed.make', () => {
-    it('should create a new seed file with the make method', () => {
-      return knex.seed.make('test').then((name) => {
-        rimraf.sync(path.dirname(name));
-        expect(path.basename(name)).to.equal('test.js');
-      });
+    it('should create a new seed file with the make method', async () => {
+      const name = await knex.seed.make('test');
+
+      rimraf.sync(path.dirname(name));
+      expect(path.basename(name)).to.equal('test.js');
     });
   });
 
   describe('knex.seed.run', () => {
-    it('should run all seed files in the configured seed directory', () => {
-      return knex.seed
-        .run({ directory: 'test/integration/seed/test' })
-        .then(([data]) => {
-          expect(path.basename(data[0])).to.equal('seed1.js');
-          expect(path.basename(data[1])).to.equal('seed2.js');
-        });
+    it('should run all seed files in the configured seed directory', async () => {
+      const [data] = await knex.seed.run({
+        directory: 'test/integration/seed/test',
+      });
+
+      expect(path.basename(data[0])).to.equal('seed1.js');
+      expect(path.basename(data[1])).to.equal('seed2.js');
     });
 
-    it('should run specific seed file in the configured seed directory', () => {
-      return knex.seed
-        .run({ directory: 'test/integration/seed/test', specific: 'seed2.js' })
-        .then(([data]) => {
-          expect(data.length).to.equal(1);
-          expect(path.basename(data[0])).to.equal('seed2.js');
-        });
+    it('should run specific seed file in the configured seed directory', async () => {
+      const [data] = await knex.seed.run({
+        directory: 'test/integration/seed/test',
+        specific: 'seed2.js',
+      });
+
+      expect(data.length).to.equal(1);
+      expect(path.basename(data[0])).to.equal('seed2.js');
     });
   });
 };

--- a/test/integration/seed/index.js
+++ b/test/integration/seed/index.js
@@ -5,22 +5,31 @@ const path = require('path');
 const rimraf = require('rimraf');
 
 module.exports = function(knex) {
-  describe('knex.seed.make', function() {
-    it('should create a new seed file with the make method', function() {
-      return knex.seed.make('test').then(function(name) {
+  describe('knex.seed.make', () => {
+    it('should create a new seed file with the make method', () => {
+      return knex.seed.make('test').then((name) => {
         rimraf.sync(path.dirname(name));
         expect(path.basename(name)).to.equal('test.js');
       });
     });
   });
 
-  describe('knex.seed.run', function() {
-    it('should run all seed files in the configured seed directory', function() {
+  describe('knex.seed.run', () => {
+    it('should run all seed files in the configured seed directory', () => {
       return knex.seed
         .run({ directory: 'test/integration/seed/test' })
         .then(([data]) => {
           expect(path.basename(data[0])).to.equal('seed1.js');
           expect(path.basename(data[1])).to.equal('seed2.js');
+        });
+    });
+
+    it('should run specific seed file in the configured seed directory', () => {
+      return knex.seed
+        .run({ directory: 'test/integration/seed/test', specific: 'seed2.js' })
+        .then(([data]) => {
+          expect(data.length).to.equal(1);
+          expect(path.basename(data[0])).to.equal('seed2.js');
         });
     });
   });

--- a/test/jake/jakelib/seed-test.js
+++ b/test/jake/jakelib/seed-test.js
@@ -35,6 +35,16 @@ test(taskList, 'seed:run prints verbose logs', (temp) => {
   });
 });
 
+test(taskList, 'seed:run runs specific file', () => {
+  return assertExec(
+    `node ${KNEX} seed:run --knexfile=test/jake-util/seeds-knexfile.js --knexpath=../knex.js --specific=second.js`
+  ).then(({ stdout }) => {
+    assert.include(stdout, 'Ran 1 seed files');
+    assert.notInclude(stdout, 'first.js');
+    assert.notInclude(stdout, 'second.js');
+  });
+});
+
 test(taskList, 'Handles seeding errors correctly', (temp) => {
   return assertExecError(
     `node ${KNEX} seed:run --knexfile=test/jake-util/seeds-error-knexfile.js --knexpath=../knex.js`


### PR DESCRIPTION
This features allows to run a specific seed file.
It adds an additional cli property `--specific=filename.js` which points to some seed file in the seed directory.

usage: `npx knex seed:run --specific=seed-filename.js`