### PR TITLE
Fix broken noWait test

### DIFF
--- a/test/integration/builder/selects.js
+++ b/test/integration/builder/selects.js
@@ -1255,6 +1255,9 @@ module.exports = function(knex) {
       }
 
       const rowName = 'row for skipLocked() test #1';
+      await knex('test_default_table')
+        .delete()
+        .where({ string: rowName });
       await knex('test_default_table').insert([
         { string: rowName, tinyint: 1 },
         { string: rowName, tinyint: 2 },
@@ -1290,6 +1293,9 @@ module.exports = function(knex) {
       }
 
       const rowName = 'row for skipLocked() test #2';
+      await knex('test_default_table')
+        .delete()
+        .where({ string: rowName });
       await knex('test_default_table').insert([
         { string: rowName, tinyint: 1 },
         { string: rowName, tinyint: 2 },
@@ -1321,6 +1327,9 @@ module.exports = function(knex) {
       }
 
       const rowName = 'row for noWait() test';
+      await knex('test_default_table')
+        .delete()
+        .where({ string: rowName });
       await knex('test_default_table').insert([
         { string: rowName, tinyint: 1 },
         { string: rowName, tinyint: 2 },

--- a/test/integration/builder/selects.js
+++ b/test/integration/builder/selects.js
@@ -1268,10 +1268,10 @@ module.exports = function(knex) {
         await trx('test_default_table')
           .where({ string: rowName })
           .orderBy('tinyint', 'asc')
-          .first()
-          .forUpdate();
+          .forUpdate()
+          .first();
 
-        // try to lock the next available row
+        // try to lock the next available row from outside of the transaction
         return await knex('test_default_table')
           .where({ string: rowName })
           .orderBy('tinyint', 'asc')
@@ -1307,15 +1307,15 @@ module.exports = function(knex) {
           .where({ string: rowName })
           .forUpdate();
 
-        // try to aquire the lock on one more row (which isn't available)
+        // try to aquire the lock on one more row (which isn't available) from another transaction
         return await knex('test_default_table')
           .where({ string: rowName })
           .forUpdate()
           .skipLocked()
-          .limit(1);
+          .first();
       });
 
-      expect(res).to.be.empty;
+      expect(res).to.be.undefined;
     });
 
     it('forUpdate().noWait() should throw immediately when a row is locked', async function() {


### PR DESCRIPTION
This fixes one of the tests from #2961 that got broken recently, and throws a very minor refactoring of the skipLocked tests to make them a little bit cleaner.

I had to re-write most of the test to use try/catch to have it resolve properly (otherwise the catch handler wouldn't fully handle the error when using await), but after doing so, it also seems the test is easier to read this way.

I also made the involved tests clear the related rows before starting, as I was getting test failures after running them multiple times because they were designed with only a single run in mind (oops).