### PR TITLE
Add missing Migrator.list typing

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1826,6 +1826,7 @@ declare namespace Knex {
     rollback(config?: MigratorConfig, all?: boolean): Promise<any>;
     status(config?: MigratorConfig): Promise<number>;
     currentVersion(config?: MigratorConfig): Promise<string>;
+    list(config?: MigratorConfig): Promise<any>;
     up(config?: MigratorConfig): Promise<any>;
     down(config?: MigratorConfig): Promise<any>;
   }


### PR DESCRIPTION
The list method is missing in the Migrator interface - this PR adds it.