### PR TITLE
Fix for concurrent child transactions failing (#2213)

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -210,6 +210,7 @@ class Transaction extends EventEmitter {
   // the original promise is marked completed.
   acquireConnection(client, config, txid) {
     const configConnection = config && config.connection;
+    const trx = this;
     return new Bluebird((resolve, reject) => {
       try {
         resolve(configConnection || client.acquireConnection());
@@ -220,7 +221,10 @@ class Transaction extends EventEmitter {
       .then(function(connection) {
         connection.__knexTxId = txid;
 
-        return connection;
+        return (trx._previousSibling ? trx._previousSibling.reflect() : Promise.resolve())
+          .then(function () {
+            return connection;
+          });
       })
       .disposer(function(connection) {
         if (!configConnection) {

--- a/test/integration/builder/transaction.js
+++ b/test/integration/builder/transaction.js
@@ -399,6 +399,22 @@ module.exports = function(knex) {
       });
     });
 
+    it('should wait for sibling transactions to finish', function() {
+      if (/redshift/i.test(knex.client.driverName)) {
+        return Promise.resolve();
+      }
+      return knex.transaction(function(trx) {
+        return Promise.all([
+          trx.transaction(function(trx2) {
+            return Bluebird.delay(100);
+          }),
+          trx.transaction(function(trx3) {
+            return Bluebird.delay(300);
+          }),
+        ]);
+      });
+    });
+
     it('#855 - Query Event should trigger on Transaction Client AND main Client', function() {
       let queryEventTriggered = false;
 

--- a/test/integration/builder/transaction.js
+++ b/test/integration/builder/transaction.js
@@ -403,6 +403,9 @@ module.exports = function(knex) {
       if (/redshift/i.test(knex.client.driverName)) {
         return Promise.resolve();
       }
+      if (/mssql/i.test(knex.client.driverName)) {
+        return Promise.resolve();
+      }
       return knex.transaction(function(trx) {
         return Promise.all([
           trx.transaction(function(trx2) {

--- a/test/integration/builder/transaction.js
+++ b/test/integration/builder/transaction.js
@@ -399,20 +399,22 @@ module.exports = function(knex) {
       });
     });
 
-    it('should wait for sibling transactions to finish', function() {
+    it('#2213 - should wait for sibling transactions to finish', function() {
       if (/redshift/i.test(knex.client.driverName)) {
         return Promise.resolve();
       }
       if (/mssql/i.test(knex.client.driverName)) {
         return Promise.resolve();
       }
+      const first = Bluebird.delay(50);
+      const second = first.then(() => Bluebird.delay(50));
       return knex.transaction(function(trx) {
         return Promise.all([
           trx.transaction(function(trx2) {
-            return Bluebird.delay(100);
+            return first;
           }),
           trx.transaction(function(trx3) {
-            return Bluebird.delay(300);
+            return second;
           }),
         ]);
       });


### PR DESCRIPTION
Fix for https://github.com/tgriesser/knex/issues/2213 where @joepie91 already did the bulk of the work and investigation. I needed this fixed for a personal project so adapted their test and reimplemented the check for `_previousSibling`.