### PR TITLE
Add .isCompleted() to transaction

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -264,6 +264,8 @@ function makeTransactor(trx, connection, trxClient) {
     transactor.rollback = (error) => trx.rollback(connection, error);
   }
 
+  transactor.isCompleted = () => trx.isCompleted();
+
   return transactor;
 }
 

--- a/test/unit/knex.js
+++ b/test/unit/knex.js
@@ -445,6 +445,15 @@ describe('knex', () => {
     expect(completed).to.be.true;
   });
 
+  it('returns false when calling isCompleted within a transaction handler', async () => {
+    const knex = Knex(sqliteConfig);
+    await knex.transaction((trx) => {
+      expect(trx.isCompleted()).to.be.false;
+
+      return trx.select(trx.raw('1 as result'));
+    });
+  });
+
   it('creating transaction copy with user params should throw an error', () => {
     if (!sqliteConfig) {
       return;

--- a/test/unit/knex.js
+++ b/test/unit/knex.js
@@ -414,6 +414,37 @@ describe('knex', () => {
     await trx.executionPromise;
   });
 
+  it('returns false when calling isCompleted on a transaction that is not complete', async () => {
+    const knex = Knex(sqliteConfig);
+    const trxProvider = knex.transactionProvider();
+    const trx = await trxProvider();
+
+    const completed = trx.isCompleted();
+    expect(completed).to.be.false;
+  });
+
+  it('returns true when calling isCompleted on a transaction that is committed', async () => {
+    const knex = Knex(sqliteConfig);
+    const trxProvider = knex.transactionProvider();
+    const trx = await trxProvider();
+
+    await trx.commit();
+
+    const completed = trx.isCompleted();
+    expect(completed).to.be.true;
+  });
+
+  it('returns true when calling isCompleted on a transaction that is rolled back', async () => {
+    const knex = Knex(sqliteConfig);
+    const trxProvider = knex.transactionProvider();
+    const trx = await trxProvider();
+
+    await trx.rollback();
+
+    const completed = trx.isCompleted();
+    expect(completed).to.be.true;
+  });
+
   it('creating transaction copy with user params should throw an error', () => {
     if (!sqliteConfig) {
       return;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1405,6 +1405,7 @@ declare namespace Knex {
   interface Transaction<TRecord extends {} = any, TResult = any>
     extends Knex<TRecord, TResult> {
     executionPromise: Promise<TResult>;
+    isCompleted: () => boolean;
 
     query<TRecord extends {} = any, TResult = void>(
       conn: any,


### PR DESCRIPTION
Adds .isCompleted() to a transactor, which just calls the underlying .isCompleted() from the transaction. I needed it because in my application, I pass a transaction around as part of a request and as a safeguard, I am rolling back the transaction. However, sometimes the transaction is already complete. This just harmlessly exposes whether I am allowed to commit/rollback or not.