### PR TITLE
Fix native enum with specified schema (#3307)

### DIFF
--- a/lib/dialects/postgres/schema/columncompiler.js
+++ b/lib/dialects/postgres/schema/columncompiler.js
@@ -36,11 +36,10 @@ Object.assign(ColumnCompiler_PG.prototype, {
 
     if (options.useNative) {
       let enumName = '';
+      const schemaName = this.tableCompiler.schemaNameRaw;
 
-      if (options.schema === true && this.tableCompiler.schemaNameRaw) {
-        enumName += `"${this.tableCompiler.schemaNameRaw}".`;
-      } else if (options.schema && typeof options.schema === 'string') {
-        enumName += `"${options.schema}".`;
+      if (schemaName) {
+        enumName += `"${schemaName}".`;
       }
 
       enumName += `"${options.enumName}"`;

--- a/lib/dialects/postgres/schema/columncompiler.js
+++ b/lib/dialects/postgres/schema/columncompiler.js
@@ -35,13 +35,23 @@ Object.assign(ColumnCompiler_PG.prototype, {
         : allowed.join("', '");
 
     if (options.useNative) {
+      let enumName = '';
+
+      if (options.schema === true && this.tableCompiler.schemaNameRaw) {
+        enumName += `"${this.tableCompiler.schemaNameRaw}".`;
+      } else if (options.schema && typeof options.schema === 'string') {
+        enumName += `"${options.schema}".`;
+      }
+
+      enumName += `"${options.enumName}"`;
+
       if (!options.existingType) {
         this.tableCompiler.unshiftQuery(
-          `create type "${options.enumName}" as enum ('${values}')`
+          `create type ${enumName} as enum ('${values}')`
         );
       }
 
-      return `"${options.enumName}"`;
+      return enumName;
     }
     return `text check (${this.formatter.wrap(this.args[0])} in ('${values}'))`;
   },

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -297,28 +297,6 @@ module.exports = function(knex) {
           });
         });
 
-        it('uses native type with specified schema', function() {
-          return knex.schema.createSchemaIfNotExists('test').then(() => {
-            return knex.schema
-              .createTable('native_enum_test', function(table) {
-                table
-                  .enum('foo_column', ['a', 'b', 'c'], {
-                    useNative: true,
-                    enumName: 'foo_type',
-                    schema: 'test',
-                  })
-                  .notNull();
-                table.uuid('id').notNull();
-              })
-              .testSql(function(tester) {
-                tester('pg', [
-                  "create type \"test\".\"foo_type\" as enum ('a', 'b', 'c')",
-                  'create table "native_enum_test" ("foo_column" "test"."foo_type" not null, "id" uuid not null)',
-                ]);
-              });
-          });
-        });
-
         it('uses native type when useNative is specified', function() {
           return knex.schema
             .createTable('native_enum_test', function(table) {

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -270,28 +270,53 @@ module.exports = function(knex) {
         afterEach(function() {
           return knex.schema
             .dropTableIfExists('native_enum_test')
-            .raw('DROP TYPE "foo_type"')
+            .raw('DROP TYPE IF EXISTS "foo_type"')
             .raw('DROP SCHEMA IF EXISTS "test" CASCADE');
         });
 
-        it('uses native type with specified schema', async function() {
-          return knex.schema
-            .withSchema('test')
-            .createTable('native_enum_test', function(table) {
-              table
-                .enum('foo_column', ['a', 'b', 'c'], {
-                  useNative: true,
-                  enumName: 'foo_type',
-                })
-                .notNull();
-              table.uuid('id').notNull();
-            })
-            .testSql(function(tester) {
-              tester('pg', [
-                "create type \"test\".\"foo_type\" as enum ('a', 'b', 'c')",
-                'create table "native_enum_test" ("foo_column" "test"."foo_type" not null, "id" uuid not null)',
-              ]);
-            });
+        it('uses native type with schema', function() {
+          return knex.schema.createSchemaIfNotExists('test').then(() => {
+            return knex.schema
+              .withSchema('test')
+              .createTable('native_enum_test', function(table) {
+                table
+                  .enum('foo_column', ['a', 'b', 'c'], {
+                    useNative: true,
+                    enumName: 'foo_type',
+                    schema: true,
+                  })
+                  .notNull();
+                table.uuid('id').notNull();
+              })
+              .testSql(function(tester) {
+                tester('pg', [
+                  "create type \"test\".\"foo_type\" as enum ('a', 'b', 'c')",
+                  'create table "test"."native_enum_test" ("foo_column" "test"."foo_type" not null, "id" uuid not null)',
+                ]);
+              });
+          });
+        });
+
+        it('uses native type with specified schema', function() {
+          return knex.schema.createSchemaIfNotExists('test').then(() => {
+            return knex.schema
+              .createTable('native_enum_test', function(table) {
+                table
+                  .enum('foo_column', ['a', 'b', 'c'], {
+                    useNative: true,
+                    enumName: 'foo_type',
+                    schema: 'test',
+                  })
+                  .notNull();
+                table.uuid('id').notNull();
+              })
+              .testSql(function(tester) {
+                tester('pg', [
+                  "create type \"test\".\"foo_type\" as enum ('a', 'b', 'c')",
+                  'create table "native_enum_test" ("foo_column" "test"."foo_type" not null, "id" uuid not null)',
+                ]);
+              });
+          });
         });
 
         it('uses native type when useNative is specified', function() {

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -918,31 +918,6 @@ describe('PostgreSQL SchemaBuilder', function() {
     );
   });
 
-  it('adding enum with useNative and specified schema', function() {
-    const schema = 'test';
-    const enumName = 'foo_type1';
-
-    tableSql = client
-      .schemaBuilder()
-      .table('users', function(table) {
-        table
-          .enu('foo', ['bar', 'baz'], {
-            useNative: true,
-            enumName,
-            schema,
-          })
-          .notNullable();
-      })
-      .toSQL();
-    equal(2, tableSql.length);
-    expect(tableSql[0].sql).to.equal(
-      `create type "${schema}"."${enumName}" as enum ('bar', 'baz')`
-    );
-    expect(tableSql[1].sql).to.equal(
-      `alter table "users" add column "foo" "${schema}"."${enumName}" not null`
-    );
-  });
-
   it('adding enum with useNative and existingType', function() {
     tableSql = client
       .schemaBuilder()

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -892,6 +892,57 @@ describe('PostgreSQL SchemaBuilder', function() {
     );
   });
 
+  it('adding enum with useNative and withSchema', function() {
+    const schema = 'test';
+    const enumName = 'foo_type';
+
+    tableSql = client
+      .schemaBuilder()
+      .withSchema(schema)
+      .table('users', function(table) {
+        table
+          .enu('foo', ['bar', 'baz'], {
+            useNative: true,
+            schema: true,
+            enumName,
+          })
+          .notNullable();
+      })
+      .toSQL();
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      `create type "${schema}"."${enumName}" as enum ('bar', 'baz')`
+    );
+    expect(tableSql[1].sql).to.equal(
+      `alter table "${schema}"."users" add column "foo" "${schema}"."${enumName}" not null`
+    );
+  });
+
+  it('adding enum with useNative and specified schema', function() {
+    const schema = 'test';
+    const enumName = 'foo_type1';
+
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function(table) {
+        table
+          .enu('foo', ['bar', 'baz'], {
+            useNative: true,
+            enumName,
+            schema,
+          })
+          .notNullable();
+      })
+      .toSQL();
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      `create type "${schema}"."${enumName}" as enum ('bar', 'baz')`
+    );
+    expect(tableSql[1].sql).to.equal(
+      `alter table "users" add column "foo" "${schema}"."${enumName}" not null`
+    );
+  });
+
   it('adding enum with useNative and existingType', function() {
     tableSql = client
       .schemaBuilder()


### PR DESCRIPTION
# Fixes issue: #3307

## Current behaviour:

```javascript
knex
      .schemaBuilder()
      .withSchema('test')
      .table('users', function(table) {
        table
          .enu('foo', ['bar', 'baz'], {
            useNative: true,
            enumName: 'foo_bar',
          })
      })
      .toSQL();
```

## Outputs:
```sql
-- ...
create type "foo_bar" as enum ('bar', 'baz');
alter table "test"."users" add column "foo" "foo_bar";
-- ...
```

Schema builder doesn't take into account `withSchema` expression and always creates a type in `public` schema.

## API proposal:
- `options.schema = '<schema name>'` - use specified schema name;
- `options.schema = true` -  use schema from `withSchema` expression (for backward compatibility if needed);

### Example 1: `options.schema = '<schema name>'` 

```javascript
knex
      .schemaBuilder()
      .withSchema('test')
      .table('users', function(table) {
        table
          .enu('foo', ['bar', 'baz'], {
            useNative: true,
            enumName: 'foo_bar',
            schema: 'test_2',
          })
      })
      .toSQL();
```

Outputs:
```sql
-- ...
create type "test_2"."foo_bar" as enum ('bar', 'baz');
alter table "test"."users" add column "foo" "test_2"."foo_bar";
-- ...
```

### Example 2: `options.schema = true`

```javascript
knex
      .schemaBuilder()
      .withSchema('test')
      .table('users', function(table) {
        table
          .enu('foo', ['bar', 'baz'], {
            useNative: true,
            enumName: 'foo_bar',
            schema: true,
          })
      })
      .toSQL();
```

Outputs:
```sql
-- ...
create type "test"."foo_bar" as enum ('bar', 'baz');
alter table "test"."users" add column "foo" "test"."foo_bar";
-- ...
```