### PR TITLE
Update configuration typings to allow for oracle db connectionstring

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1596,6 +1596,7 @@ declare namespace Knex {
       | MariaSqlConnectionConfig
       | MySqlConnectionConfig
       | MsSqlConnectionConfig
+      | OracleDbConnectionConfig
       | Sqlite3ConnectionConfig
       | SocketConnectionConfig;
     pool?: PoolConfig;
@@ -1721,6 +1722,18 @@ declare namespace Knex {
     flags?: string;
     ssl?: string | MariaSslConfiguration;
     decimalNumbers?: boolean;
+  }
+  
+  interface OracleDbConnectionConfig {
+    host: string;
+    user: string;
+    password?: string;
+    database?: string;
+    domain?: string;
+    instanceName?: string;
+    debug?: boolean;
+    requestTimeout?: number;
+    connectString?: string;
   }
 
   /** Used with SQLite3 adapter */


### PR DESCRIPTION
I am working on a typescript project with an oracle database using SID and we currently have it configured with a custom connectString. We were hoping to move to knex and ran into a typescript issue. Here is the resolution we used to get it working. 