### PR TITLE
#3405 Allow `ColumnBuilder.defaultTo()` to be `null`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1543,7 +1543,7 @@ declare namespace Knex {
     references(columnName: string): ReferencingColumnBuilder;
     onDelete(command: string): ColumnBuilder;
     onUpdate(command: string): ColumnBuilder;
-    defaultTo(value: Value): ColumnBuilder;
+    defaultTo(value: Value | null): ColumnBuilder;
     unsigned(): ColumnBuilder;
     notNullable(): ColumnBuilder;
     nullable(): ColumnBuilder;


### PR DESCRIPTION
Augment the `defaultTo` method's type to allow `null` which is required when setting a column's default to be `null` with TypeScript's strict mode enabled.