### PR TITLE
fix: make transaction rejection consistent across dialects

### DIFF
--- a/lib/dialects/mysql/transaction.js
+++ b/lib/dialects/mysql/transaction.js
@@ -30,11 +30,7 @@ Object.assign(Transaction_MySQL.prototype, {
         if (status === 1) t._resolver(value);
         if (status === 2) {
           if (isUndefined(value)) {
-            if (
-              sql &&
-              sql.toUpperCase() === 'ROLLBACK' &&
-              t.doNotRejectOnRollback
-            ) {
+            if (t.doNotRejectOnRollback && /^ROLLBACK\b/i.test(sql)) {
               t._resolver();
               return;
             }

--- a/lib/dialects/mysql2/transaction.js
+++ b/lib/dialects/mysql2/transaction.js
@@ -29,11 +29,7 @@ Object.assign(Transaction_MySQL2.prototype, {
         if (status === 1) t._resolver(value);
         if (status === 2) {
           if (isUndefined(value)) {
-            if (
-              sql &&
-              sql.toUpperCase() === 'ROLLBACK' &&
-              t.doNotRejectOnRollback
-            ) {
+            if (t.doNotRejectOnRollback && /^ROLLBACK\b/i.test(sql)) {
               t._resolver();
               return;
             }


### PR DESCRIPTION
Making `mysql` and `mysql2` dialects use the same `sql` check as the base transaction class.