### PR TITLE
Migrations up/down commands: filename parameter

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -190,11 +190,13 @@ function invoke(env) {
     });
 
   commander
-    .command('migrate:up')
-    .description('        Run the next migration that has not yet been run.')
-    .action(() => {
+    .command('migrate:up [<name>]')
+    .description(
+      '        Run the next or the defined migration that has not yet been run.'
+    )
+    .action((name) => {
       pending = initKnex(env, commander.opts())
-        .migrate.up()
+        .migrate.up(name)
         .then(([batchNo, log]) => {
           if (log.length === 0) {
             success(color.cyan('Already up to date'));
@@ -235,11 +237,11 @@ function invoke(env) {
     });
 
   commander
-    .command('migrate:down')
-    .description('        Undo the last migration performed.')
-    .action(() => {
+    .command('migrate:down [<name>]')
+    .description('        Undo the last or the defined migration performed.')
+    .action((name) => {
       pending = initKnex(env, commander.opts())
-        .migrate.down()
+        .migrate.down(name)
         .then(([batchNo, log]) => {
           if (log.length === 0) {
             success(color.cyan('Already at the base migration'));

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -196,7 +196,7 @@ function invoke(env) {
     )
     .action((name) => {
       pending = initKnex(env, commander.opts())
-        .migrate.up(name)
+        .migrate.up({ name })
         .then(([batchNo, log]) => {
           if (log.length === 0) {
             success(color.cyan('Already up to date'));
@@ -243,7 +243,7 @@ function invoke(env) {
     )
     .action((name) => {
       pending = initKnex(env, commander.opts())
-        .migrate.down(name)
+        .migrate.down({ name })
         .then(([batchNo, log]) => {
           if (log.length === 0) {
             success(color.cyan('Already at the base migration'));

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -192,7 +192,7 @@ function invoke(env) {
   commander
     .command('migrate:up [<name>]')
     .description(
-      '        Run the next or the defined migration that has not yet been run.'
+      '        Run the next or the specified migration that has not yet been run.'
     )
     .action((name) => {
       pending = initKnex(env, commander.opts())
@@ -238,7 +238,9 @@ function invoke(env) {
 
   commander
     .command('migrate:down [<name>]')
-    .description('        Undo the last or the defined migration performed.')
+    .description(
+      '        Undo the last or the specified migration that was already run.'
+    )
     .action((name) => {
       pending = initKnex(env, commander.opts())
         .migrate.down(name)

--- a/lib/migrate/Migrator.js
+++ b/lib/migrate/Migrator.js
@@ -97,7 +97,7 @@ class Migrator {
   }
 
   // Runs the next migration that has not yet been run
-  up(name, config) {
+  up(config) {
     this._disableProcessing();
     this.config = getMergedConfig(config, this.config);
 
@@ -115,6 +115,7 @@ class Migrator {
         );
 
         let migrationToRun;
+        const name = this.config.name;
         if (name) {
           if (!completed.includes(name)) {
             migrationToRun = newMigrations.find((migration) => {
@@ -190,7 +191,7 @@ class Migrator {
     });
   }
 
-  down(name, config) {
+  down(config) {
     this._disableProcessing();
     this.config = getMergedConfig(config, this.config);
 
@@ -208,6 +209,7 @@ class Migrator {
         });
 
         let migrationToRun;
+        const name = this.config.name;
         if (name) {
           migrationToRun = completedMigrations.find((migration) => {
             return (

--- a/lib/migrate/Migrator.js
+++ b/lib/migrate/Migrator.js
@@ -113,9 +113,22 @@ class Migrator {
           all,
           completed
         );
-        const migrationToRun = name
-          ? newMigrations.find((migration) => migration.file === name)
-          : newMigrations[0];
+
+        let migrationToRun;
+        if (name) {
+          if (!completed.includes(name)) {
+            migrationToRun = newMigrations.find((migration) => {
+              return (
+                this.config.migrationSource.getMigrationName(migration) === name
+              );
+            });
+            if (!migrationToRun) {
+              throw new Error(`Migration "${name}" not found.`);
+            }
+          }
+        } else {
+          migrationToRun = newMigrations[0];
+        }
 
         const migrationsToRun = [];
         if (migrationToRun) {
@@ -193,9 +206,20 @@ class Migrator {
             this.config.migrationSource.getMigrationName(migration)
           );
         });
-        const migrationToRun = name
-          ? completedMigrations.find((migration) => migration.file === name)
-          : completedMigrations[completedMigrations.length - 1];
+
+        let migrationToRun;
+        if (name) {
+          migrationToRun = completedMigrations.find((migration) => {
+            return (
+              this.config.migrationSource.getMigrationName(migration) === name
+            );
+          });
+          if (!migrationToRun) {
+            throw new Error(`Migration "${name}" was not run.`);
+          }
+        } else {
+          migrationToRun = completedMigrations[completedMigrations.length - 1];
+        }
 
         const migrationsToRun = [];
         if (migrationToRun) {

--- a/lib/migrate/Migrator.js
+++ b/lib/migrate/Migrator.js
@@ -97,7 +97,7 @@ class Migrator {
   }
 
   // Runs the next migration that has not yet been run
-  up(config) {
+  up(name, config) {
     this._disableProcessing();
     this.config = getMergedConfig(config, this.config);
 
@@ -108,16 +108,24 @@ class Migrator {
         return value;
       })
       .then(([all, completed]) => {
-        const migrationToRun = getNewMigrations(
+        const newMigrations = getNewMigrations(
           this.config.migrationSource,
           all,
           completed
-        ).slice(0, 1);
+        );
+        const migrationToRun = name
+          ? newMigrations.find((migration) => migration.file === name)
+          : newMigrations[0];
+
+        const migrationsToRun = [];
+        if (migrationToRun) {
+          migrationsToRun.push(migrationToRun);
+        }
 
         const transactionForAll =
           !this.config.disableTransactions &&
           isEmpty(
-            filter(migrationToRun, (migration) => {
+            filter(migrationsToRun, (migration) => {
               const migrationContents = this.config.migrationSource.getMigration(
                 migration
               );
@@ -128,10 +136,10 @@ class Migrator {
 
         if (transactionForAll) {
           return this.knex.transaction((trx) => {
-            return this._runBatch(migrationToRun, 'up', trx);
+            return this._runBatch(migrationsToRun, 'up', trx);
           });
         } else {
-          return this._runBatch(migrationToRun, 'up');
+          return this._runBatch(migrationsToRun, 'up');
         }
       });
   }
@@ -169,7 +177,7 @@ class Migrator {
     });
   }
 
-  down(config) {
+  down(name, config) {
     this._disableProcessing();
     this.config = getMergedConfig(config, this.config);
 
@@ -180,16 +188,21 @@ class Migrator {
         return value;
       })
       .then(([all, completed]) => {
-        const migrationToRun = all
-          .filter((migration) => {
-            return completed.includes(
-              this.config.migrationSource.getMigrationName(migration)
-            );
-          })
-          .reverse()
-          .slice(0, 1);
+        const completedMigrations = all.filter((migration) => {
+          return completed.includes(
+            this.config.migrationSource.getMigrationName(migration)
+          );
+        });
+        const migrationToRun = name
+          ? completedMigrations.find((migration) => migration.file === name)
+          : completedMigrations[completedMigrations.length - 1];
 
-        return this._runBatch(migrationToRun, 'down');
+        const migrationsToRun = [];
+        if (migrationToRun) {
+          migrationsToRun.push(migrationToRun);
+        }
+
+        return this._runBatch(migrationsToRun, 'down');
       });
   }
 

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -571,7 +571,7 @@ module.exports = function(knex) {
 
       it('should only run the first migration if no migrations have run', function() {
         return knex.migrate
-          .up(null, {
+          .up({
             directory: 'test/integration/migrate/test',
           })
           .then(() => {
@@ -588,12 +588,12 @@ module.exports = function(knex) {
 
       it('should only run the next migration that has not yet run if other migrations have already run', function() {
         return knex.migrate
-          .up(null, {
+          .up({
             directory: 'test/integration/migrate/test',
           })
           .then(() => {
             return knex.migrate
-              .up(null, {
+              .up({
                 directory: 'test/integration/migrate/test',
               })
               .then(() => {
@@ -619,7 +619,7 @@ module.exports = function(knex) {
           })
           .then(() => {
             return knex.migrate
-              .up(null, {
+              .up({
                 directory: 'test/integration/migrate/test',
               })
               .then((data) => {
@@ -645,7 +645,7 @@ module.exports = function(knex) {
 
       it('should only undo the last migration that was run if all migrations have run', function() {
         return knex.migrate
-          .down(null, {
+          .down({
             directory: ['test/integration/migrate/test'],
           })
           .then(() => {
@@ -662,12 +662,12 @@ module.exports = function(knex) {
 
       it('should only undo the last migration that was run if there are other migrations that have not yet run', function() {
         return knex.migrate
-          .down(null, {
+          .down({
             directory: ['test/integration/migrate/test'],
           })
           .then(() => {
             return knex.migrate
-              .down(null, {
+              .down({
                 directory: ['test/integration/migrate/test'],
               })
               .then(() => {
@@ -685,7 +685,7 @@ module.exports = function(knex) {
           .rollback({ directory: ['test/integration/migrate/test'] }, true)
           .then(() => {
             return knex.migrate
-              .down(null, {
+              .down({
                 directory: ['test/integration/migrate/test'],
               })
               .then((data) => {

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -571,7 +571,7 @@ module.exports = function(knex) {
 
       it('should only run the first migration if no migrations have run', function() {
         return knex.migrate
-          .up({
+          .up(null, {
             directory: 'test/integration/migrate/test',
           })
           .then(() => {
@@ -588,12 +588,12 @@ module.exports = function(knex) {
 
       it('should only run the next migration that has not yet run if other migrations have already run', function() {
         return knex.migrate
-          .up({
+          .up(null, {
             directory: 'test/integration/migrate/test',
           })
           .then(() => {
             return knex.migrate
-              .up({
+              .up(null, {
                 directory: 'test/integration/migrate/test',
               })
               .then(() => {
@@ -619,7 +619,7 @@ module.exports = function(knex) {
           })
           .then(() => {
             return knex.migrate
-              .up({
+              .up(null, {
                 directory: 'test/integration/migrate/test',
               })
               .then((data) => {
@@ -645,7 +645,7 @@ module.exports = function(knex) {
 
       it('should only undo the last migration that was run if all migrations have run', function() {
         return knex.migrate
-          .down({
+          .down(null, {
             directory: ['test/integration/migrate/test'],
           })
           .then(() => {
@@ -662,12 +662,12 @@ module.exports = function(knex) {
 
       it('should only undo the last migration that was run if there are other migrations that have not yet run', function() {
         return knex.migrate
-          .down({
+          .down(null, {
             directory: ['test/integration/migrate/test'],
           })
           .then(() => {
             return knex.migrate
-              .down({
+              .down(null, {
                 directory: ['test/integration/migrate/test'],
               })
               .then(() => {
@@ -685,7 +685,7 @@ module.exports = function(knex) {
           .rollback({ directory: ['test/integration/migrate/test'] }, true)
           .then(() => {
             return knex.migrate
-              .down({
+              .down(null, {
                 directory: ['test/integration/migrate/test'],
               })
               .then((data) => {

--- a/test/jake/jakelib/migrate-test.js
+++ b/test/jake/jakelib/migrate-test.js
@@ -430,6 +430,34 @@ test('migrate:up runs only the next unrun migration', (temp) => {
     });
 });
 
+test('migrate:up <name> runs only the defined unrun migration', (temp) => {
+  const migrationsPath = `${temp}/migrations`;
+  const migrationFile1 = '001_one.js';
+  const migrationFile2 = '002_two.js';
+  const migrationData = `
+      exports.up = () => Promise.resolve();
+      exports.down = () => Promise.resolve();
+    `;
+
+  fs.writeFileSync(`${migrationsPath}/${migrationFile1}`, migrationData);
+
+  fs.writeFileSync(`${migrationsPath}/${migrationFile2}`, migrationData);
+
+  return assertExec(
+    `node ${KNEX} migrate:up ${migrationFile2} \
+    --client=sqlite3 \
+    --connection=${temp}/db \
+    --migrations-directory=${migrationsPath}`,
+    'run_migration_002'
+  ).then(({ stdout }) => {
+    assert.include(
+      stdout,
+      `Batch 1 ran the following migrations:\n${migrationFile2}`
+    );
+    assert.notInclude(stdout, migrationFile1);
+  });
+});
+
 test('migrate:down undos only the last run migration', (temp) => {
   const migrationFile1 = '001_create_address_table.js';
   const migrationFile2 = '002_add_zip_to_address_table.js';
@@ -541,6 +569,42 @@ test('migrate:down undos only the last run migration', (temp) => {
         assert.include(stdout, 'Already at the base migration');
       });
     });
+});
+
+test('migrate:down <name> undos only the defined run migration', (temp) => {
+  const migrationsPath = `${temp}/migrations`;
+  const migrationFile1 = '001_one.js';
+  const migrationFile2 = '002_two.js';
+  const migrationData = `
+      exports.up = () => Promise.resolve();
+      exports.down = () => Promise.resolve();
+    `;
+
+  fs.writeFileSync(`${migrationsPath}/${migrationFile1}`, migrationData);
+
+  fs.writeFileSync(`${migrationsPath}/${migrationFile2}`, migrationData);
+
+  return assertExec(
+    `node ${KNEX} migrate:latest \
+    --client=sqlite3 \
+    --connection=${temp}/db \
+    --migrations-directory=${migrationsPath}`,
+    'run_all_migrations'
+  ).then(() => {
+    return assertExec(
+      `node ${KNEX} migrate:down ${migrationFile1} \
+      --client=sqlite3 \
+      --connection=${temp}/db \
+      --migrations-directory=${temp}/migrations`,
+      'undo_migration_001'
+    ).then(({ stdout }) => {
+      assert.include(
+        stdout,
+        `Batch 1 rolled back the following migrations:\n${migrationFile1}`
+      );
+      assert.notInclude(stdout, migrationFile2);
+    });
+  });
 });
 
 test('migrate:list prints migrations both completed and pending', async (temp) => {

--- a/test/jake/jakelib/migrate-test.js
+++ b/test/jake/jakelib/migrate-test.js
@@ -458,6 +458,24 @@ test('migrate:up <name> runs only the defined unrun migration', (temp) => {
   });
 });
 
+test('migrate:up <name> throw an error', (temp) => {
+  const migrationsPath = `${temp}/migrations`;
+  const migrationFile1 = '001_one.js';
+
+  return assertExec(
+    `node ${KNEX} migrate:up ${migrationFile1} \
+    --client=sqlite3 \
+    --connection=${temp}/db \
+    --migrations-directory=${migrationsPath}`,
+    'run_migration_001'
+  ).catch((error) => {
+    assert.include(
+      error.toString(),
+      `Migration "${migrationFile1}" not found.`
+    );
+  });
+});
+
 test('migrate:down undos only the last run migration', (temp) => {
   const migrationFile1 = '001_create_address_table.js';
   const migrationFile2 = '002_add_zip_to_address_table.js';
@@ -604,6 +622,24 @@ test('migrate:down <name> undos only the defined run migration', (temp) => {
       );
       assert.notInclude(stdout, migrationFile2);
     });
+  });
+});
+
+test('migrate:down <name> throw an error', (temp) => {
+  const migrationsPath = `${temp}/migrations`;
+  const migrationFile1 = '001_one.js';
+
+  return assertExec(
+    `node ${KNEX} migrate:down ${migrationFile1} \
+    --client=sqlite3 \
+    --connection=${temp}/db \
+    --migrations-directory=${migrationsPath}`,
+    'run_migration_001'
+  ).catch((error) => {
+    assert.include(
+      error.toString(),
+      `Migration "${migrationFile1}" was not run.`
+    );
   });
 });
 

--- a/test/jake/jakelib/migrate-test.js
+++ b/test/jake/jakelib/migrate-test.js
@@ -634,7 +634,7 @@ test('migrate:down <name> throw an error', (temp) => {
     --client=sqlite3 \
     --connection=${temp}/db \
     --migrations-directory=${migrationsPath}`,
-    'run_migration_001'
+    'undo_migration_001'
   ).catch((error) => {
     assert.include(
       error.toString(),

--- a/test/jake/jakelib/migrate-test.js
+++ b/test/jake/jakelib/migrate-test.js
@@ -9,7 +9,10 @@ const rimrafSync = require('rimraf').sync;
 const path = require('path');
 const sqlite3 = require('sqlite3');
 const { assert } = require('chai');
-const { assertExec } = require('../../jake-util/helpers/migration-test-helper');
+const {
+  assertExec,
+  assertExecError,
+} = require('../../jake-util/helpers/migration-test-helper');
 const knexfile = require('../../jake-util/knexfile/knexfile.js');
 
 const KNEX = path.normalize(__dirname + '/../../../bin/cli.js');
@@ -462,17 +465,14 @@ test('migrate:up <name> throw an error', (temp) => {
   const migrationsPath = `${temp}/migrations`;
   const migrationFile1 = '001_one.js';
 
-  return assertExec(
+  return assertExecError(
     `node ${KNEX} migrate:up ${migrationFile1} \
     --client=sqlite3 \
     --connection=${temp}/db \
     --migrations-directory=${migrationsPath}`,
     'run_migration_001'
-  ).catch((error) => {
-    assert.include(
-      error.toString(),
-      `Migration "${migrationFile1}" not found.`
-    );
+  ).catch(({ stderr }) => {
+    assert.include(stderr, `Migration "${migrationFile1}" not found.`);
   });
 });
 
@@ -629,17 +629,14 @@ test('migrate:down <name> throw an error', (temp) => {
   const migrationsPath = `${temp}/migrations`;
   const migrationFile1 = '001_one.js';
 
-  return assertExec(
+  return assertExecError(
     `node ${KNEX} migrate:down ${migrationFile1} \
     --client=sqlite3 \
     --connection=${temp}/db \
     --migrations-directory=${migrationsPath}`,
     'undo_migration_001'
-  ).catch((error) => {
-    assert.include(
-      error.toString(),
-      `Migration "${migrationFile1}" was not run.`
-    );
+  ).catch(({ stderr }) => {
+    assert.include(stderr, `Migration "${migrationFile1}" was not run.`);
   });
 });
 


### PR DESCRIPTION
Add the ability to explicitly define the migration's filename for `up` and `down` commands (#1550).

### Current CLI
Run only the next migration:
```bash
migrate:up
```

Undo only the latest migration:
```bash
migrate:down
```

### Proposed CLI:
Add the optional `name` parameter for `up` and `down` commands.

Run only the specified or the next migration:
```bash
knex migrate:up <name>
```

Undo only the specified or the latest migration:
```bash
knex migrate:down <name>
```

#### Example 1:
Let's say we have two new migrations:
```
001_one.js
002_two.js
```
If we want to run only the `002_two.js` then we can use this:
```bash
knex migrate:up 002_two.js
```

#### Example 2:
Let's say we have two completed migrations:
```
001_one.js
002_two.js
```
If we want to revert only the `001_one.js` then we can use this:
```bash
knex migrate:down 001_one.js
```