### PR TITLE
add ability to manually define schema for enu with useNative (#3307)

### DIFF
--- a/lib/dialects/postgres/schema/columncompiler.js
+++ b/lib/dialects/postgres/schema/columncompiler.js
@@ -36,7 +36,7 @@ Object.assign(ColumnCompiler_PG.prototype, {
 
     if (options.useNative) {
       let enumName = '';
-      const schemaName = this.tableCompiler.schemaNameRaw;
+      const schemaName = options.schemaName || this.tableCompiler.schemaNameRaw;
 
       if (schemaName) {
         enumName += `"${schemaName}".`;

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -964,6 +964,58 @@ describe('PostgreSQL SchemaBuilder', function() {
     );
   });
 
+  it('adding enum with useNative, from manually defined schema and withSchema', function() {
+    const tableSchema = 'table_schema';
+    const tableName = 'table_name';
+    const typeSchema = 'type_schema';
+    const typeName = 'type_name';
+    const columnName = 'column_name';
+
+    tableSql = client
+      .schemaBuilder()
+      .withSchema(tableSchema)
+      .table(tableName, function(table) {
+        table.enu(columnName, ['foo', 'bar', 'baz'], {
+          useNative: true,
+          schemaName: typeSchema,
+          enumName: typeName,
+        });
+      })
+      .toSQL();
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      `create type "${typeSchema}"."${typeName}" as enum ('foo', 'bar', 'baz')`
+    );
+    expect(tableSql[1].sql).to.equal(
+      `alter table "${tableSchema}"."${tableName}" add column "${columnName}" "${typeSchema}"."${typeName}"`
+    );
+  });
+
+  it('adding enum with useNative and existingType, from manually defined schema and withSchema', function() {
+    const tableSchema = 'table_schema';
+    const tableName = 'table_name';
+    const typeSchema = 'type_schema';
+    const typeName = 'type_name';
+    const columnName = 'column_name';
+
+    tableSql = client
+      .schemaBuilder()
+      .withSchema(tableSchema)
+      .table(tableName, function(table) {
+        table.enu(columnName, null, {
+          useNative: true,
+          schemaName: typeSchema,
+          enumName: typeName,
+          existingType: true,
+        });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      `alter table "${tableSchema}"."${tableName}" add column "${columnName}" "${typeSchema}"."${typeName}"`
+    );
+  });
+
   it('adding date', function() {
     tableSql = client
       .schemaBuilder()


### PR DESCRIPTION
# Fixes issue: #3307
## Improve https://github.com/tgriesser/knex/pull/3400

There is no way to define schema manually, the schema name from withSchema will be always prepended to enumName.

### Current behaviour:

#### Code:
```javascript
knex
      .schemaBuilder()
      .withSchema('test')
      .table('users', function(table) {
        table
          .enu('foo', ['bar', 'baz'], {
            useNative: true,
            enumName: 'type_schema.foo_bar',
          })
      })
      .toSQL();
```

#### Outputs:

```sql
-- ...
create type "test"."type_schema"."foo_bar" as enum ('bar', 'baz');
alter table "test"."users" add column "foo" "test"."type_schema"."foo_bar";
-- ...
```



### API proposal:
If enumName includes a dot, then don't prepend the schema name from withSchema to enumName.

### Example 1:

#### Code:
```javascript
knex
      .schemaBuilder()
      .withSchema('test')
      .table('users', function(table) {
        table
          .enu('foo', ['bar', 'baz'], {
            useNative: true,
            existingType: true,
            enumName: 'type_schema.foo_bar'
          })
      })
      .toSQL();
```

#### Outputs:
```sql
-- ...
alter table "test"."users" add column "foo" "type_schema"."foo_bar";
-- ...
```

### Example 2:

#### Code:
```javascript
knex
      .schemaBuilder()
      .withSchema('test')
      .table('users', function(table) {
        table
          .enu('foo', ['bar', 'baz'], {
            useNative: true,
            enumName: 'type_schema.foo_bar'
          })
      })
      .toSQL();
```

#### Outputs:
```sql
-- ...
create type "type_schema"."foo_bar" as enum ('bar', 'baz');
alter table "test"."users" add column "foo" "type_schema"."foo_bar";
-- ...
```