### PR TITLE
Handle null bytes in Postgres strings

### DIFF
--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -59,6 +59,9 @@ Object.assign(Client_PG.prototype, {
         const c = str[i];
         if (c === "'") {
           escaped += c + c;
+        } else if (c === '\0') {
+          escaped += '\\x00';
+          hasBackslash = true;
         } else if (c === '\\') {
           escaped += c + c;
           hasBackslash = true;

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -8178,6 +8178,19 @@ describe('QueryBuilder', function() {
     );
   });
 
+  it('escapes null bytes properly', function() {
+    testquery(
+      qb()
+        .select('*')
+        .from('strings')
+        .where('value', 'a tricky\0 user string'),
+      {
+        pg:
+          'select * from "strings" where "value" = E\'a tricky\\x00 user string\'',
+      }
+    );
+  });
+
   it('allows join without operator and with value 0 #953', function() {
     testsql(
       qb()


### PR DESCRIPTION
Older versions of knex handled null bytes in strings reasonably, but
newer versions do not. This commit fixes this regression by converting
any string with a null byte in it into a Postgres escape string with
an escaped hex value.