### PR TITLE
Minor enhancements around aliasing of aggregates

### DIFF
--- a/lib/dialects/mssql/query/compiler.js
+++ b/lib/dialects/mssql/query/compiler.js
@@ -136,7 +136,7 @@ Object.assign(QueryCompiler_MSSQL.prototype, {
         const stmt = columns[i];
         if (stmt.distinct) distinct = true;
         if (stmt.type === 'aggregate') {
-          sql.push(this.aggregate(stmt));
+          sql.push(...this.aggregate(stmt));
         } else if (stmt.type === 'aggregateRaw') {
           sql.push(this.aggregateRaw(stmt));
         } else if (stmt.value && stmt.value.length > 0) {

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -22,6 +22,8 @@ const {
   toArray,
   reject,
   includes,
+  last,
+  isPlainObject
 } = require('lodash');
 const saveAsyncStack = require('../util/save-async-stack');
 
@@ -869,33 +871,37 @@ assign(Builder.prototype, {
   },
 
   // Retrieve the "count" result of the query.
-  count(column) {
-    return this._aggregate('count', column || '*');
+  count(column, options) {
+    return this._aggregate('count', column || '*', options);
   },
 
   // Retrieve the minimum value of a given column.
-  min(column) {
-    return this._aggregate('min', column);
+  min(column, options) {
+    return this._aggregate('min', column, options);
   },
 
   // Retrieve the maximum value of a given column.
-  max(column) {
-    return this._aggregate('max', column);
+  max(column, options) {
+    return this._aggregate('max', column, options);
   },
 
   // Retrieve the sum of the values of a given column.
-  sum(column) {
-    return this._aggregate('sum', column);
+  sum(column, options) {
+    return this._aggregate('sum', column, options);
   },
 
   // Retrieve the average of the values of a given column.
-  avg(column) {
-    return this._aggregate('avg', column);
+  avg(column, options) {
+    return this._aggregate('avg', column, options);
   },
 
   // Retrieve the "count" of the distinct results of the query.
   countDistinct() {
     let columns = helpers.normalizeArr.apply(null, arguments);
+    let options;
+    if (columns.length > 1 && isPlainObject(last(columns))) {
+        ([options] = columns.splice(columns.length - 1, 1));
+    }
 
     if (!columns.length) {
       columns = '*';
@@ -903,17 +909,17 @@ assign(Builder.prototype, {
       columns = columns[0];
     }
 
-    return this._aggregate('count', columns, true);
+    return this._aggregate('count', columns, {...options, distinct: true});
   },
 
   // Retrieve the sum of the distinct values of a given column.
-  sumDistinct(column) {
-    return this._aggregate('sum', column, true);
+  sumDistinct(column, options) {
+    return this._aggregate('sum', column, {...options, distinct: true});
   },
 
   // Retrieve the vg of the distinct results of the query.
-  avgDistinct(column) {
-    return this._aggregate('avg', column, true);
+  avgDistinct(column, options) {
+    return this._aggregate('avg', column, {...options, distinct: true});
   },
 
   // Increments a column's value by the specified amount.
@@ -1198,13 +1204,14 @@ assign(Builder.prototype, {
   },
 
   // Helper for compiling any aggregate queries.
-  _aggregate(method, column, aggregateDistinct) {
+  _aggregate(method, column, options = {}) {
     this._statements.push({
       grouping: 'columns',
       type: column instanceof Raw ? 'aggregateRaw' : 'aggregate',
       method,
       value: column,
-      aggregateDistinct: aggregateDistinct || false,
+      aggregateDistinct: options.distinct || false,
+      alias: options.as
     });
     return this;
   },

--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -194,7 +194,7 @@ assign(QueryCompiler.prototype, {
         const stmt = columns[i];
         if (stmt.distinct) distinct = true;
         if (stmt.type === 'aggregate') {
-          sql.push(this.aggregate(stmt));
+          sql.push(...this.aggregate(stmt));
         } else if (stmt.type === 'aggregateRaw') {
           sql.push(this.aggregateRaw(stmt));
         } else if (stmt.value && stmt.value.length > 0) {
@@ -239,28 +239,33 @@ assign(QueryCompiler.prototype, {
     };
 
     if (Array.isArray(value)) {
-      return aggregateArray(value);
+      return [aggregateArray(value)];
     }
 
     if (typeof value === 'object') {
-      const keys = Object.keys(value);
-      const alias = keys[0];
-      const column = value[alias];
-      if (Array.isArray(column)) {
-        return aggregateArray(column, alias);
+      if (stmt.alias) {
+          throw new Error('When using an object explicit alias can not be used');
       }
-      return aggregateString(column, alias);
+      return Object.entries(value).map(([alias, column]) => {
+          if (Array.isArray(column)) {
+            return aggregateArray(column, alias);
+          }
+          return aggregateString(column, alias);
+      });
     }
 
     // Allows us to speciy an alias for the aggregate types.
     const splitOn = value.toLowerCase().indexOf(' as ');
+    let column = value;
+    let {alias} = stmt;
     if (splitOn !== -1) {
-      const column = value.slice(0, splitOn);
-      const alias = value.slice(splitOn + 4);
-      return aggregateString(column, alias);
+      column = value.slice(0, splitOn);
+      if (alias) {
+          throw new Error(`Found multiple aliases for same column: ${column}`);
+      }
+      alias = value.slice(splitOn + 4);
     }
-
-    return aggregateString(value);
+    return [aggregateString(column, alias)];
   },
 
   aggregate(stmt) {

--- a/test/integration/builder/aggregate.js
+++ b/test/integration/builder/aggregate.js
@@ -79,6 +79,167 @@ module.exports = function(knex) {
         });
     });
 
+    it('supports sum with an alias', function() {
+      return knex('accounts')
+        .sum('logins', {as: 'login_sum'})
+        .testSql(function(tester) {
+          tester(
+            'mysql',
+            'select sum(`logins`) as `login_sum` from `accounts`',
+            [],
+            [
+              {
+                login_sum: 10,
+              },
+            ]
+          );
+          tester(
+            'mysql2',
+            'select sum(`logins`) as `login_sum` from `accounts`',
+            [],
+            [
+              {
+                login_sum: '10',
+              },
+            ]
+          );
+          tester(
+            'pg',
+            'select sum("logins") as "login_sum" from "accounts"',
+            [],
+            [
+              {
+                login_sum: '10',
+              },
+            ]
+          );
+          tester(
+            'pg-redshift',
+            'select sum("logins") as "login_sum" from "accounts"',
+            [],
+            [
+              {
+                login_sum: '10',
+              },
+            ]
+          );
+          tester(
+            'sqlite3',
+            'select sum(`logins`) as `login_sum` from `accounts`',
+            [],
+            [
+              {
+                login_sum: 10,
+              },
+            ]
+          );
+          tester(
+            'oracledb',
+            'select sum("logins") "login_sum" from "accounts"',
+            [],
+            [
+              {
+                login_sum: 10,
+              },
+            ]
+          );
+          tester(
+            'mssql',
+            'select sum([logins]) as [login_sum] from [accounts]',
+            [],
+            [
+              {
+                login_sum: 10,
+              },
+            ]
+          );
+        });
+    });
+
+    it('supports sum through object containing multiple aliases', function() {
+      return knex('accounts')
+        .sum({login_sum: 'logins', balance_sum: 'balance'})
+        .testSql(function(tester) {
+          tester(
+            'mysql',
+            'select sum(`logins`) as `login_sum`, sum(`balance`) as `balance_sum` from `accounts`',
+            [],
+            [
+              {
+                balance_sum: 0,
+                login_sum: 10,
+              },
+            ]
+          );
+          tester(
+            'mysql2',
+            'select sum(`logins`) as `login_sum`, sum(`balance`) as `balance_sum` from `accounts`',
+            [],
+            [
+              {
+                balance_sum: 0,
+                login_sum: '10',
+              },
+            ]
+          );
+          tester(
+            'pg',
+            'select sum("logins") as "login_sum", sum("balance") as "balance_sum" from "accounts"',
+            [],
+            [
+              {
+                balance_sum: 0,
+                login_sum: '10',
+              },
+            ]
+          );
+          tester(
+            'pg-redshift',
+            'select sum("logins") as "login_sum", sum("balance") as "balance_sum" from "accounts"',
+            [],
+            [
+              {
+                balance_sum: '0',
+                login_sum: '10',
+              },
+            ]
+          );
+          tester(
+            'sqlite3',
+            'select sum(`logins`) as `login_sum`, sum(`balance`) as `balance_sum` from `accounts`',
+            [],
+            [
+              {
+                balance_sum: 0,
+                login_sum: 10,
+              },
+            ]
+          );
+          tester(
+            'oracledb',
+            'select sum("logins") "login_sum", sum("balance") "balance_sum" from "accounts"',
+            [],
+            [
+              {
+                balance_sum: 0,
+                login_sum: 10,
+              },
+            ]
+          );
+          tester(
+            'mssql',
+            'select sum([logins]) as [login_sum], sum([balance]) as [balance_sum] from [accounts]',
+            [],
+            [
+              {
+                balance_sum: 0,
+                login_sum: 10,
+              },
+            ]
+          );
+        });
+    });
+
     it('has an avg', function() {
       return knex('accounts')
         .avg('logins')


### PR DESCRIPTION
- Allows an options object to specify alias (as suggested in https://github.com/tgriesser/knex/issues/3315#issuecomment-507439215) (Closes #3315)
- Allows multiple aliases when using object syntax (Closes #2871)