### PR TITLE
Add SSL/TLS support for Postgres connection string

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "liftoff": "3.1.0",
     "lodash": "^4.17.15",
     "mkdirp": "^0.5.1",
-    "pg-connection-string": "2.0.0",
+    "pg-connection-string": "2.1.0",
     "tarn": "^2.0.0",
     "tildify": "2.0.0",
     "uuid": "^3.3.2",


### PR DESCRIPTION
- Upgrade pg-connection-string to 2.1.0

Fixes #852